### PR TITLE
reloading problem with an angularjs app with default ngRoute-ing

### DIFF
--- a/client/live.js
+++ b/client/live.js
@@ -80,6 +80,7 @@ $(function() {
 				var old = iframe[0].contentWindow.location + "";
 				if(old.indexOf("about") == 0) old = null;
 				iframe.attr("src", old || (contentPage + window.location.hash));
+				old && iframe[0].contentWindow.location.reload();
 			} catch(e) {
 				iframe.attr("src", contentPage + window.location.hash);
 			}


### PR DESCRIPTION
I had the problem that my angularjs app (using a default route, e.g. `.otherwise({redirectTo:'/somewhere'})`) doesn't get reloaded - it shows "App updated. Reloading app..." - but the iframe stays empty.

I guess it has something to do of how the browser handles reloads of URLs with a fragment. I had to put `contentWindow.location.reload()` to make it work.
