### PR TITLE
Add repository field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,10 @@
 			"url": "http://www.opensource.org/licenses/mit-license.php"
 		}
 	],
+	"repository": {
+		"type": "git",
+		"url": "git://github.com/webpack/webpack-dev-server.git"
+	},
 	"homepage": "http://github.com/webpack/webpack-dev-server",
 	"main": "lib/Server.js",
 	"bin": "bin/webpack-dev-server.js",


### PR DESCRIPTION
To silence warning with npm: `npm WARN package.json webpack-dev-server@1.2.4 No repository field.`
