### PR TITLE
Make live.html work on PS4 browser by adding Content-Type

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -54,6 +54,7 @@ function Server(compiler, options) {
 	});
 
 	app.get("/webpack-dev-server/*", function(req, res) {
+		res.setHeader("Content-Type", "text/html");
 		this.livePage.pipe(res);
 	}.bind(this));
 


### PR DESCRIPTION
The PS4 web browser refuses to open web pages without a Content-Type header.
