### PR TITLE
Serve files with static middleware.

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -59,7 +59,7 @@ function Server(compiler, options) {
 	}.bind(this));
 
 	// route content request
-	app.get("*", this.serveContent.bind(this));
+	app.get("*", this.serveContent.bind(this), express.static(this.contentBase));
 }
 
 // delegate listen call and init socket.io
@@ -93,8 +93,7 @@ Server.prototype.serveContent = function(req, res, next) {
 				} catch(e) { return false; }
 			}
 			if(!err && stat.isFile()) {
-				res.setHeader("Content-Type", mime.lookup(_path));
-				fs.createReadStream(target).pipe(res);
+				next();
 			} else if(!err && stat.isDirectory()) {
 				res.writeHead(302, {
 					'Location': req.path + (/\/$/.test(_path) || !_path ? "index.html" : "/") + (req._parsedUrl.search || "")


### PR DESCRIPTION
Importantly this supports http streaming with Ranges headers and 304 not
modified responses. Caching is left off with the middleware's default value of
0 for the max-age value in the Cache-Control header.
