### PR TITLE
Set Content-Type for live.bundle.js and webpack-dev-server.js

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -46,10 +46,12 @@ function Server(compiler, options) {
 	app.use(this.middleware = webpackDevMiddleware(compiler, options));
 
 	app.get("/__webpack_dev_server__/live.bundle.js", function(req, res) {
+		res.setHeader("Content-Type", "application/javascript");
 		liveJs.pipe(res);
 	});
 
 	app.get("/webpack-dev-server.js", function(req, res) {
+		res.setHeader("Content-Type", "application/javascript");
 		inlinedJs.pipe(res);
 	});
 


### PR DESCRIPTION
Browsers try to auto-detect files without a Content-Type, and warn in many cases. Google Chrome for example detects the files as text/plain, and then warns when they are used as scripts: 'Resource interpreted as Script but transferred with MIME type text/plain: "http://localhost:8080/**webpack_dev_server**/live.bundle.js".'
