### PR TITLE
Allow the dev server to use an existing http.Server

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -1,5 +1,6 @@
 var fs = require("fs");
 var path = require("path");
+var http = require("http");
 var webpackDevMiddleware = require("webpack-dev-middleware");
 var express = require("express");
 var socketio = require("socket.io");
@@ -131,8 +132,9 @@ function Server(compiler, options) {
 
 // delegate listen call and init socket.io
 Server.prototype.listen = function() {
+	var serverSupplied = arguments.length > 0 && arguments[0] instanceof http.Server;
 	var listeningApp = this.listeningApp =
-		this.app.listen.apply(this.app, arguments);
+		(serverSupplied ? arguments[0] : this.app.listen.apply(this.app, arguments));
 	this.io = socketio.listen(listeningApp, {
 		"log level": 1
 	});


### PR DESCRIPTION
If the first argument to Server.listen is a node http.Server then the dev
server will use this. This allows the dev server to be embedded as middleware
within an existing express application.

```javascript
var app = express();
var devServer = new WebpackDevServer(webpack(config), {});
app.use(devServer.app);
var server = express.listen(3000);
devServer.listen(server);
```

I've implemented this as an overload of the dev server `listen` function, however it could be split into its own method if you think this is too messy or backwards incompatible (perhaps `devServer.listenWith(server)`).