### PR TITLE
Smarter query string for client entry, also works for script

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -1,9 +1,36 @@
+var url = require("url");
+var path = require("path");
 var io = require("socket.io");
 var scriptElements = document.getElementsByTagName("script");
-io = io.connect(typeof __resourceQuery === "string" && __resourceQuery ?
-	__resourceQuery.substr(1) :
-	scriptElements[scriptElements.length-1].getAttribute("src").replace(/\/[^\/]+$/, "")
+
+var urlparts;
+var options = {};
+
+urlparts = url.parse(
+	scriptElements[scriptElements.length-1].getAttribute("src")
 );
+
+// Append tailing slash so that url.resolve works correctly
+urlparts.pathname = path.dirname(urlparts.pathname) + '/';
+
+if (typeof __resourceQuery === "string" && __resourceQuery) {
+	urlparts = url.parse(url.resolve(url.format(urlparts), __resourceQuery.substr(1)));
+} else if (urlparts.search) {
+	urlparts.search = '';
+	urlparts = url.parse(url.resolve(url.format(urlparts), urlparts.query));
+} else {
+	// Since we didn't resolve the slash has to be removed
+	urlparts.pathname = urlparts.pathname.substr(-1);
+}
+
+if (urlparts.path !== '/') {
+	// socket.io does not accept a leading slash
+	options.resource = urlparts.path.substr(1);
+	urlparts.pathname = '';
+	urlparts.search = '';
+}
+
+io = io.connect(url.format(urlparts), options);
 
 var hot = false;
 var initial = true;


### PR DESCRIPTION
My use-case is that I require HTTPS and have set-up an nginx proxy in a directory `/webpack-dev-server/` for webpack-dev-server. This allows me to use certificates and basically pretend that webpack-dev-server doesn't exist. However, `/socket.io/` is "hard-coded" and cannot be changed currently, this allows it to be replaced with any URL.

This PR significantly improves the query string and also enables it for the script tag.

Currently, the only supported syntax is:
`'webpack-dev-server/client?http://domain'`
... `/socket.io` is implicit.

This adds support for paths:
`'webpack-dev-server/client?https://domain/webpack-dev-server/socket.io'`
... `/socket.io` is no longer implicit when a path is present.

It also adds support for relative paths:
`'webpack-dev-server/client?/webpack-dev-server/socket.io'`
`'webpack-dev-server/client?socket.io'`
... is equivalent if the bundle is loaded from `/webpack-dev-server/bundle.js`.

Also, as I mentioned, script tags support the same syntax:
`<script src="/webpack-dev-server/bundle.js?http://put.it/somewhere/else/socket.io"></script>`

Caution though, I haven't tested this extensively and I haven't tested the script tag at all (but I did test it manually in the code and it seemed fine) as I'm not sure how the `index.bundle.js` is created. The code is complicated a bit by the fact that URLs are currently required (by webpack-dev-server) to not have a tailing `/` which is technically incorrect as they really are directories and not files.

:+1: for a kick-ass project.

If someone finds it useful, I use the following nginx configuration (the tailing slash for `proxy_pass` is important!):

```
  location /<path>/ {
    proxy_http_version 1.1;
    proxy_set_header Upgrade $http_upgrade;
    proxy_set_header Connection "upgrade";
    proxy_pass http://<webpack-dev-server>/;
  }
```