### PR TITLE
Log proxy errors instead of throwing exception

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -43,6 +43,14 @@ io.on("errors", function(errors) {
 	reloadApp();
 });
 
+io.on("proxy-error", function(errors) {
+	console.log("[WDS] Proxy error.");
+	for(var i = 0; i < errors.length; i++)
+		console.error(errors[i]);
+	if(initial) return initial = false;
+	reloadApp();
+});
+
 io.on("disconnect", function() {
 	console.error("[WDS] Disconnected!");
 });

--- a/client/live.js
+++ b/client/live.js
@@ -55,6 +55,14 @@ $(function() {
 		$errors.show(); iframe.hide();
 	});
 
+	io.on("proxy-error", function(errors) {
+		status.text("Could not proxy to content base target!");
+		okness.text("Proxy error.");
+		$errors.text("\n" + errors.join("\n\n\n") + "\n\n");
+		header.css({borderColor: "#ebcb8b"});
+		$errors.show(); iframe.hide();
+	});
+
 	io.on("disconnect", function() {
 		status.text("");
 		okness.text("Disconnected.");

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -106,8 +106,10 @@ function Server(compiler, options) {
 		// Proxy every request to contentBase.target
 		app.all("*", function(req, res) {
 			proxy.web(req, res, this.contentBase, function(err) {
-				console.log('cannot proxy: ', err.message);
-			});
+				var msg = "cannot proxy to " + this.contentBase.target + " (" + err.message + ")";
+				console.log(msg);
+				this.io.sockets.emit("proxy-error", [msg]);
+			}.bind(this));
 		}.bind(this));
 	} else if(/^(https?:)?\/\//.test(this.contentBase)) {
 		// Redirect every request to contentBase


### PR DESCRIPTION
If the upstream server is for some reason unavailable (for example, if it's being restarted/reloaded due to code changes) then `webpack-dev-server` should log the error and not crash the running process.
