### PR TITLE
Fixes proxy issue introduced in commit 6969f57

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -107,8 +107,8 @@ function Server(compiler, options) {
 		if(typeof contentBase === "object") {
 			// Proxy every request to contentBase.target
 			app.all("*", function(req, res) {
-				proxy.web(req, res, this.contentBase, function(err) {
-					var msg = "cannot proxy to " + this.contentBase.target + " (" + err.message + ")";
+				proxy.web(req, res, contentBase, function(err) {
+					var msg = "cannot proxy to " + contentBase.target + " (" + err.message + ")";
 					this.io.sockets.emit("proxy-error", [msg]);
 				}.bind(this));
 			}.bind(this));


### PR DESCRIPTION
Commit 6969f57 introduced brekaing changes to how `contentBase` is read. This commit fixes the issue by reading from a scoped variable instead of `this.contentBase`.
