### PR TITLE
Do not reloadApp() on errors when compiling modules.

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -40,7 +40,6 @@ io.on("errors", function(errors) {
 	for(var i = 0; i < errors.length; i++)
 		console.error(errors[i]);
 	if(initial) return initial = false;
-	reloadApp();
 });
 
 io.on("proxy-error", function(errors) {


### PR DESCRIPTION
Partially fixes #42.
