### PR TITLE
Remove early exit from ok

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -23,7 +23,7 @@ io.on("hash", function(hash) {
 });
 
 io.on("ok", function() {
-	if(initial) return initial = false;
+	initial = false;
 	reloadApp();
 });
 


### PR DESCRIPTION
I couldn't find any good reason for this and it causes the first update to be lost: https://github.com/webpack/webpack-dev-server/issues/57
