### PR TITLE
Adds options.headers being set on any request to files within the content base

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -13,6 +13,7 @@ function Server(compiler, options) {
 	// Default options
 	if(!options) options = {};
 	this.hot = options.hot;
+	this.headers = options.headers;
 
 	// Listening for events
 	var invalidPlugin = function() {
@@ -130,13 +131,23 @@ function Server(compiler, options) {
 			}.bind(this));
 		} else {
 			// route content request
-			app.get("*", this.serveMagicHtml.bind(this), express.static(contentBase), serveIndex(contentBase));
+			app.get("*", this.setContentHeaders.bind(this), this.serveMagicHtml.bind(this), express.static(contentBase), serveIndex(contentBase));
 		}
 	}
 }
 
 Server.prototype.use = function() {
 	this.app.use.apply(this.app, arguments);
+}
+
+Server.prototype.setContentHeaders = function(req, res, next) {
+	if(this.headers) {
+		for(var name in this.headers) {
+			res.setHeader(name, this.headers[name]);
+		}
+	}
+
+	next();
 }
 
 // delegate listen call and init socket.io


### PR DESCRIPTION
Adds support for specifying `options.headers` which are then set on any request to a file within the content base not just the bundles. The pull requests relates to issue #69. 

A `webpack.config.js` such as 

``` javascript
...
devServer: {
   headers: { "Access-Control-Allow-Origin": "*" }
}
...
```

would set the `Access-Control-Allow-Origin` entry on e.g. the `index.html` within the content base.
