### PR TITLE
exit Hot Module Replacement script if not in Browser context

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -1,4 +1,7 @@
 var io = require("socket.io");
+if ("undefined" === typeof document) {
+	return;// might be in a WebWorker context
+}
 var scriptElements = document.getElementsByTagName("script");
 io = io.connect(typeof __resourceQuery === "string" && __resourceQuery ?
 	__resourceQuery.substr(1) :


### PR DESCRIPTION
This solves the issue that if we start the server with `--inline --hot` option, and later the script get injected into `WebWorker` will throw exception.
I'd better to silently fail rather than throw exception.