### PR TITLE
Add support for a HTML 5 History API fallback

### DIFF
--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -33,6 +33,8 @@ var optimist = require("optimist")
 
 	.string("content-base-target").describe("content-base-target", "Proxy requests to this target.")
 
+	.boolean("history-api-fallback").describe("history-api-fallback", "Fallback to /index.html for Single Page Applications.")
+
 	.describe("port", "The port").default("port", 8080);
 
 require("webpack/bin/config-optimist")(optimist);
@@ -104,6 +106,9 @@ if(argv["inline"]) {
 	});
 }
 
+if(argv["history-api-fallback"])
+	options.historyApiFallback = true;
+
 new Server(webpack(wpOpt), options).listen(argv.port, function(err) {
 	if(err) throw err;
 	if(argv["inline"])
@@ -115,4 +120,6 @@ new Server(webpack(wpOpt), options).listen(argv.port, function(err) {
 		console.log("requests are proxied to " + options.contentBase.target);
 	else
 		console.log("content is served from " + options.contentBase);
+	if(options.historyApiFallback)
+		console.log("404s will fallback to /index.html");
 });

--- a/example/README.md
+++ b/example/README.md
@@ -48,9 +48,6 @@ The app without a webpack-dev-server frame. Console displays status messages.
 
 The webpack-dev-server client is added as script tag to the html page.
 
-
-
-
 ## Reloading
 
 Try to update app.js, by uncommenting some lines.
@@ -58,3 +55,12 @@ Try to update app.js, by uncommenting some lines.
 The browser should reflect your changes.
 
 You may also update the css file or any other file used by the app.
+
+## History API Fallback
+
+``` text
+webpack-dev-server --colors --history-api-fallback
+http://localhost:8080/some/url/from/spa
+```
+
+The contents of /index.html is served.

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -7,6 +7,7 @@ var StreamCache = require("stream-cache");
 var httpProxy = require("http-proxy");
 var proxy = new httpProxy.createProxyServer();
 var serveIndex = require("serve-index");
+var historyApiFallback = require("connect-history-api-fallback");
 
 function Server(compiler, options) {
 
@@ -40,6 +41,11 @@ function Server(compiler, options) {
 
 	// Init express server
 	var app = this.app = new express();
+
+	if (options.historyApiFallback) {
+		// Fall back to /index.html if nothing else matches.
+		app.use(historyApiFallback);
+	}
 
 	// serve webpack bundle
 	app.use(this.middleware = webpackDevMiddleware(compiler, options));

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
 		"optimist": "~0.6.0",
 		"stream-cache": "~0.0.1",
 		"http-proxy": "^1.1.4",
-		"serve-index": "^1.2.0"
+		"serve-index": "^1.2.0",
+		"connect-history-api-fallback": "0.0.5"
 	},
 	"devDependencies": {
 		"css-loader": "~0.7.1",


### PR DESCRIPTION
I had some good fun tonight running the dev server. Unfortunately I couldn't find a way to setup it so it serves the index.html page when a non-existing page is requested. The feature is quite handy in development of single page applications (SPAs) and the otherwise splendid did server not-supporting it has kind of ruined all the fun.

So, the PR implements this: if you pass the `--history-api-fallback` option to cli, or pass the `historyApiFallback: true` option in the Node API options, the server will then serve /index.html on any requests that don't happen to have another match.

This is implemented with the help of the [connect-history-api-fallback](https://github.com/bripkens/connect-history-api-fallback) Connect middleware. I've used this in some other places and it works perfectly.

I've tried to update the README and the examples to match the new feature. Please let me know if there's anything I have missed.

I hope this will be merged in someday. :)
