### PR TITLE
avoid `Cannot get /` errors if history-api-fallback is enabled

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -107,6 +107,8 @@ function Server(compiler, options) {
 	if (options.historyApiFallback) {
 		// Fall back to /index.html if nothing else matches.
 		app.use(historyApiFallback);
+                // include our middleware to ensure it is able to handle '/index.html' requrst after redirect
+		app.use(this.middleware);
 	}
 
 	if(options.contentBase !== false) {


### PR DESCRIPTION
I start webpack dev server with 
`webpack-dev-server -d --history-api-fallback --inline --progress --colors --port 9000`
I expect it to return post-processed `index.html` content for all queries including `/` or `index.html`

It works brilliant for `/index.html` but it does not work for any other URLs. The thing is that `historyApiFallback` implementation only changes `req.url` of the request and puts request processing down the interceptors chain. This means that `this.middleware` interceptor is not called after request URL is changed. 

My idea is to add `this.middleware` once again to let it work correctly. I cannot put this interceptor before  `this.middleware` because it might start returning `/index.html` for every possible queries. From the other hand, there is no API for `express.js` I aware of to make `express.js` restart all interceptors for server-side include. If there is such, the fix could be done on the `connect-history-api-fallback` library side
