### PR TITLE
Add configurable express initializer for mocking

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -42,7 +42,15 @@ function Server(compiler, options) {
 	fs.createReadStream(path.join(__dirname, "..", "client", "index.bundle.js")).pipe(inlinedJs);
 
 	// Init express server
-	var app = this.app = new express();
+	var app = this.app = function() {
+		var a = new express();
+		var mockMaybe = process.env.WDSMOCK;
+		if(mockMaybe) {
+			return require(mockMaybe).mock(a);
+		} else {
+			return a;
+		}
+	}()
 
 	// serve webpack bundle
 	app.use(this.middleware = webpackDevMiddleware(compiler, options));


### PR DESCRIPTION
It's no secret that oftentimes when frontend teams work with
webpack, the backend they see and the real backend are different
things. Also, it's known that often such "mocking" backend is
implemented with Express.

This small patch provides a way to adapt a mocking backend to
webpack-dev-server with a simple adapter. It also allows us to
make template engines play better with webpack-dev-server.

===

Invocation example:

```
WDSMOCK='/tmp/wdsmock.js' node bin/webpack-dev-server.js
```

(should go into a script in your package.json);

Initializer example:

```
module.exports.mock = function(app) {

  app.get('/mocked', function(req, res) {
    res.setHeader("Content-Type", "text/html");
    res.write('<strong style="color: red; font-size: 142px;">' +
                '<blink>Mocked!</blink>' +
              '</strong>');
    res.send();
  })

  app.get('/mocked/:param', function(req, res) {
    res.setHeader("Content-Type", "text/html");
    res.write('<strong style="color: red; font-size: 142px;">' +
                '<blink>' + req.params.param + '!</blink>' +
              '</strong>');
    res.send();
  })

  return app;

}
```