### PR TITLE
use a monospace font for error output

### DIFF
--- a/client/style.css
+++ b/client/style.css
@@ -45,7 +45,7 @@ html {
 	width: 100%;
 	margin: 0;
 	padding: 10px;
-	font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+	font-family: monospace;
 	font-size: 14px;
 	line-height: 1.4;
 	color: #eff1f5;


### PR DESCRIPTION
The error output displays errors in a variable width font. Since this output is effectively the same as what's output by loaders to the CLI it can look strange when using loaders that output error information expecting fixed width fonts (in this example 6to5/6to5). Screenshot showing before and after this change.

![before](https://cloud.githubusercontent.com/assets/88399/5994244/9496b294-aa39-11e4-8a2d-1436b0137751.png)

![after](https://cloud.githubusercontent.com/assets/88399/5994245/98b64a56-aa39-11e4-9930-daff0933f7e8.png)
