### PR TITLE
Add default filename when using through api

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -14,6 +14,11 @@ var historyApiFallback = require("connect-history-api-fallback");
 function Server(compiler, options) {
 	// Default options
 	if(!options) options = {};
+
+	if (options.lazy && !options.filename) {
+		throw new Error("'filename' option must be set in lazy mode.");
+	}
+
 	this.hot = options.hot;
 	this.headers = options.headers;
 


### PR DESCRIPTION
When trying to set-up webpack-dev-server today via the API I ran into an issue that I was unable to ever load the bundle.

The issue was that the `filename` is only given a default when set via the CLI.  I [updated the wiki to note this requirement](https://github.com/webpack/docs/wiki/webpack-dev-server/_compare/58ce95651f311ad99ca6ef694258f2141abfc84c...14496dc39d893c41b1c4abd475da607bf0ccfc1f) however it'd be good to have it built into the code by default.