### PR TITLE
update socket.io to 1.3.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 	"dependencies": {
 		"webpack-dev-middleware": "^1.0.7",
 		"express": "^4.3.2",
-		"socket.io": "^0.9.17",
+		"socket.io": "^1.3.3",
 		"optimist": "~0.6.0",
 		"stream-cache": "~0.0.1",
 		"http-proxy": "^1.1.4",


### PR DESCRIPTION
fixes: #73 
This will not work in cases where (somehow, not through normal use of webpack-dev-server; perhaps you built --inline into a bundle?) you have a different client socket.io version.