### PR TITLE
added option to proxy a path to another server

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -111,6 +111,15 @@ function Server(compiler, options) {
 		app.use(this.middleware);
 	}
 
+	if (options.proxy) {
+		var paths = Object.keys(options.proxy);
+		paths.forEach(function (path) {
+			app.all(path, function (req, res) {
+				proxy.web(req, res, {target: options.proxy[path], ws: true, secure: false});
+			});
+		});
+	}
+
 	if(options.contentBase !== false) {
 		var contentBase = options.contentBase || process.cwd();
 


### PR DESCRIPTION
Add this to the configs and it will proxy any request to /api/* to localhost:5000.

```
    devServer: {
        proxy: {
            '/api/*': 'http://localhost:5000/'
        }
    }
```
