### PR TITLE
Add proxy to allow working with a back end on a different server/port

### DIFF
--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -137,4 +137,18 @@ new Server(webpack(wpOpt), options).listen(options.port, options.host, function(
 		console.log("content is served from " + options.contentBase);
 	if(options.historyApiFallback)
 		console.log("404s will fallback to /index.html");
+
+	if (options.proxy) {
+		var paths = Object.keys(options.proxy);
+		paths.forEach(function (path) {
+			var target;
+			if (typeof options.proxy[path] === 'string') {
+				target = options.proxy[path];
+			} else {
+				target = options.proxy[path].target;
+			}
+			console.log('proxying '+path+' to '+target);
+		});
+	}
+
 });

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -111,6 +111,15 @@ function Server(compiler, options) {
 		app.use(this.middleware);
 	}
 
+	if (options.proxy) {
+		var paths = Object.keys(options.proxy);
+		paths.forEach(function (path) {
+			app.all(path, function (req, res) {
+				proxy.web(req, res, {target: options.proxy[path], ws: true, secure: false});
+			});
+		});
+	}
+
 	if(options.contentBase !== false) {
 		var contentBase = options.contentBase || process.cwd();
 

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -130,6 +130,8 @@ function Server(compiler, options) {
 		var contentBase = options.contentBase || process.cwd();
 
 		if(typeof contentBase === "object") {
+			console.log('Using contentBase as a proxy is deprecated and will be removed in the next major version. Please use the proxy option instead.\n\nTo update remove the contentBase option from webpack.config.js and add this:');
+			console.log('proxy: {\n\t"*": [your current contentBase configuration]\n}');
 			// Proxy every request to contentBase.target
 			app.all("*", function(req, res) {
 				proxy.web(req, res, contentBase, function(err) {

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -107,15 +107,21 @@ function Server(compiler, options) {
 	if (options.historyApiFallback) {
 		// Fall back to /index.html if nothing else matches.
 		app.use(historyApiFallback);
-                // include our middleware to ensure it is able to handle '/index.html' requrst after redirect
+		// include our middleware to ensure it is able to handle '/index.html' requrst after redirect
 		app.use(this.middleware);
 	}
 
 	if (options.proxy) {
 		var paths = Object.keys(options.proxy);
 		paths.forEach(function (path) {
+			var proxyOptions;
+			if (typeof options.proxy[path] === 'string') {
+				proxyOptions = {target: options.proxy[path], ws: true};
+			} else {
+				proxyOptions = options.proxy[path];
+			}
 			app.all(path, function (req, res) {
-				proxy.web(req, res, {target: options.proxy[path], ws: true, secure: false});
+				proxy.web(req, res, proxyOptions);
 			});
 		});
 	}


### PR DESCRIPTION
I think the purpose of this PR got missed with my last one. I'm reopening because this is a feature that either makes or breaks the server for me and I'm sure many others. I've implemented this many times and seen it implemented even more. I also changed the configurations to be more flexible.

This adds an option to proxy a *single path* to an arbitrary server. This is different than the contentBase setting, which can proxy all requests or none. Unless I'm missing a configuration, this is something that *is not possible* with the server as it stands.

Here are some use cases that make this feature worthwhile:

* Developing a front end that uses a server side API that runs in a different process or on a different computer.
* Debugging a problem in production using a local build with production data.
* Editing non-build files such as images in an app that uses an external service.
* Developing and debugging using user-supplied or timely content, such as news.
* Creating a test harness for integration tests or test HTML pages for widgets.
* Creating a playground for developers to learn a client side interface to a service.
* Being able to easily switch between dev branches, QA, and production services.

Without a built in proxy this must be done with nginx or a proxy above this server, which makes changing paths tedious and means you can't just clone and spin up another instance of your app.