### PR TITLE
Get rid of ANSI escaping

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -1,4 +1,5 @@
 var io = require("socket.io-client");
+var stripAnsi = require('strip-ansi');
 var scriptElements = document.getElementsByTagName("script");
 io = io.connect(typeof __resourceQuery === "string" && __resourceQuery ?
 	__resourceQuery.substr(1) :
@@ -38,7 +39,7 @@ io.on("warnings", function(warnings) {
 io.on("errors", function(errors) {
 	console.log("[WDS] Errors while compiling.");
 	for(var i = 0; i < errors.length; i++)
-		console.error(errors[i]);
+		console.error(stripAnsi(errors[i]));
 	if(initial) return initial = false;
 	reloadApp();
 });
@@ -46,7 +47,7 @@ io.on("errors", function(errors) {
 io.on("proxy-error", function(errors) {
 	console.log("[WDS] Proxy error.");
 	for(var i = 0; i < errors.length; i++)
-		console.error(errors[i]);
+		console.error(stripAnsi(errors[i]));
 	if(initial) return initial = false;
 	reloadApp();
 });

--- a/client/live.js
+++ b/client/live.js
@@ -1,5 +1,6 @@
 var $ = require("jquery");
 var io = require("socket.io-client");
+var stripAnsi = require('strip-ansi');
 require("./style.css");
 
 $(function() {
@@ -50,7 +51,7 @@ $(function() {
 	io.on("errors", function(errors) {
 		status.text("App updated with errors. No reload!");
 		okness.text("Errors while compiling.");
-		$errors.text("\n" + errors.join("\n\n\n") + "\n\n");
+		$errors.text("\n" + stripAnsi(errors.join("\n\n\n")) + "\n\n");
 		header.css({borderColor: "#ebcb8b"});
 		$errors.show(); iframe.hide();
 	});
@@ -58,7 +59,7 @@ $(function() {
 	io.on("proxy-error", function(errors) {
 		status.text("Could not proxy to content base target!");
 		okness.text("Proxy error.");
-		$errors.text("\n" + errors.join("\n\n\n") + "\n\n");
+		$errors.text("\n" + stripAnsi(errors.join("\n\n\n")) + "\n\n");
 		header.css({borderColor: "#ebcb8b"});
 		$errors.show(); iframe.hide();
 	});

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
 		"stream-cache": "~0.0.1",
 		"http-proxy": "^1.1.4",
 		"serve-index": "^1.2.0",
-		"connect-history-api-fallback": "0.0.5"
+		"connect-history-api-fallback": "0.0.5",
+		"strip-ansi": "^2.0.1",
 	},
 	"devDependencies": {
 		"css-loader": "~0.7.1",


### PR DESCRIPTION
It's also possible to convert it to style or whatever the console uses. fixes #136