### PR TITLE
Fix http-history-fallback overriding proxy settings

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -109,13 +109,6 @@ function Server(compiler, options) {
 		res.end('</body></html>');
 	}.bind(this));
 
-	if (options.historyApiFallback) {
-		// Fall back to /index.html if nothing else matches.
-		app.use(historyApiFallback);
-		// include our middleware to ensure it is able to handle '/index.html' requrst after redirect
-		app.use(this.middleware);
-	}
-
 	if (options.proxy) {
 		var paths = Object.keys(options.proxy);
 		paths.forEach(function (path) {
@@ -129,6 +122,13 @@ function Server(compiler, options) {
 				proxy.web(req, res, proxyOptions);
 			});
 		});
+	}
+
+	if (options.historyApiFallback) {
+		// Fall back to /index.html if nothing else matches.
+		app.use(historyApiFallback);
+		// include our middleware to ensure it is able to handle '/index.html' requrst after redirect
+		app.use(this.middleware);
 	}
 
 	if(options.contentBase !== false) {


### PR DESCRIPTION
I'm not sure if others have encountered this issue, but I found that requests were always being sent to index.html even though I had set up a few proxies for a backend server. Switching the order in which these options are applied has made everything work smoothly.