### PR TITLE
fix package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 		"http-proxy": "^1.1.4",
 		"serve-index": "^1.2.0",
 		"connect-history-api-fallback": "0.0.5",
-		"strip-ansi": "^2.0.1",
+		"strip-ansi": "^2.0.1"
 	},
 	"devDependencies": {
 		"css-loader": "~0.7.1",


### PR DESCRIPTION
currently package.json is invalid (trailing comma) so webpack-dev-server can't be installed via npm directly from github.