### PR TITLE
Failure to proxy a request no longer causes the dev server to crash

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -126,10 +126,10 @@ function Server(compiler, options) {
 				proxyOptions = options.proxy[path];
 			}
 			app.all(path, function (req, res) {
-				proxy.web(req, res, proxyOptions,function(err){
+				proxy.web(req, res, proxyOptions, function(err){
 					var msg = "cannot proxy to " + proxyOptions.target + " (" + err.message + ")";
 					this.io.sockets.emit("proxy-error", [msg]);
-                }.bind(this));
+        			}.bind(this));
 			}.bind(this));
 		}.bind(this));
 	}

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -126,9 +126,12 @@ function Server(compiler, options) {
 				proxyOptions = options.proxy[path];
 			}
 			app.all(path, function (req, res) {
-				proxy.web(req, res, proxyOptions);
-			});
-		});
+				proxy.web(req, res, proxyOptions,function(err){
+					var msg = "cannot proxy to " + proxyOptions.target + " (" + err.message + ")";
+					this.io.sockets.emit("proxy-error", [msg]);
+                }.bind(this));
+			}.bind(this));
+		}.bind(this));
 	}
 
 	if(options.contentBase !== false) {


### PR DESCRIPTION
Added extra error handling when using the proxy option. I notice that the deprecated contentBase option does include error handling when being used as a proxy that prevents the dev server from crashing if any proxied requests fail. The proxy option did not include this extra error handling, so I added it.