### PR TITLE
added support for regex in proxy options

### DIFF
--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -135,17 +135,14 @@ new Server(webpack(wpOpt), options).listen(options.port, options.host, function(
 	if(options.historyApiFallback)
 		console.log("404s will fallback to /index.html");
 
-	if (options.proxy) {
-		var paths = Object.keys(options.proxy);
-		paths.forEach(function (path) {
-			var target;
-			if (typeof options.proxy[path] === 'string') {
-				target = options.proxy[path];
-			} else {
-				target = options.proxy[path].target;
-			}
-			console.log('proxying '+path+' to '+target);
+	if (options.proxy && !Array.isArray(options.proxy)) {
+		options.proxy = Object.keys(options.proxy).map(function (path) {
+			return ({
+				path: path,
+				target: typeof options.proxy[path] === "string" ? options.proxy[path] : options.proxy[path].target
+			});
 		});
 	}
-
+	if(options.proxy)
+		console.log("proxying config", options.proxy);
 });

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -120,6 +120,7 @@ function Server(compiler, options) {
 		options.proxy.forEach(function (proxyOptions) {
 			proxyOptions.ws = proxyOptions.hasOwnProperty("ws") ? proxyOptions.ws : true;
 			app.all(proxyOptions.path, function (req, res) {
+				if(typeof proxyOptions.rewrite === "function") proxyOptions.rewrite(req, proxyOptions);
 				proxy.web(req, res, proxyOptions, function(err){
 					var msg = "cannot proxy to " + proxyOptions.target + " (" + err.message + ")";
 					this.io.sockets.emit("proxy-error", [msg]);

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -117,15 +117,9 @@ function Server(compiler, options) {
 	}
 
 	if (options.proxy) {
-		var paths = Object.keys(options.proxy);
-		paths.forEach(function (path) {
-			var proxyOptions;
-			if (typeof options.proxy[path] === 'string') {
-				proxyOptions = {target: options.proxy[path], ws: true};
-			} else {
-				proxyOptions = options.proxy[path];
-			}
-			app.all(path, function (req, res) {
+		options.proxy.forEach(function (proxyOptions) {
+			proxyOptions.ws = proxyOptions.hasOwnProperty("ws") ? proxyOptions.ws : true;
+			app.all(proxyOptions.path, function (req, res) {
 				proxy.web(req, res, proxyOptions, function(err){
 					var msg = "cannot proxy to " + proxyOptions.target + " (" + err.message + ")";
 					this.io.sockets.emit("proxy-error", [msg]);


### PR DESCRIPTION
provide configurations where the path is a regular expression, eg:

```
        proxy: [
            {
                path: /\/google(.*)/,
                target: "http://www.google.com/"
            }
        ],
```