### PR TITLE
fix historyApiFallback+proxy combo

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -109,13 +109,6 @@ function Server(compiler, options) {
 		res.end('</body></html>');
 	}.bind(this));
 
-	if (options.historyApiFallback) {
-		// Fall back to /index.html if nothing else matches.
-		app.use(historyApiFallback);
-		// include our middleware to ensure it is able to handle '/index.html' requrst after redirect
-		app.use(this.middleware);
-	}
-
 	if (options.proxy) {
 		var paths = Object.keys(options.proxy);
 		paths.forEach(function (path) {
@@ -167,6 +160,13 @@ function Server(compiler, options) {
 			// route content request
 			app.get("*", this.setContentHeaders.bind(this), this.serveMagicHtml.bind(this), express.static(contentBase), serveIndex(contentBase));
 		}
+	}
+
+	if (options.historyApiFallback) {
+		// Fall back to /index.html if nothing else matches.
+		app.use(historyApiFallback);
+		// include our middleware to ensure it is able to handle '/index.html' requrst after redirect
+		app.use(this.middleware);
 	}
 
 	this.listeningApp = options.https


### PR DESCRIPTION
Both `contentBase: "http://url"` and `proxy` are incompatible with `historyApiFallback`. This PR fixes that.

### Steps to reproduce:

Setup webpack with config

```
var server = new WebpackDevServer(webpack(config), {
  historyApiFallback: true,
  proxy: {
    "/api/*": "http://localhost:3100/"
  }
})
```

Then, open `/api/foo` in browser.

__Expected result:__ result from proxy is returned.
__Actual result:__ index.html is returned.