### PR TITLE
Strip ANSI escaping from warnings

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -35,7 +35,7 @@ io.on("ok", function() {
 io.on("warnings", function(warnings) {
 	console.log("[WDS] Warnings while compiling.");
 	for(var i = 0; i < warnings.length; i++)
-		console.warn(warnings[i]);
+		console.warn(stripAnsi(warnings[i]));
 	if(initial) return initial = false;
 	reloadApp();
 });


### PR DESCRIPTION
Errors were cleaned up recently: 6ea80ce82ef5020e112f9f7c69c37134329e19ca, but warnings were not.