### PR TITLE
Update connect-history-api-fallback dependency and allow passing params to it

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -131,7 +131,7 @@ function Server(compiler, options) {
 
 	if (options.historyApiFallback) {
 		// Fall back to /index.html if nothing else matches.
-		app.use(historyApiFallback);
+		app.use(historyApiFallback(typeof options.historyApiFallback === 'object' ? options.historyApiFallback : null));
 		// include our middleware to ensure it is able to handle '/index.html' requrst after redirect
 		app.use(this.middleware);
 	}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "webpack": "^1.3.0"
   },
   "dependencies": {
-    "connect-history-api-fallback": "0.0.5",
+    "connect-history-api-fallback": "1.1.0",
     "express": "^4.3.2",
     "http-proxy": "^1.1.4",
     "optimist": "~0.6.0",


### PR DESCRIPTION
To make connect-history-api-fallback [options](https://github.com/bripkens/connect-history-api-fallback#options) configurable