### PR TITLE
Use license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,12 +28,7 @@
     "url-loader": "~0.5.5",
     "webpack": "^1.3.0"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://www.opensource.org/licenses/mit-license.php"
-    }
-  ],
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git://github.com/webpack/webpack-dev-server.git"


### PR DESCRIPTION
Array deprecated in `npm@2.10.0`

https://github.com/npm/npm/blob/master/doc/files/package.json.md#license