### PR TITLE
proxy doesn't work with Heroku

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -119,6 +119,9 @@ function Server(compiler, options) {
 				proxyOptions = options.proxy[path];
 			}
 			app.all(path, function (req, res) {
+				if (proxyOptions.host) {
+					req.headers.host = proxyOptions.host;
+				}
 				proxy.web(req, res, proxyOptions, function(err){
 					var msg = "cannot proxy to " + proxyOptions.target + " (" + err.message + ")";
 					this.io.sockets.emit("proxy-error", [msg]);


### PR DESCRIPTION
Hi,

I want to use webpack-dev-server with backend Heroku.

But it returns 404. (No such app)

I found this article and made this change.

http://stackoverflow.com/questions/6444280/heroku-no-such-app-error-with-node-js-node-http-proxy-module

So, it works fine.
Please consider to merge this.
