### PR TITLE
Adding setup option for pre-configuring app middleware.

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -49,6 +49,11 @@ function Server(compiler, options) {
 	// Init express server
 	var app = this.app = new express();
 
+	// Allow pre-setup of app middleware
+	if (typeof options.setup === 'function') {
+		options.setup(app);
+	}
+
 	// serve webpack bundle
 	app.use(this.middleware = webpackDevMiddleware(compiler, options));
 


### PR DESCRIPTION
By passing a `setup` function as a server option, one can pre-configure app middleware before `webpack-dev-middleware` is installed. This is useful for installing pre-webpack middleware that inspects an incoming request and makes adjustments to the Webpack server if needed.