### PR TITLE
Proof of concept: send hot updates via sockets

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -27,8 +27,19 @@ io.on("still-ok", function() {
 	console.log("[WDS] Nothing changed.")
 });
 
-io.on("ok", function() {
-	if(initial) return initial = false;
+io.on("ok", function(assets) {
+	if (!initial && !assets) return;
+	if (initial) return initial = false;
+
+	if (assets) {
+		if (!window.PRELOADED_HOT_ASSETS)
+			window.PRELOADED_HOT_ASSETS = {};
+
+		for (var url in assets) {
+			window.PRELOADED_HOT_ASSETS[url] = assets[url];
+		}
+	}
+
 	reloadApp();
 });
 

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -21,6 +21,7 @@ function Server(compiler, options) {
 
 	this.hot = options.hot;
 	this.headers = options.headers;
+	this.publicPath = options.publicPath || "/";
 
 	// Listening for events
 	var invalidPlugin = function() {
@@ -70,7 +71,7 @@ function Server(compiler, options) {
 	app.get("/webpack-dev-server", function(req, res) {
 		res.setHeader("Content-Type", "text/html");
 		res.write('<!DOCTYPE html><html><head><meta charset="utf-8"/></head><body>');
-		var path = this.middleware.getFilenameFromUrl(options.publicPath || "/");
+		var path = this.middleware.getFilenameFromUrl(this.publicPath);
 		var fs = this.middleware.fileSystem;
 		function writeDirectory(baseUrl, basePath) {
 			var content = fs.readdirSync(basePath);
@@ -105,7 +106,7 @@ function Server(compiler, options) {
 			});
 			res.write("</ul>");
 		}
-		writeDirectory(options.publicPath || "/", path);
+		writeDirectory(this.publicPath, path);
 		res.end('</body></html>');
 	}.bind(this));
 
@@ -237,13 +238,29 @@ Server.prototype._sendStats = function(socket, stats, force) {
 	if(!force && stats && stats.assets && stats.assets.every(function(asset) {
 		return !asset.emitted;
 	})) return socket.emit("still-ok");;
+
 	socket.emit("hash", stats.hash);
+
 	if(stats.errors.length > 0)
 		socket.emit("errors", stats.errors);
 	else if(stats.warnings.length > 0)
 		socket.emit("warnings", stats.warnings);
-	else
-		socket.emit("ok");
+	else {
+		var assetContents;
+
+		if (stats.assets.every(function (asset) {
+			return asset.size < 10000;
+		})) {
+			assetContents = {};
+			stats.assets.forEach(function (asset) {
+				var url = this.publicPath + asset.name;
+				var filename = this.middleware.getFilenameFromUrl(url);
+				assetContents[url] = this.middleware.fileSystem.readFileSync(filename).toString();
+			}, this);
+		}
+
+		socket.emit("ok", assetContents);
+	}
 }
 
 Server.prototype.invalidate = function() {


### PR DESCRIPTION
I know this is pretty ridiculous with reading from `window` but that's not the point. It's just a proof of concept.

This PR works in conjunction with [this PR to Webpack](https://github.com/webpack/webpack/pull/1173).

It embeds small hot updates right into the socket response so that the client doesn't need to do any further requests. This saves some roundtrip time and, most importantly, lets the client go on without asking the server *while the server is performing the second pass* in `multiPass` mode. That's where the real savings are.

This cuts hot reload time (from “save” to seeing the changes) from 1500ms to 700ms on my machine.

I don't ask this to be merged, but I wonder if something like this makes sense for a future version. Making hot reload faster is important as it saves the brain cycles.