### PR TITLE
Allow contentBase to override proxy

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -219,13 +219,13 @@ function Server(compiler, options) {
 	};
 
 	var defaultFeatures = ["setup", "headers", "middleware"];
+	if(options.contentBase !== false)
+		defaultFeatures.push("contentBase");
 	if(options.proxy)
 		defaultFeatures.push("proxy");
 	if(options.historyApiFallback)
 		defaultFeatures.push("historyApiFallback", "middleware");
 	defaultFeatures.push("magicHtml");
-	if(options.contentBase !== false)
-		defaultFeatures.push("contentBase");
 	// compress is placed last and uses unshift so that it will be the first middleware used
 	if(options.compress)
 		defaultFeatures.unshift("compress");


### PR DESCRIPTION
Only use the proxy if a file can't be served from contentBase. This allows greater development flexibility.