### PR TITLE
Update peerDependencies of webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Tobias Koppers @sokra",
   "description": "Serves a webpack app. Updates the browser on changes.",
   "peerDependencies": {
-    "webpack": "^1.3.0"
+    "webpack": "^1.9.11"
   },
   "dependencies": {
     "connect-history-api-fallback": "1.1.0",


### PR DESCRIPTION
Fix this error report in npm:

```
npm ERR! peerinvalid The package webpack does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer extract-text-webpack-plugin@0.8.2 wants webpack@^1.9.11
npm ERR! peerinvalid Peer webpack-dev-server@1.9.0 wants webpack@^1.3.0
```