### PR TITLE
Expose socket.io instance from client

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -69,3 +69,5 @@ function reloadApp() {
 		window.location.reload();
 	}
 }
+
+module.exports = io;


### PR DESCRIPTION
By exposing the socket.io instance as `module.exports`, we can hook up other interesting things to the same websocket connection.

In my case, I want to live reload CSS without using webpack css loaders. By creating a dev server which emits events on the `server.io` instance, I can broadcast to the client, but I currently have to duplicate all the logic of the client side in order to extend it.

With this PR, I can simply do:

```js
/* global __resourceQuery */
'use strict';

var client = require('webpack-dev-server/client' + __resourceQuery);

client.on('some-custom-event', function() {
    console.log('Yay, some custom event happened!');
});
```