### PR TITLE
Don't emit "still-ok" when there are errors

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -241,7 +241,7 @@ Server.prototype.serveMagicHtml = function(req, res, next) {
 
 // send stats to a socket or multiple sockets
 Server.prototype._sendStats = function(socket, stats, force) {
-	if(!force && stats && stats.assets && stats.assets.every(function(asset) {
+	if(!force && stats && (!stats.errors || stats.errors.length === 0) && stats.assets && stats.assets.every(function(asset) {
 		return !asset.emitted;
 	})) return socket.emit("still-ok");;
 	socket.emit("hash", stats.hash);


### PR DESCRIPTION
Emitting "still-ok" and returning means that no "error" event is emitted , forcing the user to manually refresh the page to see compile errors.

This change causes compile errors to be shown with no manual refresh needed.

Before:
![before](https://cloud.githubusercontent.com/assets/48019/8385841/35b0bb60-1c00-11e5-8bd6-76d117d97799.gif)

After:
![after](https://cloud.githubusercontent.com/assets/48019/8385844/3c882860-1c00-11e5-87fb-9b3b1fe9d3fe.gif)
