### PR TITLE
Add listener to react to manual reload message

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -60,6 +60,11 @@ io.on("disconnect", function() {
 	console.error("[WDS] Disconnected!");
 });
 
+io.on("reload", function() {
+	console.log("[WDS] Manual reload invoked.");
+	window.location.reload();
+});
+
 function reloadApp() {
 	if(hot) {
 		console.log("[WDS] App hot update...");


### PR DESCRIPTION
This will allow the developer to invoke a browser reload. This can be implemented by using `server.io.sockets.emit("reload");`

I'm using this in my gulp build as such:
```javascript
var paths = require('../paths');
var path = require('path');
var WebpackDevServer = require("webpack-dev-server");
var webpack = require("webpack");
var webpackConfig = require("../webpack.config.js");
var $ = {
  watch: require("gulp-watch")
};

module.exports = function (cb) {
  // Add Hot Module Replacement, needs to be first in plugins
  webpackConfig.plugins.unshift(new webpack.HotModuleReplacementPlugin());
  // Add webpack/hot/dev-server to the entry point
  webpackConfig.entry["main-app"].unshift("webpack/hot/dev-server");
  // Use full url for publicPath
  //webpackConfig.publicPath = "http://localhost:9090/assets/";

  var compiler = webpack(webpackConfig);
  var server = new WebpackDevServer(compiler, {
    // webpack-dev-server options
  });
  server.listen(3001, "localhost", function () {
    // [List of bundles](http://localhost:3001/webpack-dev-server)
    // [iframe reload mode](http://localhost:3001/webpack-dev-server/)
    // [app](http://localhost:3001)
    console.log("WebpackDevServer running on http://localhost:3001")
    cb();
  });

  var debounceReload = -1
  $.watch("dist/**/*.html", function () {
    clearTimeout(debounceReload);
    debounceReload = setTimeout(function () {
      console.log("reloading browser");
      server.io.sockets.emit("reload");
    }, 500);
  })
};

if (require.main === module)
  module.exports(function () {
    console.log("I'm ready.")
  })
```