### PR TITLE
Fix: support html base tag via public path option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
+.idea
 /client/live.bundle.js
 /client/index.bundle.js

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -181,7 +181,21 @@ function Server(compiler, options) {
 				res.end();
 			}.bind(this));
 		} else {
-			// route content request
+			// take in count public path when serving static files
+			if (options.publicPath && options.publicPath !== "/") {
+				app.get(path.join(options.publicPath, '*'),
+					function (req, res, next) {
+						req._url = req.url;
+						req.url = req.url.replace(options.publicPath, "");
+						next();
+					},
+					express.static(contentBase),
+					function (req, res, next) {
+						req.url = req._url;
+						next()
+					});
+			}
+            // route content request
 			app.get("*", this.setContentHeaders.bind(this), this.serveMagicHtml.bind(this), express.static(contentBase), serveIndex(contentBase));
 		}
 	}


### PR DESCRIPTION
Hello @chentsulin 

Here is PR solving one particular case,
I have a project consisting from several angular apps
with set html base tag
```html
<base href="/user/">
<base href="/admin/">
...
```

So basically I am serving several angular apps on different routes
and this peace of code solves this problem

**BUT** it starts to serve files from file system!
how it could be fixed?