### PR TITLE
Added a flag for public ip to seed the inline frame.

### DIFF
--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -46,6 +46,8 @@ var optimist = require("optimist")
 
 	.describe("port", "The port").default("port", 8080)
 
+	.describe("public", "The public hostname/ip address of the server")
+
 	.describe("host", "The hostname/ip address the server will bind to").default("host", "localhost");
 
 require("webpack/bin/config-optimist")(optimist);
@@ -59,6 +61,9 @@ var options = wpOpt.devServer || firstWpOpt.devServer || {};
 
 if(argv.host !== "localhost" || !options.host)
 	options.host = argv.host;
+
+if(!options.public)
+	options.public = argv.public;
 
 if(argv.port !== 8080 || !options.port)
 	options.port = argv.port;
@@ -140,7 +145,7 @@ if(argv["compress"])
 var protocol = options.https ? "https" : "http";
 
 if(options.inline) {
-	var devClient = [require.resolve("../client/") + "?" + protocol + "://" + options.host + ":" + options.port];
+	var devClient = [require.resolve("../client/") + "?" + protocol + "://" + (options.public || (options.host + ":" + options.port))];
 
 	if(options.hot)
 		devClient.push("webpack/hot/dev-server");


### PR DESCRIPTION
I am currently using `webpack-dev-server` inside a docker container, this requires more control of the bind address and external public facing address to ensure it works.

To manage this I have added a flag which enables overriding of the ip address which is used in the `--inline` mode.

An example of this can be seen below, the server binds to `0.0.0.0` and the inline client uses `123.123.23.14`.

```
webpack-dev-server \
-d --hot --inline --display-reasons --display-error-details --history-api-fallback --progress \
--colors --port 8080 --host 0.0.0.0 --public 123.123.23.14
```

This provides a fix for #205