### PR TITLE
Allow changing socket.io-path via query string

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -1,9 +1,21 @@
+var url = require('url');
 var io = require("socket.io-client");
 var stripAnsi = require('strip-ansi');
 var scriptElements = document.getElementsByTagName("script");
-io = io.connect(typeof __resourceQuery === "string" && __resourceQuery ?
+
+var urlParts = url.parse(typeof __resourceQuery === "string" && __resourceQuery ?
 	__resourceQuery.substr(1) :
 	scriptElements[scriptElements.length-1].getAttribute("src").replace(/\/[^\/]+$/, "")
+);
+
+io = io.connect(
+	url.format({
+		protocol: urlParts.protocol,
+		auth: urlParts.auth,
+		host: urlParts.host
+	}), {
+		path: urlParts.path === '/' ? null : urlParts.path
+	}
 );
 
 var hot = false;


### PR DESCRIPTION
Related #46, #220, (kind of) #239

This PR allows you to use `'webpack-dev-server/client?http://mydomain/mysocket.io/'` (domain is optional, just as path is). I.e. being able to change the `socket.io` path too and not just the domain. If there is no path you get the current behavior. `url.parse` parses `http://example.com` as having path `/` (so we must consider it no path), but that's not really a problem and preferable to avoid breaking existing configs.

If anyone wants to try it:
`"webpack-dev-server": "git://github.com/syranide/webpack-dev-server#socketiopath_npm"`

cc @sokra 
