### PR TITLE
Add option to bypass proxying requests based on a function call

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -134,19 +134,25 @@ function Server(compiler, options) {
 				}
 				options.proxy.forEach(function (proxyOptions) {
 					proxyOptions.ws = proxyOptions.hasOwnProperty('ws') ? proxyOptions.ws : true;
-					app.all(proxyOptions.path, function (req, res) {
-						if(typeof proxyOptions.rewrite === 'function') proxyOptions.rewrite(req, proxyOptions);
-						if (proxyOptions.host) {
-							req.headers.host = proxyOptions.host;
-						}
-						proxy.web(req, res, proxyOptions, function(err){
-							var msg = "cannot proxy to " + proxyOptions.target + " (" + err.message + ")";
-							this.io.sockets.emit("proxy-error", [msg]);
-							res.statusCode = 502;
-							res.end();
-						}.bind(this));
-						if (proxyOptions.configure) {
-							proxyOptions.configure(proxy);
+					app.all(proxyOptions.path, function (req, res, next) {
+						var bypassUrl = typeof proxyOptions.bypass === 'function' ? proxyOptions.bypass(req, res, proxyOptions) : false;
+						if (bypassUrl) {
+							req.url = bypassUrl;
+							next();
+						} else {
+							if(typeof proxyOptions.rewrite === 'function') proxyOptions.rewrite(req, proxyOptions);
+							if (proxyOptions.host) {
+								req.headers.host = proxyOptions.host;
+							}
+							proxy.web(req, res, proxyOptions, function(err){
+								var msg = "cannot proxy to " + proxyOptions.target + " (" + err.message + ")";
+								this.io.sockets.emit("proxy-error", [msg]);
+								res.statusCode = 502;
+								res.end();
+							}.bind(this));
+							if (proxyOptions.configure) {
+								proxyOptions.configure(proxy);
+							}
 						}
 					}.bind(this));
 				}.bind(this));


### PR DESCRIPTION
The primary use-case behind this addition is to allow HTML5 history API support for proxied paths.

The example below uses the same pattern as the `historyApiFallback` URL rewriting code to avoid the extra behavior (proxying) when the request comes from a non-ajax browser request.

```
proxy: {
    '/thepath*': {
        target: 'https://otherserver.example.com',
        bypass: function(req) {
            if (req.headers.accept.indexOf('html') !== -1) {
                console.log('Skipping proxy for browser request.');
                return '/index.html';
            }
        },
    },
},
```

I'm very option to suggestions for alternate implementations that make better reuse of the existing `historyApiFallback` code. I'm not very familiar with Express middleware yet.