### PR TITLE
Remove SSL mutual auth requirement from https option

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -191,9 +191,7 @@ function Server(compiler, options) {
 				// using built-in self-signed certificate
 				key: options.key || fs.readFileSync(path.join(__dirname, "../ssl/server.key")),
 				cert: options.cert || fs.readFileSync(path.join(__dirname, "../ssl/server.crt")),
-				ca: options.ca || fs.readFileSync(path.join(__dirname, "../ssl/ca.crt")),
-				requestCert: true,
-				rejectUnauthorized: false
+				ca: options.ca || fs.readFileSync(path.join(__dirname, "../ssl/ca.crt"))
 			}, app)
 		: http.createServer(app);
 }


### PR DESCRIPTION
This removes the whole mutual-authentication aspect of the SSL handshake. For many people, a server requesting an SSL client cert means an OS X keychain pop up to unlock the System keychain -- :fearful: :hocho:

When we remove the `requestCert` option, `rejectUnauthorized` now becomes meaningless. 

Node docs for the options `requestCert` and `rejectUnauthorized`: https://nodejs.org/api/tls.html#tls_tls_createserver_options_secureconnectionlistener