### PR TITLE
Added support for multiple static virtual paths

### DIFF
--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -137,6 +137,14 @@ new Server(webpack(wpOpt), options).listen(options.port, options.host, function(
 	else
 		console.log(protocol + "://" + options.host + ":" + options.port + "/webpack-dev-server/");
 	console.log("webpack result is served from " + options.publicPath);
+	if(options.staticRoutes) {
+		// Must be array
+		if (Array.isArray(options.staticRoutes)) {
+			options.staticRoutes.forEach(function (staticRoute) {
+				console.log("static route " + staticRoute.route + " is served from " + staticRoute.dir);
+			});
+		}
+	}
 	if(typeof options.contentBase === "object")
 		console.log("requests are proxied to " + options.contentBase.target);
 	else

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -149,6 +149,19 @@ function Server(compiler, options) {
 		app.use(this.middleware);
 	}
 
+	if(options.staticRoutes !== false) {
+		// Must be array
+		if (Array.isArray(options.staticRoutes)) {
+			options.staticRoutes.forEach(function (staticRoute) {
+				app.use(staticRoute.route, 
+					express.static(staticRoute.dir),
+					serveIndex(staticRoute.dir));
+			});
+		}
+    } else {
+        console.log("staticRoute is false");
+    }
+
 	if(options.contentBase !== false) {
 		var contentBase = options.contentBase || process.cwd();
 

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -158,8 +158,6 @@ function Server(compiler, options) {
 					serveIndex(staticRoute.dir));
 			});
 		}
-    } else {
-        console.log("staticRoute is false");
     }
 
 	if(options.contentBase !== false) {


### PR DESCRIPTION
I looked through a lot of different node.js projects before writing this trying to find a way to do what I want to do.  Given a complicated source tree that has a number of different subdirectories all supplying some static files I wanted a way to be able to define multiple static virtual paths for the webpack-dev-server.  

So, I added support for a new parameter "staticRoutes" which expects an array of objects that have a route and dir fields.  route specifies the static route as it will be seen from the browser and dir specifies a the directory in your source tree that will host those files.  For example:

```
var config = {
  devServer: {
    contentBase: 'src/public',
    publicPath: '/__build__',
    staticRoutes: [ { 'route': '/npm_scripts', 'dir' : __dirname + '/node_modules'},
                    { 'route': '/bower_scripts', 'dir' : __dirname + '/bower_components'} ]
  }
}
```

Now you will be able to specify something like:

```
<link rel="stylesheet" type="text/css" href="/npm_scripts/bootstrap/dist/css/bootstrap.css">
<script src="/bower_scripts/jquery/dist/jquery.js"></script>
```

In your html and those files will be served appropriately.