### PR TITLE
Correct console message for historyApiFallback

### DIFF
--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -158,5 +158,5 @@ new Server(webpack(wpOpt), options).listen(options.port, options.host, function(
 	else
 		console.log("content is served from " + options.contentBase);
 	if(options.historyApiFallback)
-		console.log("404s will fallback to /index.html");
+		console.log("404s will fallback to %s", options.historyApiFallback.index || "/index.html");
 });


### PR DESCRIPTION
Tiny update to correct the console message when passing an `index` option to the historyApiFallback.

With the following config, the console message should say: *404s will fallback to /default.html*

```
// webpack.config.js
module.exports = {
  devServer: {
    historyApiFallback: {
      index: '/default.html'
    }
  }
}
```