### PR TITLE
allow bind to all host (--host 0.0.0.0)

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -12,7 +12,8 @@ io = io.connect(
 	url.format({
 		protocol: urlParts.protocol,
 		auth: urlParts.auth,
-		host: urlParts.host
+		hostname: (urlParts.hostname === '0.0.0.0') ? window.location.hostname : urlParts.hostname,
+		port: urlParts.port
 	}), {
 		path: urlParts.path === '/' ? null : urlParts.path
 	}


### PR DESCRIPTION
'0.0.0.0' allows webpack-dev-server to bind to all addresses on the machine but cannot be navigated to so use window.location.hostname in this case