### PR TITLE
Add --compress option to enable gzip compression

### DIFF
--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -42,6 +42,8 @@ var optimist = require("optimist")
 
 	.boolean("history-api-fallback").describe("history-api-fallback", "Fallback to /index.html for Single Page Applications.")
 
+	.boolean("compress").describe("compress", "enable gzip compression")
+
 	.describe("port", "The port").default("port", 8080)
 
 	.describe("host", "The hostname/ip address the server will bind to").default("host", "localhost");
@@ -131,6 +133,9 @@ if(argv["inline"])
 
 if(argv["history-api-fallback"])
 	options.historyApiFallback = true;
+
+if(argv["compress"])
+	options.compress = true;
 
 var protocol = options.https ? "https" : "http";
 

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -2,6 +2,7 @@ var fs = require("fs");
 var path = require("path");
 var webpackDevMiddleware = require("webpack-dev-middleware");
 var express = require("express");
+var compress = require("compression");
 var socketio = require("socket.io");
 var StreamCache = require("stream-cache");
 var http = require("http");
@@ -110,6 +111,13 @@ function Server(compiler, options) {
 	}.bind(this));
 
 	var features = {
+		compress: function() {
+			if (options.compress) {
+				// Enable gzip compression.
+				app.use(compress());
+			}
+		}.bind(this),
+
 		proxy: function() {
 			if (options.proxy) {
 				if (!Array.isArray(options.proxy)) {
@@ -213,6 +221,9 @@ function Server(compiler, options) {
 	defaultFeatures.push("magicHtml");
 	if(options.contentBase !== false)
 		defaultFeatures.push("contentBase");
+	// compress is placed last and uses unshift so that it will be the first middleware used
+	if(options.compress)
+		defaultFeatures.unshift("compress");
 
 	(options.features || defaultFeatures).forEach(function(feature) {
 		features[feature]();

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "webpack": "^1.3.0"
   },
   "dependencies": {
+    "compression": "^1.5.2",
     "connect-history-api-fallback": "1.1.0",
     "express": "^4.13.3",
     "http-proxy": "^1.11.2",


### PR DESCRIPTION
The --compress option uses the `compression` express middleware to gzip
compress responses from the dev server.

A development bundle for a babel + react project can easily be 1MB. I work on a remove development machine where I would take up to three seconds just to fetch the bundle. Gzip here makes a huge difference.