### PR TITLE
do not reload on error

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -58,7 +58,6 @@ io.on("errors", function(errors) {
 	for(var i = 0; i < errors.length; i++)
 		console.error(stripAnsi(errors[i]));
 	if(initial) return initial = false;
-	reloadApp();
 });
 
 io.on("proxy-error", function(errors) {


### PR DESCRIPTION
This remove a useless page reload to print an error when it was already printed before page reload.

I dunno if that's going to break things for people, but it seems weird that nobody wanted this or proposed this.

NB: live.js actually dos NOT reload when there are errors, this would make the client match this behaviour.