### PR TITLE
Add setup option to prepend custom middlewares

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -210,10 +210,15 @@ function Server(compiler, options) {
 
 		magicHtml: function() {
 			app.get("*", this.serveMagicHtml.bind(this));
+		}.bind(this),
+
+		setup: function() {
+			if(typeof options.setup === "function")
+				options.setup(app);
 		}.bind(this)
 	};
 
-	var defaultFeatures = ["headers", "middleware"];
+	var defaultFeatures = ["setup", "headers", "middleware"];
 	if(options.proxy)
 		defaultFeatures.push("proxy");
 	if(options.historyApiFallback)


### PR DESCRIPTION
Take two after #190, this time using the new fancy `features` object.

Example usage:

```js
devServer: {
  //...
  setup: function (app) {
    app.use(function(req, res, next) {
      res.cookie('my_fancy_cookie', {lorem: 'ipsum'}, {httpOnly: false})
    })
  },
},
```