### PR TITLE
Disable http-proxy certificate check

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -8,7 +8,7 @@ var StreamCache = require("stream-cache");
 var http = require("http");
 var https = require("https");
 var httpProxy = require("http-proxy");
-var proxy = new httpProxy.createProxyServer({secure: options.secureProxy});
+var proxy = new httpProxy.createProxyServer({secure: false});
 var serveIndex = require("serve-index");
 var historyApiFallback = require("connect-history-api-fallback");
 

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -8,7 +8,7 @@ var StreamCache = require("stream-cache");
 var http = require("http");
 var https = require("https");
 var httpProxy = require("http-proxy");
-var proxy = new httpProxy.createProxyServer();
+var proxy = new httpProxy.createProxyServer({secure: options.secureProxy});
 var serveIndex = require("serve-index");
 var historyApiFallback = require("connect-history-api-fallback");
 


### PR DESCRIPTION
I am receiving the following error when trying to use the webpack-dev-server proxy:

     cannot proxy to https://192.168.5.5/services/ (Hostname/IP doesn't match certificate's altnames:     "Host: localhost. is not in the cert's altnames: DNS:*.blah.com")

Chrome and Node.js both load the URL without error.

I think the core difference here is that [http-proxy defaults to rejecting unauthorized certificates](https://github.com/nodejitsu/node-http-proxy/blob/master/lib/http-proxy/common.js#L54), while Node.js allows [unauthorized certificates](https://nodejs.org/api/tls.htm) by default:

> rejectUnauthorized: If true the server will reject any connection which is not authorized with the list of supplied CAs. This option only has an effect if requestCert is true. Default: false.

Example usage, to disable rejectUnauthorized behavior:

    secureProxy: false, // default true
    proxy: { '/google/*': 'https://www.google.com' }

If you think it's more appropriate to just always disable the secure flag, I'm open to that approach as well. After all, this is a dev tool and it would follow Node.js' behavior.