### PR TITLE
add close() api

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -271,6 +271,11 @@ Server.prototype.listen = function() {
 	}.bind(this));
 }
 
+Server.prototype.close = function() {
+	this.io.close();  // Will also close listeningApp
+	this.middleware.close();
+}
+
 Server.prototype.serveMagicHtml = function(req, res, next) {
 	var _path = req.path;
 	try {


### PR DESCRIPTION
Implements close as described in #249. I don't believe it's possible to support a callback since socket.io's close does not have a callback. Happy to add some tests though not sure how the are split up amongst the various webpack libraries.