### PR TITLE
Lookup files in webpack fs, fallback to real fs

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -10,6 +10,7 @@ var https = require("https");
 var httpProxy = require("http-proxy");
 var proxy = new httpProxy.createProxyServer();
 var serveIndex = require("serve-index");
+var mime = require('mime-types');
 var historyApiFallback = require("connect-history-api-fallback");
 
 function Server(compiler, options) {
@@ -194,6 +195,25 @@ function Server(compiler, options) {
 					}.bind(this));
 				} else {
 					// route content request
+					// firstly lookup in webpack fs, otherwise load from real folder (contentBase)
+					app.get("*", function(req, res, next) {
+						var webpackfs = this.middleware.fileSystem;
+						var requestedUrl = req.path;
+
+						if (!isFile(webpackfs, requestedUrl)) {
+							next();
+							return;
+						}
+
+						var contentType = mime.contentType(path.extname(requestedUrl));
+						var content = webpackfs.readFileSync(requestedUrl);
+
+						res.setHeader('Content-Type', contentType);
+						res.setHeader('Content-Length', content.length);
+						res.write(content);
+						res.end();
+					}.bind(this));
+
 					app.get("*", express.static(contentBase), serveIndex(contentBase));
 				}
 			}
@@ -242,6 +262,15 @@ function Server(compiler, options) {
 				ca: options.ca || fs.readFileSync(path.join(__dirname, "../ssl/ca.crt"))
 			}, app)
 		: http.createServer(app);
+}
+
+function isFile(fileSystem, filePath) {
+	try {
+		return fileSystem.statSync(filePath).isFile();
+	}
+	catch(e) {
+		return false;
+	}
 }
 
 Server.prototype.use = function() {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "connect-history-api-fallback": "1.1.0",
     "express": "^4.13.3",
     "http-proxy": "^1.11.2",
+    "mime-types": "^2.1.7",
     "optimist": "~0.6.0",
     "serve-index": "^1.7.2",
     "socket.io": "^1.3.6",


### PR DESCRIPTION
This changes allow to use webpack-processed version of resources instead of read them 'as is' from `contentBase`. 

So, when client request some resource, for example `/index.html` it will lookup such resource in webpack middleware fs. If found - webpack-processed version will be returned, otherwise it will be requested from `contentBase` as is now.