### PR TITLE
make devClient URL adjustable without touching host+port

### DIFF
--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -128,7 +128,7 @@ if(argv["key"])
 if(argv["cacert"])
 	options.cacert = fs.readFileSync(path.resolve(argv["cacert"]));
 
-if(argv["inline"])
+if (argv["inline"])
 	options.inline = true;
 
 if(argv["history-api-fallback"])
@@ -140,7 +140,14 @@ if(argv["compress"])
 var protocol = options.https ? "https" : "http";
 
 if(options.inline) {
-	var devClient = [require.resolve("../client/") + "?" + protocol + "://" + options.host + ":" + options.port];
+	var client = protocol + "://" + options.host + ":" + options.port;
+
+	if (options.inlineClient) {
+		client = options.inlineClient;
+		delete options.inlineClient;
+	}
+
+	var devClient = [require.resolve("../client/") + "?" + client];
 
 	if(options.hot)
 		devClient.push("webpack/hot/dev-server");

--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -128,7 +128,7 @@ if(argv["key"])
 if(argv["cacert"])
 	options.cacert = fs.readFileSync(path.resolve(argv["cacert"]));
 
-if (argv["inline"])
+if(argv["inline"])
 	options.inline = true;
 
 if(argv["history-api-fallback"])


### PR DESCRIPTION
I'm using vagrant for development and the webpack-dev-server runs inside the VM but should be accessible from outside via `http://project.dev`.

```javascript
devServer: {
  contentBase: "/",
  historyApiFallback: true,
  hot: true,
  inline: true,
  progress: true,
  host: "localhost",
  port: 9999,
  watchOptions: {
    poll: 500
  }
}
```

This config spins up the server alright, but after adjusting nginx to proxy calls from `http://project.dev/webpack` to `http://localhost:9999` (and socket.io calls) the bundle gets served but the client tries to connect to `localhost:9999`, instead of `project.dev`. If I change `host` and `port` the server won't spin up b/c of the `project.dev`.

So I added another option to the `bin`, that sets the URL the `devClient` has to call from the browser.
It's not a big addition but it allows for a config like this:

```javascript
devServer: {
  contentBase: "/",
  historyApiFallback: true,
  hot: true,
  inline: true,
  inlineClient: "http://project.dev",
  progress: true,
  host: "localhost",
  port: 9999,
  watchOptions: {
    poll: 500
  }
}
```

What do you think?