### PR TITLE
Return "true" in bypass function to allow full proxy bypass

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -136,8 +136,10 @@ function Server(compiler, options) {
 					proxyOptions.ws = proxyOptions.hasOwnProperty('ws') ? proxyOptions.ws : true;
 					app.all(proxyOptions.path, function (req, res, next) {
 						var bypassUrl = typeof proxyOptions.bypass === 'function' ? proxyOptions.bypass(req, res, proxyOptions) : false;
-						if (bypassUrl) {
+						if (typeof bypassUrl === 'string') {
 							req.url = bypassUrl;
+							next();
+						} else if (bypassUrl) {
 							next();
 						} else {
 							if(typeof proxyOptions.rewrite === 'function') proxyOptions.rewrite(req, proxyOptions);


### PR DESCRIPTION
I have a use case where I want to proxy everything to a rails application, except a folder where the static files are contained ( so paths in production and development environment work ).

Settings would look something like this:

```javascript
  , devServer: {
      port: 8000
    , proxy: {
        "/*": {
          target: "http://localhost:3000"
        , bypass: function (req, res) {
              return /^\/a\//.test(req.url);            
          }
        }
      }
```

If you find this OK, should I add another PR to update the docs in the public pages?

Cheers!