### PR TITLE
Express middleware for History API fallback

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -10,7 +10,7 @@ var https = require("https");
 var httpProxy = require("http-proxy");
 var proxy = new httpProxy.createProxyServer();
 var serveIndex = require("serve-index");
-var historyApiFallback = require("connect-history-api-fallback");
+var historyApiFallback = require("express-history-api-fallback");
 
 function Server(compiler, options) {
 	// Default options
@@ -161,8 +161,12 @@ function Server(compiler, options) {
 
 		historyApiFallback: function() {
 			if (options.historyApiFallback) {
-				// Fall back to /index.html if nothing else matches.
-				app.use(historyApiFallback(typeof options.historyApiFallback === 'object' ? options.historyApiFallback : null));
+				var contentBase = options.contentBase || process.cwd();
+				var args = Array.isArray(options.historyApiFallback)
+					? options.historyApiFallback
+					: ['index.html', { root: contentBase }]
+				var fallback = historyApiFallback.apply(undefined, args);
+				app.use(fallback);
 			}
 		}.bind(this),
 
@@ -227,11 +231,11 @@ function Server(compiler, options) {
 	var defaultFeatures = ["setup", "headers", "middleware"];
 	if(options.proxy)
 		defaultFeatures.push("proxy");
-	if(options.historyApiFallback)
-		defaultFeatures.push("historyApiFallback", "middleware");
 	defaultFeatures.push("magicHtml");
 	if(options.contentBase !== false)
 		defaultFeatures.push("contentBase");
+	if(options.historyApiFallback)
+		defaultFeatures.push("historyApiFallback", "middleware");
 	// compress is placed last and uses unshift so that it will be the first middleware used
 	if(options.compress)
 		defaultFeatures.unshift("compress");

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   },
   "dependencies": {
     "compression": "^1.5.2",
-    "connect-history-api-fallback": "1.1.0",
     "express": "^4.13.3",
+    "express-history-api-fallback": "^2.0.0",
     "http-proxy": "^1.11.2",
     "optimist": "~0.6.0",
     "serve-index": "^1.7.2",


### PR DESCRIPTION
The Connect middleware has issues with dots in URLs due to how it
redirects the request. The Express middleware is much simpler and
leverages Request.sendFile (Express 4.8.0 or later) to serve a fixed
file (index.html) only if the express.static middleware failed to find
a file. No rewriting needed, no issues with special characters in paths.

BTW there are no tests for this project so I would appreciate help in reviewing the change.