### PR TITLE
Send `exit(0)` when stdin closed

### DIFF
--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -20,6 +20,8 @@ var optimist = require("optimist")
 	.usage("webpack-dev-server " + require("../package.json").version + "\n" +
 			"Usage: http://webpack.github.io/docs/webpack-dev-server.html")
 
+	.boolean("stdin").describe("close when stdin ends")
+
 	.boolean("lazy").describe("lazy")
 
 	.boolean("info").describe("info").default("info", true)
@@ -79,6 +81,14 @@ if(!options.filename)
 
 if(!options.watchOptions)
 	options.watchOptions = firstWpOpt.watchOptions;
+
+if(argv["stdin"]) {
+	process.stdin.on('end', function() {
+		process.exit(0);
+	});
+	process.stdin.resume();
+}
+
 if(!options.watchDelay && !options.watchOptions) // TODO remove in next major version
 	options.watchDelay = firstWpOpt.watchDelay;
 


### PR DESCRIPTION
Since I do really need this feature, this PR is the indentation fix from https://github.com/webpack/webpack-dev-server/pull/286