### PR TITLE
Allow development on single page apps

### DIFF
--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -162,10 +162,26 @@ new Server(webpack(wpOpt), options).listen(options.port, options.host, function(
 	else
 		console.log(protocol + "://" + options.host + ":" + options.port + "/webpack-dev-server/");
 	console.log("webpack result is served from " + options.publicPath);
-	if(typeof options.contentBase === "object")
-		console.log("requests are proxied to " + options.contentBase.target);
-	else
+	
+	if(typeof options.contentBase === "object") {
+		var isOldTargetRequest = options.contentBase.target && Object.keys(options.contentBase).length === 1;
+		if (isOldTargetRequest) {
+			console.log("requests are proxied to " + options.contentBase.target);
+		} else {
+			if (Array.isArray(options.contentBase)) { 
+				options.contentBase.forEach(function (item) {
+					console.log("serving "+item.path+" from "+item.target);
+				});
+			} else {
+				Object.keys(options.contentBase).forEach(function (path) {
+					console.log("serving "+path+" from "+options.contentBase[path]);
+				});
+			}
+		}
+
+	} else {
 		console.log("content is served from " + options.contentBase);
+	}
 	if(options.historyApiFallback)
 		console.log("404s will fallback to %s", options.historyApiFallback.index || "/index.html");
 });

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -198,7 +198,13 @@ function Server(compiler, options) {
 							});
 						}
 						contentBase.forEach(function (contentItem) {
-							if (contentItem.target.substr(-5) === '.html') {
+							var isFile = false;
+							try {
+								isFile = fs.lstatSync(contentItem.target).isFile();
+							} catch (e) {
+								console.log('Warning: Serving files from '+contentItem.target+', which does not exist!');
+							}
+							if (isFile) {
 								app.get(contentItem.path, function (req, res) {
 									res.end(fs.readFileSync(contentItem.target));
 								});

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -171,17 +171,42 @@ function Server(compiler, options) {
 				var contentBase = options.contentBase || process.cwd();
 
 				if(typeof contentBase === "object") {
-					console.log('Using contentBase as a proxy is deprecated and will be removed in the next major version. Please use the proxy option instead.\n\nTo update remove the contentBase option from webpack.config.js and add this:');
-					console.log('proxy: {\n\t"*": <your current contentBase configuration>\n}');
-					// Proxy every request to contentBase.target
-					app.all("*", function(req, res) {
-						proxy.web(req, res, contentBase, function(err) {
-							var msg = "cannot proxy to " + contentBase.target + " (" + err.message + ")";
-							this.sockWrite(this.sockets, "proxy-error", [msg]);
-							res.statusCode = 502;
-							res.end();
+					var isOldTargetRequest = contentBase.target && Object.keys(contentBase).length === 1;
+					if (isOldTargetRequest) {
+						console.log('Using contentBase as a proxy is deprecated and will be removed in the next major version. Please use the proxy option instead.\n\nTo update remove the contentBase option from webpack.config.js and add this:');
+						console.log('proxy: {\n\t"*": <your current contentBase configuration>\n}');
+						// Proxy every request to contentBase.target
+						app.all("*", function(req, res) {
+							proxy.web(req, res, contentBase, function(err) {
+								var msg = "cannot proxy to " + contentBase.target + " (" + err.message + ")";
+								this.sockWrite(this.sockets, "proxy-error", [msg]);
+								res.statusCode = 502;
+								res.end();
+							}.bind(this));
 						}.bind(this));
-					}.bind(this));
+					} else {
+						if (!Array.isArray(contentBase)) {
+							contentBase = Object.keys(contentBase).map(function (path) {
+								var options;
+								if (typeof contentBase[path] === 'string') {
+									options = {path: path, target: contentBase[path]};
+								} else {
+									options = contentBase[path];
+									options.path = path;
+								}
+								return options;
+							});
+						}
+						contentBase.forEach(function (contentItem) {
+							if (contentItem.target.substr(-5) === '.html') {
+								app.get(contentItem.path, function (req, res) {
+									res.end(fs.readFileSync(contentItem.target));
+								});
+							} else {
+								app.get(contentItem.path, express.static(contentItem.target), serveIndex(contentItem.target));
+							}
+						});
+					}
 				} else if(/^(https?:)?\/\//.test(contentBase)) {
 					// Redirect every request to contentBase
 					app.get("*", function(req, res) {

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -11,6 +11,7 @@ var httpProxy = require("http-proxy");
 var proxy = new httpProxy.createProxyServer();
 var serveIndex = require("serve-index");
 var historyApiFallback = require("connect-history-api-fallback");
+var send = require("send");
 
 function Server(compiler, options) {
 	// Default options
@@ -206,7 +207,7 @@ function Server(compiler, options) {
 							}
 							if (isFile) {
 								app.get(contentItem.path, function (req, res) {
-									res.end(fs.readFileSync(contentItem.target));
+									send(req, contentItem.target).pipe(res);
 								});
 							} else {
 								app.get(contentItem.path, express.static(contentItem.target), serveIndex(contentItem.target));

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -12,6 +12,8 @@ var proxy = new httpProxy.createProxyServer();
 var serveIndex = require("serve-index");
 var historyApiFallback = require("connect-history-api-fallback");
 var send = require("send");
+var mime = require("mime");
+
 
 function Server(compiler, options) {
 	// Default options
@@ -200,6 +202,13 @@ function Server(compiler, options) {
 						}
 						contentBase.forEach(function (contentItem) {
 							var isFile = false;
+							if (contentItem.target.indexOf('devserver:') === 0) {
+								app.get(contentItem.path, function (req, res, next) {
+									req.url = contentItem.target.replace('devserver:', '');
+									this.middleware(req, res, next);
+								}.bind(this));
+								return;
+							}
 							try {
 								isFile = fs.lstatSync(contentItem.target).isFile();
 							} catch (e) {
@@ -212,7 +221,7 @@ function Server(compiler, options) {
 							} else {
 								app.get(contentItem.path, express.static(contentItem.target), serveIndex(contentItem.target));
 							}
-						});
+						}.bind(this));
 					}
 				} else if(/^(https?:)?\/\//.test(contentBase)) {
 					// Redirect every request to contentBase

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "connect-history-api-fallback": "1.1.0",
     "express": "^4.13.3",
     "http-proxy": "^1.11.2",
+    "mime": "^1.3.4",
     "optimist": "~0.6.0",
     "send": "^0.13.0",
     "serve-index": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "express": "^4.13.3",
     "http-proxy": "^1.11.2",
     "optimist": "~0.6.0",
+    "send": "^0.13.0",
     "serve-index": "^1.7.2",
     "sockjs": "^0.3.15",
     "sockjs-client": "^1.0.3",


### PR DESCRIPTION
**Use Case**

I am developing a single page app that changes the URL. When I hit reload I need the server to serve the same HTML file each time, however I also have static assets, such as fonts and images, that need to be served from the file system. You can also prefix paths with devserver: to have them served from the dev server's build output rather than the file system.

**Functionality**

This PR allows you to use an object or an array for contentBase, so you can serve files from more than one place. If the target is a file, that file will be served for all requests to that path instead of using a static server.

**Example usage**

This will serve files from `./src` for `bower_components` and `assets`, falling back to the built version of `index.html` if the files don't exist or the path is not one of the two.
```
	devServer: {
		contentBase: {
			'/bower_components*': './src',
			'/assets*': './src',
			'*': 'devserver:/index.html'
		}
	},
```

**Notes**

If the object used for contentBase contains only the property `target`, it will use the deprecated proxy. I assume you'll want to remove this at the next major release.

I'm very open to doing this differently, but without something of the sort there's no good way to do this. The community has been running a separate static server and using redirects or proxies, which are a pain to work with.