### PR TITLE
Show horizontal scrollbar in errors text

### DIFF
--- a/client/style.css
+++ b/client/style.css
@@ -50,6 +50,7 @@ html {
 	line-height: 1.4;
 	color: #eff1f5;
 	background: #bf616a;
+	overflow: auto;
 }
 
 #okness {


### PR DESCRIPTION
If the error text is too long, it now shows a scrollbar instead of overflowing out of the errors element, making the text unreadable (see issue #322).

![localhost_8080_webpack-dev-server_bundle_and_1__npm_run_prepublish____npm_run_inline__node_](https://cloud.githubusercontent.com/assets/533616/11451334/ccdc9cfc-95c2-11e5-9899-6aed63fedd06.png)

Fixes #322