### PR TITLE
fix socket pathname

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -8,7 +8,7 @@ var scriptHost = scriptElements[scriptElements.length-1].getAttribute("src").rep
 // Else, get the url from the <script> this file was called with.
 var urlParts = url.parse(typeof __resourceQuery === "string" && __resourceQuery ?
 	__resourceQuery.substr(1) :
-	(scriptHost ? scriptHost : "/")
+	(scriptHost ? scriptHost : "/"), false, true
 );
 
 var sock = null;
@@ -63,7 +63,7 @@ var newConnection = function() {
 		auth: urlParts.auth,
 		hostname: (urlParts.hostname === '0.0.0.0') ? window.location.hostname : urlParts.hostname,
 		port: urlParts.port,
-		pathname: urlParts.path === '/' ? "/sockjs-node" : urlParts.path
+		pathname: urlParts.path == null || urlParts.path === '/' ? "/sockjs-node" : urlParts.path
 	}));
 
 	sock.onclose = function() {


### PR DESCRIPTION
Fixes bug in socket url composing which produces incorrect url from `webpack-dev-server/client?<some_url>` entry if `some_url` has schema omitted or doesn't end with `/`.

For instance, for `webpack-dev-server/client?http://localhost:3000/` correct socket url is produced, but for both `webpack-dev-server/client?//localhost:3000/` and `webpack-dev-server/client?http://localhost:3000` produced urls are incorrect.

This PR fixes the issue, restores compatibility with v1.10.1 in which all the mentioned variants worked well and also restores conformity with the [docs](http://webpack.github.io/docs/webpack-dev-server.html#inline-mode).