### PR TITLE
Closing listeningApp when server closes

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -313,6 +313,7 @@ Server.prototype.close = function() {
 	});
 	this.sockets = [];
 	this.middleware.close();
+	this.listeningApp.close();
 }
 
 Server.prototype.sockWrite = function(sockets, type, data) {


### PR DESCRIPTION
I ran into the same issue as in #348. When multiple sockets were added in 2dd3058746ea8ce9247726df616c8fd72c09c461, the `listeningApp` was no longer being closed by closing the server. The `close` method now explicitly closes the listening app when the server closes, thus closing the port and freeing the node process to exit gracefully (assuming it was shut down by something other than `Ctrl+C`).