### PR TITLE
Use http-proxy-middleware instead of http-proxy.

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -7,8 +7,7 @@ var sockjs = require("sockjs");
 var StreamCache = require("stream-cache");
 var http = require("http");
 var https = require("https");
-var httpProxy = require("http-proxy");
-var proxy = new httpProxy.createProxyServer({secure: false});
+var httpProxyMiddleware = require("http-proxy-middleware");
 var serveIndex = require("serve-index");
 var historyApiFallback = require("connect-history-api-fallback");
 
@@ -120,42 +119,69 @@ function Server(compiler, options) {
 
 		proxy: function() {
 			if (options.proxy) {
-				if (!Array.isArray(options.proxy)) {
-					options.proxy = Object.keys(options.proxy).map(function (path) {
+				/**
+				 * Assume a proxy configuration specified as:
+				 * proxy: 'a url'
+				 */
+				if(typeof options.proxy === 'string') {
+					options.proxy = [{
+						context: options.proxy
+					}];
+				}
+
+				/**
+				 * Assume a proxy configuration specified as:
+				 * proxy: {
+				 *   'context': { options }
+				 * }
+				 * OR
+				 * proxy: {
+				 *   'context': 'target'
+				 * }
+				 */
+			 	if(!Array.isArray(options.proxy)) {
+					options.proxy = Object.keys(options.proxy).map(function (context) {
 						var proxyOptions;
-						if (typeof options.proxy[path] === 'string') {
-							proxyOptions = {path: path, target: options.proxy[path]};
-						} else {
-							proxyOptions = options.proxy[path];
-							proxyOptions.path = path;
+
+						if(typeof options.proxy[context] === 'string') {
+							proxyOptions = {
+								context: context,
+								target: options.proxy[target]
+							};
 						}
+						else {
+							proxyOptions = options.proxy[context];
+							proxyOptions.context = context;
+						}
+
 						return proxyOptions;
 					});
 				}
-				options.proxy.forEach(function (proxyOptions) {
-					proxyOptions.ws = proxyOptions.hasOwnProperty('ws') ? proxyOptions.ws : true;
-					app.all(proxyOptions.path, function (req, res, next) {
-						var bypassUrl = typeof proxyOptions.bypass === 'function' ? proxyOptions.bypass(req, res, proxyOptions) : false;
-						if (bypassUrl) {
-							req.url = bypassUrl;
-							next();
-						} else {
-							if(typeof proxyOptions.rewrite === 'function') proxyOptions.rewrite(req, proxyOptions);
-							if (proxyOptions.host) {
-								req.headers.host = proxyOptions.host;
-							}
-							proxy.web(req, res, proxyOptions, function(err){
-								var msg = "cannot proxy to " + proxyOptions.target + " (" + err.message + ")";
-								this.sockWrite(this.sockets, "proxy-error", [msg]);
-								res.statusCode = 502;
-								res.end();
-							}.bind(this));
-							if (proxyOptions.configure) {
-								proxyOptions.configure(proxy);
+
+				/**
+				 * Assume a proxy configuration specified as:
+				 * proxy: [
+				 *   {
+				 *     context: ...,
+				 *     ...options...
+				 *   }
+				 * ]
+				 */
+				options.proxy.forEach(function (proxyConfig) {
+					var context = proxyConfig.context || proxyConfig.path;
+
+					app.use(function(req, res, next) {
+						if(typeof proxyConfig.bypass === 'function') {
+							var bypassUrl = proxyConfig.bypass(req, res, proxyConfig) || false;
+
+							if(bypassUrl) {
+								req.url = bypassUrl;
 							}
 						}
-					}.bind(this));
-				}.bind(this));
+
+						next();
+					}, httpProxyMiddleware(context, proxyConfig));
+				});
 			}
 		}.bind(this),
 
@@ -296,7 +322,7 @@ Server.prototype.listen = function() {
 				this.sockets.splice(connIndex, 1);
 			}
 		}.bind(this));
-		
+
 		if(this.hot) this.sockWrite([conn], "hot");
 		if(!this._stats) return;
 		this._sendStats([conn], this._stats.toJson(), true);

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "compression": "^1.5.2",
     "connect-history-api-fallback": "1.1.0",
     "express": "^4.13.3",
-    "http-proxy": "^1.11.2",
     "optimist": "~0.6.0",
     "serve-index": "^1.7.2",
     "sockjs": "^0.3.15",
@@ -18,7 +17,8 @@
     "stream-cache": "~0.0.1",
     "strip-ansi": "^3.0.0",
     "supports-color": "^3.1.1",
-    "webpack-dev-middleware": "^1.4.0"
+    "webpack-dev-middleware": "^1.4.0",
+    "http-proxy-middleware": "~0.9.0"
   },
   "devDependencies": {
     "css-loader": "~0.23.0",


### PR DESCRIPTION
I've found that the configuration of the node-http-proxy (NHP) library doesn't allow for some basic use cases (including my own). For example, it doesn't seem possible (through configuration only) to proxy a request from `host1.com/api/user/1` to `host2.com/user/1`.

This PR changes the implementation to use the [http-proxy-middleware (HPM)](https://www.npmjs.com/package/http-proxy-middleware) library which is built on top of the original NHP, so all current configurations should work. The HPM library has a lot more configuration options available.

I have ported over `proxyOptions.bypass(...)`, but without a `proxy` object, there is no need for `proxyOptions.configure(...)` anymore.

Comments in the code can be removed on request, I wanted to make my intent clear. Cheers