### PR TITLE
FIX console output format

### DIFF
--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -157,11 +157,13 @@ if(options.inline) {
 
 new Server(webpack(wpOpt), options).listen(options.port, options.host, function(err) {
 	if(err) throw err;
+	console.log("");
 	if(options.inline)
 		console.log(protocol + "://" + options.host + ":" + options.port + "/");
 	else
+		console.log("\n");
 		console.log(protocol + "://" + options.host + ":" + options.port + "/webpack-dev-server/");
-	console.log("webpack result is served from " + options.publicPath);
+		console.log("webpack result is served from " + options.publicPath);
 	if(typeof options.contentBase === "object")
 		console.log("requests are proxied to " + options.contentBase.target);
 	else

--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -163,7 +163,7 @@ new Server(webpack(wpOpt), options).listen(options.port, options.host, function(
 	else
 		console.log("\n");
 		console.log(protocol + "://" + options.host + ":" + options.port + "/webpack-dev-server/");
-		console.log("webpack result is served from " + options.publicPath);
+	console.log("webpack result is served from " + options.publicPath);
 	if(typeof options.contentBase === "object")
 		console.log("requests are proxied to " + options.contentBase.target);
 	else


### PR DESCRIPTION
```shell
$ webpack-dev-server --progress --colors
  0% compilehttp://localhost:8080/webpack-dev-server/
webpack result is served from /
content is served from /Users/losingle/hi
Hash: 2cef5380a790c050aa7a
Version: webpack 1.12.10
Time: 388ms
```

To

```shell
$ webpack-dev-server --progress --colors
  0% compile
http://localhost:8080/webpack-dev-server/
webpack result is served from /
content is served from /Users/losingle/hi
Hash: 2cef5380a790c050aa7a
Version: webpack 1.12.10
Time: 370ms
```