### PR TITLE
Extend contentBase to support array with multiple sources.

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -197,7 +197,11 @@ function Server(compiler, options) {
 			if(options.contentBase !== false) {
 				var contentBase = options.contentBase || process.cwd();
 
-				if(typeof contentBase === "object") {
+				if(Array.isArray(contentBase)) {
+					contentBase.forEach(function(item, index, array) {
+						app.get("*", express.static(item), serveIndex(item));
+					});
+				} else if(typeof contentBase === "object") {
 					console.log('Using contentBase as a proxy is deprecated and will be removed in the next major version. Please use the proxy option instead.\n\nTo update remove the contentBase option from webpack.config.js and add this:');
 					console.log('proxy: {\n\t"*": <your current contentBase configuration>\n}');
 					// Proxy every request to contentBase.target


### PR DESCRIPTION
Hello

This is a small but important PR that will allow us to have multiple sources as content base.

It opens a raft of development build features and solves masses of messy workarounds to achieve the same thing.

One typical example on how it would be used in a `webpack.config` is:

    var WHITELABEL = 'visa';
    config.devServer = {
      contentBase: ['./public/common', './public/' + WHITELABEL]
    }

In this example we are now able to separate `common` and `whitelabel` specific assets, externals and  sources cleanly in different folders - rather than having copies of all common files in each whitelabel folder.