### PR TITLE
Prevent application from covering up webpack errors

### DIFF
--- a/client/style.css
+++ b/client/style.css
@@ -39,6 +39,7 @@ html {
 	height: -o-calc(100% - 30px);
 	height: calc(100% - 30px);
 	border: 0;
+	z-index: -1;
 }
 
 #errors {


### PR DESCRIPTION
Currently, my web application is getting rendered on top of the build errors/warnings, preventing me from seeing them. This CSS change seems to fix it.