### PR TITLE
Fix webpack peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Tobias Koppers @sokra",
   "description": "Serves a webpack app. Updates the browser on changes.",
   "peerDependencies": {
-    "webpack": ">=2.0.3-beta <3"
+    "webpack": ">=2.0.4-beta <3"
   },
   "dependencies": {
     "compression": "^1.5.2",


### PR DESCRIPTION
Just tried to install the new beta version and it broke because of a version mis-match