### PR TITLE
fix hostname resolving on newConnection

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -59,10 +59,18 @@ var onSocketMsg = {
 };
 
 var newConnection = function() {
+	var hostname = urlParts.hostname;
+
+	if (urlParts.hostname === '0.0.0.0') {
+		if (window.location.hostname && !!~window.location.protocol.indexOf('http')) {
+			hostname = window.location.hostname;
+		}
+	}
+
 	sock = new SockJS(url.format({
 		protocol: urlParts.protocol,
 		auth: urlParts.auth,
-		hostname: (urlParts.hostname === '0.0.0.0') ? window.location.hostname : urlParts.hostname,
+		hostname: hostname,
 		port: urlParts.port,
 		pathname: urlParts.path == null || urlParts.path === '/' ? "/sockjs-node" : urlParts.path
 	}));


### PR DESCRIPTION
correct behaviour when:
1) window.location.hostname is empty or undefined
2) window.location.protocol not http or https

I'll get bug with ```ionic emulate ios``` because default protocol in WebView is :file and hostname is empty string, hence SockJs url resolve to "http:/sockjs-node" that caused a bug ```SyntaxError: The URL's scheme must be either 'http:' or 'https:'. 'file:' is not allowed.```