### PR TITLE
add `staticOptions` for expose express.static options pass in

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -234,7 +234,7 @@ function Server(compiler, options) {
 					});
 				} else {
 					// route content request
-					app.get("*", express.static(contentBase), serveIndex(contentBase));
+					app.get("*", express.static(contentBase, options.staticOptions), serveIndex(contentBase));
 				}
 			}
 		}.bind(this),


### PR DESCRIPTION
Issue #327 (Expose a way to pass params for `express.static`)