### PR TITLE
Updates webpack dev server url when iframe url changes.

### DIFF
--- a/client/live.js
+++ b/client/live.js
@@ -124,5 +124,13 @@ $(function() {
 			}
 		}
 	}
-
+	var path = '';
+	setInterval(function(){
+		if (path !== iframe[0].contentWindow.location.pathname) {
+			path = iframe[0].contentWindow.location.pathname;
+			if (path !== 'blank' && path !== 'javascript:;') {
+				history.pushState({}, null, '/webpack-dev-server' + path);
+			}
+		}
+	}, 200);
 });


### PR DESCRIPTION
### Problem
webpack dev server can initiate your application on certain url using the part of it's on path name. such as `http://localhost:8080/webpack-dev-server/account/login`, but when application redirects to a different url, webpack dev server will not update it's own url.

This makes it hard to develop applications because when you reload the page for any reason, it takes you back to beginning. also debugging URL changes are tedious.

### Solution
This change adds a simple polling code that checks the pathname of the iframe and if it changes, it silently changes the webpack url too.

I searched the docs but couldn't find a similar feature, you don't need to merge this commit but it should give you an idea of the problem and the possible solution.

Thanks for building such an awesome tool.