### PR TITLE
correct proxy options

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -148,7 +148,7 @@ function Server(compiler, options) {
 						if(typeof options.proxy[context] === 'string') {
 							proxyOptions = {
 								context: correctedContext,
-								target: options.proxy[target]
+								target: options.proxy[context]
 							};
 						} else {
 							proxyOptions = options.proxy[context];


### PR DESCRIPTION
Proxy configuration was failing due to unknown variable 'target'. Should be 'context' instead, I assume.