### PR TITLE
Permit webpack@2 betas

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Tobias Koppers @sokra",
   "description": "Serves a webpack app. Updates the browser on changes.",
   "peerDependencies": {
-    "webpack": ">=2.0.3-beta <3"
+    "webpack": "^2 || 2.0.4-beta || 2.0.5-beta || 2.0.6-beta || 2.0.7-beta || 2.1.0-beta.0"
   },
   "dependencies": {
     "compression": "^1.5.2",


### PR DESCRIPTION
Ranges don't work on pre-releases.

Heads-up: `2.0.3-beta` never existed (or was unpublished).