### PR TITLE
Output build errors to console

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -29,6 +29,7 @@ function Server(compiler, options) {
 	}.bind(this);
 	compiler.plugin("compile", invalidPlugin);
 	compiler.plugin("invalid", invalidPlugin);
+	compiler.plugin("failed", console.error.bind(console));
 	compiler.plugin("done", function(stats) {
 		this._sendStats(this.sockets, stats.toJson());
 		this._stats = stats;


### PR DESCRIPTION
Before this, if postcss throws a syntax error, because user's css is invalid,
the dev server silently sits there, and the browser is stuck there waiting.
No feedback to the developer is available.