### PR TITLE
Guess server's port from current page.

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -63,7 +63,7 @@ var newConnection = function() {
 		protocol: urlParts.protocol,
 		auth: urlParts.auth,
 		hostname: (urlParts.hostname === '0.0.0.0') ? window.location.hostname : urlParts.hostname,
-		port: urlParts.port,
+		port: (urlParts.port == '0') ? window.location.port : urlParts.port,
 		pathname: urlParts.path == null || urlParts.path === '/' ? "/sockjs-node" : urlParts.path
 	}));
 


### PR DESCRIPTION
Allow to use port from current page, the same way we allow to use hostname.

This is useful in setups where the webpack server is for instance in a docker container and doesn't know statically on which hostname and port it will be accessed from. It's already possible to use "0.0.0.0" as an address to use current page's hostname. I'm adding the same trick for the port.

The config should then look like this
"webpack-dev-server/client?http://0.0.0.0:0"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/webpack/webpack-dev-server/430)
<!-- Reviewable:end -->
