### PR TITLE
Add hot-only option to allow setting `only-dev-server` from cli or config

### DIFF
--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -23,6 +23,7 @@ var yargs = require("yargs")
 
 require("webpack/bin/config-yargs")(yargs);
 
+var ADVANCED_GROUP = "Advanced options:";
 var DISPLAY_GROUP = "Stats options:";
 var SSL_GROUP = "SSL options:";
 var CONNECTION_GROUP = "Connection options:";
@@ -37,6 +38,11 @@ yargs.options({
 		type: "boolean",
 		default: true,
 		describe: "Inline mode"
+	},
+	"hot-only": {
+		type: "boolean",
+		describe: "Do not refresh page if HMR fails",
+		group: ADVANCED_GROUP
 	},
 	"stdin": {
 		type: "boolean",
@@ -169,6 +175,9 @@ function processOptions(wpOpt) {
 	if(!options.hot)
 		options.hot = argv["hot"];
 
+	if(!options.hotOnly)
+		options.hotOnly = argv["hot-only"];
+
 	if(argv["content-base"]) {
 		options.contentBase = argv["content-base"];
 		if(/^[0-9]$/.test(options.contentBase))
@@ -231,8 +240,11 @@ function processOptions(wpOpt) {
 	if(options.inline !== false) {
 		var devClient = [require.resolve("../client/") + "?" + protocol + "://" + (options.public || (options.host + ":" + options.port))];
 
-		if(options.hot)
+		if(options.hotOnly)
+			devClient.push("webpack/hot/only-dev-server");
+		else if(options.hot)
 			devClient.push("webpack/hot/dev-server");
+
 		[].concat(wpOpt).forEach(function(wpOpt) {
 			if(typeof wpOpt.entry === "object" && !Array.isArray(wpOpt.entry)) {
 				Object.keys(wpOpt.entry).forEach(function(key) {

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -19,7 +19,7 @@ function Server(compiler, options) {
 		throw new Error("'filename' option must be set in lazy mode.");
 	}
 
-	this.hot = options.hot;
+	this.hot = options.hot || options.hotOnly;
 	this.headers = options.headers;
 	this.sockets = [];
 


### PR DESCRIPTION
I currently have to mess around with `entry` manually as I want `only-dev-server`. This allows me to just add the options, or cli flag.

current:
```js
entry: [
  'webpack-dev-server/client?http://0.0.0.0:3030',
  'webpack/hot/only-dev-server',
  origConfig.entry
],
devServer: {
  host: '0.0.0.0',
  port: 3030,
  hot: true,
},
```

wanted: 
```js
devServer: {
  host: '0.0.0.0',
  port: 3030,
  hotOnly: true,
  inline: true
},
```

Ideally I'd PR this into `webpack-dev-server@1` (as IE8 support is dropped, we'll probably never upgrade), but there doesn't seem like there's a branch for it.