### PR TITLE
Update to v2.0.0-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-dev-server",
-  "version": "2.0.0-beta",
+  "version": "2.0.0-beta.1",
   "author": "Tobias Koppers @sokra",
   "description": "Serves a webpack app. Updates the browser on changes.",
   "peerDependencies": {


### PR DESCRIPTION
The `package.json` has been updated to work with webpack 2.1.0-beta, but the beta published to NPM doesn't support that version of webpack.

This PR introduces a newer version of the beta that can be published to NPM allowing developers to more easily use this in conjunction with the latest webpack beta.