### PR TITLE
Allow running dev-server behind https proxy

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -60,7 +60,7 @@ var onSocketMsg = {
 
 var newConnection = function() {
 	sock = new SockJS(url.format({
-		protocol: urlParts.protocol,
+		protocol: (window.location.protocol == "https:") ? "https:" : urlParts.protocol,
 		auth: urlParts.auth,
 		hostname: (urlParts.hostname === '0.0.0.0') ? window.location.hostname : urlParts.hostname,
 		port: (urlParts.port == '0') ? window.location.port : urlParts.port,


### PR DESCRIPTION
Forces use of https protocol when window.location.protocol is https

This is useful in cases when the server is behind https proxy, and shouldn't break anything since browsers block http access from https page anyway.

see https://community.c9.io/t/mixed-content-with-webpack-dev-server/3053/3