### PR TITLE
set protocol to https if window using same

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -60,7 +60,7 @@ var onSocketMsg = {
 
 var newConnection = function() {
 	sock = new SockJS(url.format({
-		protocol: urlParts.protocol,
+		protocol: (window.location.protocol === "https:") ? "https:" : urlParts.protocol,
 		auth: urlParts.auth,
 		hostname: (urlParts.hostname === '0.0.0.0') ? window.location.hostname : urlParts.hostname,
 		port: (urlParts.port == '0') ? window.location.port : urlParts.port,


### PR DESCRIPTION
Fixes webpack-dev-server hot reloading failure when using Cloud9 IDE due to mixed protocol error.