### PR TITLE
Don't reload app upon proxy errors.

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -54,7 +54,6 @@ var onSocketMsg = {
 		for(var i = 0; i < errors.length; i++)
 			console.error(stripAnsi(errors[i]));
 		if(initial) return initial = false;
-		reloadApp();
 	}
 };
 


### PR DESCRIPTION
Previously the clientside application would reload whenever a proxy answered with an error response
or in other ways behaved badly. This change removes that reloading behavior, as reloading the clientside
application probably won't fix any issue the proxy has anyway.

/ping @SpaceK33z as he made these socket handlers in the first place

Refs https://github.com/webpack/webpack-dev-server/issues/446