### PR TITLE
Fix error message box display when having not found module

### DIFF
--- a/client/live.js
+++ b/client/live.js
@@ -99,7 +99,10 @@ $(function() {
 	iframe.load(function() {
 		status.text("App ready.");
 		header.css({borderColor: ""});
-		iframe.show();
+		
+		if ($errors.is(':hidden')) {
+			iframe.show();
+		}
 	});
 
 	function reloadApp() {


### PR DESCRIPTION
With many errors like
```
bundle.js:40842 Uncaught Error: Cannot find module "./../CandidateHeader"
```

The screen show no thing, only the error message in console log.

The root cause is webpack-dev-server's client shows the iframe, and it hides the below error message box.