### PR TITLE
Serve sockjs.js from sockjs-client dependency, don't use default from CDN

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 /client/live.bundle.js
 /client/index.bundle.js
+/client/sockjs.bundle.js

--- a/client/sockjs.js
+++ b/client/sockjs.js
@@ -1,0 +1,1 @@
+module.exports = require('sockjs-client');

--- a/client/webpack.sockjs.config.js
+++ b/client/webpack.sockjs.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+	output: {
+		library: "SockJS",
+		libraryTarget: "umd"
+	}
+}

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -10,7 +10,6 @@ var https = require("https");
 var httpProxyMiddleware = require("http-proxy-middleware");
 var serveIndex = require("serve-index");
 var historyApiFallback = require("connect-history-api-fallback");
-var pkg = require("../package.json");
 
 function Server(compiler, options) {
 	// Default options
@@ -48,6 +47,10 @@ function Server(compiler, options) {
 	var inlinedJs = new StreamCache();
 	fs.createReadStream(path.join(__dirname, "..", "client", "index.bundle.js")).pipe(inlinedJs);
 
+	// Prepare the sockjs js file
+	var sockjsJs = new StreamCache();
+	fs.createReadStream(path.join(__dirname, "..", "client", "sockjs.bundle.js")).pipe(sockjsJs);
+
 	// Init express server
 	var app = this.app = new express();
 
@@ -57,6 +60,11 @@ function Server(compiler, options) {
 	app.get("/__webpack_dev_server__/live.bundle.js", function(req, res) {
 		res.setHeader("Content-Type", "application/javascript");
 		liveJs.pipe(res);
+	});
+
+	app.get("/__webpack_dev_server__/sockjs.bundle.js", function(req, res) {
+		res.setHeader("Content-Type", "application/javascript");
+		sockjsJs.pipe(res);
 	});
 
 	app.get("/webpack-dev-server.js", function(req, res) {
@@ -308,9 +316,8 @@ Server.prototype.setContentHeaders = function(req, res, next) {
 Server.prototype.listen = function() {
 	var returnValue = this.listeningApp.listen.apply(this.listeningApp, arguments);
 	var sockServer = sockjs.createServer({
-		// The SockJS server package uses a version of the client script
-		// that doesn't match our version of the client script.
-		sockjs_url: 'https://cdn.jsdelivr.net/sockjs/' + pkg.dependencies['sockjs-client'] + '/sockjs.min.js',
+		// Use provided up-to-date sockjs-client
+		sockjs_url: "/__webpack_dev_server__/sockjs.bundle.js",
 		// Limit useless logs
 		log: function(severity, line) {
 			if(severity === "error") {

--- a/package.json
+++ b/package.json
@@ -49,8 +49,11 @@
     "ssl/"
   ],
   "scripts": {
-    "prepublish": "webpack ./client/live.js client/live.bundle.js --color --config client/webpack.config.js -p && webpack ./client/index.js client/index.bundle.js --color --config client/webpack.config.js -p",
-    "lint": "eslint bin lib test examples client/{index,live,socket,webpack.config}.js",
+    "prepublish": "npm run -s client-live && npm run -s client-index && npm run -s client-sockjs",
+    "client-live": "webpack ./client/live.js client/live.bundle.js --color --config client/webpack.config.js -p",
+    "client-index": "webpack ./client/index.js client/index.bundle.js --color --config client/webpack.config.js -p",
+    "client-sockjs": "webpack ./client/sockjs.js client/sockjs.bundle.js --color --config client/webpack.sockjs.config.js -p",
+    "lint": "eslint bin lib test examples client/{index,live,socket,sockjs,webpack.config}.js",
     "beautify": "npm run lint -- --fix",
     "travis": "npm run lint && node lib/Server.js"
   }


### PR DESCRIPTION
Fixes #474 "Incompatibile SockJS" (appears when using iframe mode)