### PR TITLE
Use 'document.scripts' instead of document.getElementsByTagName

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -7,7 +7,7 @@ if (typeof __resourceQuery === "string" && __resourceQuery) {
 	urlParts = url.parse(__resourceQuery.substr(1));
 } else {
 	// Else, get the url from the <script> this file was called with.
-	var scriptElements = document.getElementsByTagName("script");
+	var scriptElements = document.scripts;
 	var scriptHost = scriptElements[scriptElements.length-1].getAttribute("src");
 	scriptHost = scriptHost && scriptHost.replace(/\/[^\/]+$/, "");
 	urlParts = url.parse((scriptHost ? scriptHost : "/"), false, true);

--- a/client/index.js
+++ b/client/index.js
@@ -1,15 +1,30 @@
 var url = require('url');
 var SockJS = require("sockjs-client");
 var stripAnsi = require('strip-ansi');
+
+function getCurrentScriptSource() {
+	// try to get the current script
+	if (document.currentScript) {
+		return document.currentScript.getAttribute("src");
+	}
+	// fall back to getting all scripts in the document
+	var scriptElements = document.scripts || [],
+		currentScript = scriptElements[scriptElements.length - 1];
+	if (currentScript) {
+		return currentScript.getAttribute("src");
+	}
+	// fail as there was no script to use
+	throw new Error("Failed to get current script source");
+}
+
 var urlParts;
 if (typeof __resourceQuery === "string" && __resourceQuery) {
 	// If this bundle is inlined, use the resource query to get the correct url.
 	urlParts = url.parse(__resourceQuery.substr(1));
 } else {
 	// Else, get the url from the <script> this file was called with.
-	var scriptElements = document.scripts;
-	var scriptHost = scriptElements[scriptElements.length-1].getAttribute("src");
-	scriptHost = scriptHost && scriptHost.replace(/\/[^\/]+$/, "");
+	var scriptHost = getCurrentScriptSource();
+	scriptHost = scriptHost.replace(/\/[^\/]+$/, "");
 	urlParts = url.parse((scriptHost ? scriptHost : "/"), false, true);
 }
 


### PR DESCRIPTION
`document.scripts` preserves script-addition order, so we can add scripts in the HEAD as well as BODY.

Currently using `getElementsByTagName` fails if the script is placed in the HEAD.

EDIT: This is nicely discussed [here](http://www.2ality.com/2014/05/current-script.html), where the author mentions (discussing the `getElementsByTagName` alternative):
> There are two situations where this snippet will fail, though. When a script is loaded asynchronously using `<script async>`, the order of script execution is uncertain. Therefore the `document.getElementsByTagName()` trick will not work, as it relies on the currently executed script being the last of that collection. __The same holds true for `<script>`s that are not appended to the end of the document__. In the future this might become less of a problem, as `document.currentScript` __properly resolves async scripts__.