### PR TITLE
set headers on all methods to support e.g. CORS

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -245,7 +245,7 @@ function Server(compiler, options) {
 		}.bind(this),
 
 		headers: function() {
-			app.get("*", this.setContentHeaders.bind(this));
+			app.all("*", this.setContentHeaders.bind(this));
 		}.bind(this),
 
 		magicHtml: function() {


### PR DESCRIPTION
Hey @sokra,

currently the headers are only set on GET responses. It would be great to also set them on at least OPTIONS as well to support e.g. CORS. My solution is to set headers on all methods supported by express.

Please also backport this to 1.x

cc: @mischi