### PR TITLE
Return http.Server instance from listen

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -311,7 +311,7 @@ Server.prototype.setContentHeaders = function(req, res, next) {
 
 // delegate listen call and init sockjs
 Server.prototype.listen = function() {
-	this.listeningApp.listen.apply(this.listeningApp, arguments);
+	var returnValue = this.listeningApp.listen.apply(this.listeningApp, arguments);
 	var sockServer = sockjs.createServer({
 		// Limit useless logs
 		log: function(severity, line) {
@@ -339,6 +339,7 @@ Server.prototype.listen = function() {
 	sockServer.installHandlers(this.listeningApp, {
 		prefix: '/sockjs-node'
 	});
+	return returnValue;
 }
 
 Server.prototype.close = function() {


### PR DESCRIPTION
Return the `http.Server` instance from `listen` to [match the return value of the same function in express](https://github.com/expressjs/express/blob/31dd549f350accd7b4e3685c13f745e857557827/lib/application.js#L617).