### PR TITLE
Would something simple like this be a start to handling an array of webpack configs?

### DIFF
--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -278,4 +278,8 @@ function processOptions(wpOpt) {
 	});
 }
 
-processOptions(wpOpt);
+if (Array.isArray(wpOpt)) {
+	wpOpt.forEach(processOptions);
+} else {
+	processOptions(wpOpt);
+}


### PR DESCRIPTION
I work on a project that has several webpack configs. All of the configs are essentially the same, they just have different entry points and output locations. Because of the this, the configs are exported as an array from webpack.config.js. This works great for a simple webpack build, but webpack-dev-server doesn't handle an array of configs. Currently, just the first config is used if an array is encountered.

I'd think that as long as the config specifies a unique port for each config then webpack-dev-server should have no problem booting up more than 1 express server.

I just made this super basic, non-master-ready hack and it seems to do what I'm wanting. I get multiple servers. Would an approach like this be a viable option, and perhaps one day be included as part of webpack-dev-server? I opened issued #487 on this awhile back.