### PR TITLE
Add --skip-errors option to webpack-dev-server

### DIFF
--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -44,6 +44,11 @@ yargs.options({
 		describe: "Do not refresh page if HMR fails",
 		group: ADVANCED_GROUP
 	},
+	"skip-errors": {
+		type: "boolean",
+		describe: "Do not reload if there are compilation errors",
+		group: ADVANCED_GROUP
+	},
 	"stdin": {
 		type: "boolean",
 		describe: "close when stdin ends"
@@ -177,6 +182,9 @@ function processOptions(wpOpt) {
 
 	if(!options.hotOnly)
 		options.hotOnly = argv["hot-only"];
+
+	if (!options.skipErrors)
+		options.skipErrors = argv["skip-errors"];
 
 	if(argv["content-base"]) {
 		options.contentBase = argv["content-base"];

--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -183,7 +183,7 @@ function processOptions(wpOpt) {
 	if(!options.hotOnly)
 		options.hotOnly = argv["hot-only"];
 
-	if (!options.skipErrors)
+	if(!options.skipErrors)
 		options.skipErrors = argv["skip-errors"];
 
 	if(argv["content-base"]) {

--- a/client/index.js
+++ b/client/index.js
@@ -76,7 +76,7 @@ var newConnection = function() {
 
 		// Try to reconnect.
 		sock = null;
-		setTimeout(function () {
+		setTimeout(function() {
 			newConnection();
 		}, 2000);
 	};

--- a/client/index.js
+++ b/client/index.js
@@ -17,6 +17,7 @@ var sock = null;
 var hot = false;
 var initial = true;
 var currentHash = "";
+var skipErrors = false;
 
 var onSocketMsg = {
 	hot: function() {
@@ -43,12 +44,15 @@ var onSocketMsg = {
 		if(initial) return initial = false;
 		reloadApp();
 	},
+	"skip-errors": function() {
+		skipErrors = true;
+	},
 	errors: function(errors) {
 		console.log("[WDS] Errors while compiling.");
 		for(var i = 0; i < errors.length; i++)
 			console.error(stripAnsi(errors[i]));
 		if(initial) return initial = false;
-		reloadApp();
+		if(!skipErrors) reloadApp();
 	},
 	"proxy-error": function(errors) {
 		console.log("[WDS] Proxy error.");

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -20,6 +20,7 @@ function Server(compiler, options) {
 	}
 
 	this.hot = options.hot || options.hotOnly;
+	this.skipErrors = options.skipErrors;
 	this.headers = options.headers;
 	this.sockets = [];
 
@@ -332,6 +333,7 @@ Server.prototype.listen = function() {
 		}.bind(this));
 
 		if(this.hot) this.sockWrite([conn], "hot");
+		if(this.skipErrors) this.sockWrite([conn], "skip-errors");
 		if(!this._stats) return;
 		this._sendStats([conn], this._stats.toJson(), true);
 	}.bind(this));


### PR DESCRIPTION
Intended to be used when NoErrorsPlugin is active in webpack, but can be
used without it. It should work without --hot too, but untested.

Prevents reloadApp() from being called when there are compilation errors
reported; ultimately stopping webpack/hot/{only-,}dev-server from trying
to fetch a nonexisting update (if NoErrorsPlugin is active) and/or
reloading the window.location.

Fixes #209.