### PR TITLE
Handle missing `src` attribute on unused last script

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -2,7 +2,8 @@ var url = require('url');
 var SockJS = require("sockjs-client");
 var stripAnsi = require('strip-ansi');
 var scriptElements = document.getElementsByTagName("script");
-var scriptHost = scriptElements[scriptElements.length-1].getAttribute("src").replace(/\/[^\/]+$/, "");
+var scriptSrc = scriptElements[scriptElements.length-1].getAttribute("src");
+var scriptHost = scriptSrc && scriptSrc.replace(/\/[^\/]+$/, "");
 
 // If this bundle is inlined, use the resource query to get the correct url.
 // Else, get the url from the <script> this file was called with.


### PR DESCRIPTION
Hi,

This fixes a bug introduced in 3d3c000, in the case where:

- `__resourceQuery` is set, and
- The last script tag on the page has no `src` attribute

Previously the script tag's `src` attribute was accessed lazily only if `__resourceQuery` was not defined. The last script on the page may not be the script that loaded webpack-dev-server.  This can happen, for example, with the use of an asynchronous loader such as LABjs.

I've pointed this PR at master, but it is based on `v1.14.1`, which is the latest non-beta release.  We are not on webpack `>=2.0.3-beta <3`, so we would need this bug fix on the `^1.14.1` range.  How are you handling patches there?

Thanks,

Bo