### PR TITLE
Fix HistoryApiFallback when publicPath is set

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -189,7 +189,10 @@ function Server(compiler, options) {
 		historyApiFallback: function() {
 			if(options.historyApiFallback) {
 				// Fall back to /index.html if nothing else matches.
-				app.use(historyApiFallback(typeof options.historyApiFallback === 'object' ? options.historyApiFallback : null));
+				var historyApiFallbackOptions = typeof options.historyApiFallback === 'object' ? options.historyApiFallback : {};
+				// If publicPath is set then fallback to publicPath (where there would be index.html)
+				if(!historyApiFallbackOptions.index && options.publicPath) historyApiFallbackOptions.index = options.publicPath;
+				app.use(historyApiFallback(historyApiFallbackOptions));
 			}
 		},
 


### PR DESCRIPTION
Currently HistoryApiFallback does not work properly when publicPath as it redirects request to `/index.html` which gives as it does not exist, instead we should redirect to publicPath (which redirects to `publicPath/index.html`).

Fixes #216