### PR TITLE
Assign --cacert CLI argument to correct server options property

### DIFF
--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -221,7 +221,7 @@ function processOptions(wpOpt) {
 		options.key = fs.readFileSync(path.resolve(argv["key"]));
 
 	if(argv["cacert"])
-		options.cacert = fs.readFileSync(path.resolve(argv["cacert"]));
+		options.ca = fs.readFileSync(path.resolve(argv["cacert"]));
 
 	if(argv["inline"] === false)
 		options.inline = false;


### PR DESCRIPTION
The `--cacert` CLI argument was being mapped to `options.cacert` which is never actually used in _Server.js_.

The correct property name is `options.ca`. In order to preserve documentation & backwards compatibility for any existing users currently passing the the `--cacert` flag, I've left the flag the same but mapped it to the `options.ca` property so that it gets passed to the `createServer` call.