### PR TITLE
Fix issue with defer/async/empty script src

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -2,7 +2,8 @@ var url = require('url');
 var SockJS = require("sockjs-client");
 var stripAnsi = require('strip-ansi');
 var scriptElements = document.getElementsByTagName("script");
-var scriptHost = scriptElements[scriptElements.length-1].getAttribute("src").replace(/\/[^\/]+$/, "");
+var scriptSrc = scriptElements[scriptElements.length-1].getAttribute("src");
+var scriptHost = scriptSrc ? scriptSrc.replace(/\/[^\/]+$/, "") : '';
 
 // If this bundle is inlined, use the resource query to get the correct url.
 // Else, get the url from the <script> this file was called with.


### PR DESCRIPTION
This PR fixes issue #381 for `v1.14.1`.

When you have a page with a `script` tag with no `src` attribute or if the script is `async`, it's trying to call `.replace()` from a non-string.

This patch should also fix the loading issues for facebookincubator/create-react-app/issues/134