### PR TITLE
Added message for server starting address.

### DIFF
--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -262,7 +262,7 @@ function processOptions(wpOpt) {
 		var uri = protocol + "://" + options.host + ":" + options.port + "/";
 		if(options.inline === false)
 			uri += "webpack-dev-server/";
-		console.log(" " + uri);
+		console.log("\nserver is started on: " + uri);
 
 		console.log("webpack result is served from " + options.publicPath);
 		if(Array.isArray(options.contentBase))


### PR DESCRIPTION
With this issue where address is appended to rest of the text should be fixed eg. `70% 1/1 build moduleshttp://localhost:8080/` should be `70% 1/1 build modules http://localhost:8080/` .