### PR TITLE
Updated connect-history-api-fallback to 1.3.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "compression": "^1.5.2",
-    "connect-history-api-fallback": "^1.2.0",
+    "connect-history-api-fallback": "^1.3.0",
     "express": "^4.13.3",
     "http-proxy-middleware": "~0.15.0",
     "open": "0.0.5",


### PR DESCRIPTION
This way we'll get the fix for https://github.com/bripkens/connect-history-api-fallback/issues/5.