### PR TITLE
Add a flag to prevent websocket reconnect

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -72,9 +72,12 @@ var newConnection = function() {
 
 		// Try to reconnect.
 		sock = null;
-		setTimeout(function () {
-			newConnection();
-		}, 2000);
+
+		if (!window.__WEBPACK_DEV_SERVER_NO_RECONNECT) {
+			setTimeout(function () {
+				newConnection();
+			}, 2000);
+		}
 	};
 
 	sock.onmessage = function(e) {


### PR DESCRIPTION
I managed to unify my "regular dev" and "hot" builds in a single one, that is served through my regular pipeline. The only problem is that if dev-server isn't running, the websocket client attempts to reconnect every 2 seconds and pollutes the console and request tabs a bunch.

This is a rather dirty fix, but there is no config mechanism for the websocket client, if you have a suggestion for something cleaner let me know and I'll make another PR.

Cheers