### PR TITLE
Fix bypass proxy middleware

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -171,22 +171,23 @@ function Server(compiler, options) {
 				options.proxy.forEach(function(proxyConfig) {
 					var bypass = typeof proxyConfig.bypass === 'function';
 					var context = proxyConfig.context || proxyConfig.path;
+					var proxyMiddleware;
+					// It is possible to use the `bypass` method without a `target`.
+					// However, the proxy middleware has no use in this case, and will fail to instantiate.
+					if(proxyConfig.target) {
+						proxyMiddleware = httpProxyMiddleware(context, proxyConfig);
+					}
 
-					function bypassMiddleware(req, res, next) {
-						var bypassUrl = proxyConfig.bypass(req, res, proxyConfig) || false;
+					app.use(function(req, res, next) {
+						var bypassUrl = bypass && proxyConfig.bypass(req, res, proxyConfig) || false;
 
 						if(bypassUrl) {
 							req.url = bypassUrl;
+							next();
+						} else if(proxyMiddleware) {
+							return proxyMiddleware(req, res, next);
 						}
-
-						next();
-					}
-
-					if(bypass) {
-						app.use(bypassMiddleware);
-					} else {
-						app.use(httpProxyMiddleware(context, proxyConfig));
-					}
+					});
 				});
 			}
 		},

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -169,19 +169,24 @@ function Server(compiler, options) {
 				 * ]
 				 */
 				options.proxy.forEach(function(proxyConfig) {
+					var bypass = typeof proxyConfig.bypass === 'function';
 					var context = proxyConfig.context || proxyConfig.path;
 
-					app.use(function(req, res, next) {
-						if(typeof proxyConfig.bypass === 'function') {
-							var bypassUrl = proxyConfig.bypass(req, res, proxyConfig) || false;
+					function bypassMiddleware(req, res, next) {
+						var bypassUrl = proxyConfig.bypass(req, res, proxyConfig) || false;
 
-							if(bypassUrl) {
-								req.url = bypassUrl;
-							}
+						if(bypassUrl) {
+							req.url = bypassUrl;
 						}
 
 						next();
-					}, httpProxyMiddleware(context, proxyConfig));
+					}
+
+					if(bypass) {
+						app.use(bypassMiddleware);
+					} else {
+						app.use(httpProxyMiddleware(context, proxyConfig));
+					}
 				});
 			}
 		},


### PR DESCRIPTION
The `bypass` feature was no longer working because the code added the bypass method as middleware AND `httpProxyMiddleware` as middleware. However, if a `bypass` method is given, it should only use that as middleware.

This was caused in #359, and effects `1.15.0` and the 2.x branch.

For now, this is based on `1.15.0`, because the people that reported issues with this are using that version. It should be merged to `master` too.