### PR TITLE
Fix for proxy rewrite not working anymore

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -180,14 +180,18 @@ function Server(compiler, options) {
 					}
 
 					app.use(function(req, res, next) {
-						if(typeof proxyConfig.rewrite === 'function') proxyConfig.rewrite(req, proxyConfig);
 						var bypassUrl = bypass && proxyConfig.bypass(req, res, proxyConfig) || false;
 
 						if(bypassUrl) {
 							req.url = bypassUrl;
 							next();
 						} else if(proxyMiddleware) {
-							return proxyMiddleware(req, res, next);
+							// TODO: `proxyConfig.rewrite` should be deprecated, http-proxy-middleware added `proxyConfig.pathRewrite`.
+							if(typeof proxyConfig.rewrite === 'function') {
+								// http-proxy-middleware overwrites `req.url` to `req.originalUrl` if it is set.
+								req.originalUrl = null;
+								proxyConfig.rewrite(req, proxyConfig)
+							};
 						}
 					});
 				});

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -192,6 +192,7 @@ function Server(compiler, options) {
 								req.originalUrl = null;
 								proxyConfig.rewrite(req, proxyConfig)
 							};
+							return proxyMiddleware(req, res, next);
 						}
 					});
 				});

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -180,6 +180,7 @@ function Server(compiler, options) {
 					}
 
 					app.use(function(req, res, next) {
+						if(typeof proxyConfig.rewrite === 'function') proxyConfig.rewrite(req, proxyConfig);
 						var bypassUrl = bypass && proxyConfig.bypass(req, res, proxyConfig) || false;
 
 						if(bypassUrl) {


### PR DESCRIPTION
Apparently this whole config option was removed in PR #359.

I'm not 100% sure this fixes everything, so it should be tested by someone who uses this feature.