### PR TITLE
Add optional delay to proxy responses (ms)

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -173,13 +173,20 @@ function Server(compiler, options) {
 					var bypass = typeof proxyConfig.bypass === 'function';
 					var context = proxyConfig.context || proxyConfig.path;
 					var proxyMiddleware;
+					var proxyDelayMiddleware;
 					// It is possible to use the `bypass` method without a `target`.
 					// However, the proxy middleware has no use in this case, and will fail to instantiate.
 					if(proxyConfig.target) {
 						proxyMiddleware = httpProxyMiddleware(context, proxyConfig);
+						if (typeof proxyConfig.delay === 'number') {
+							proxyDelayMiddleware = function(req, res, next) {
+								console.log('Delaying %s for %sms ', req.originalUrl, proxyConfig.delay);
+								setTimeout(next, proxyConfig.delay);
+							};
+						}
 					}
 
-					app.use(function(req, res, next) {
+					var middleware = function(req, res, next) {
 						var bypassUrl = bypass && proxyConfig.bypass(req, res, proxyConfig) || false;
 
 						if(bypassUrl) {
@@ -188,7 +195,13 @@ function Server(compiler, options) {
 						} else if(proxyMiddleware) {
 							return proxyMiddleware(req, res, next);
 						}
-					});
+					}
+
+					if (proxyDelayMiddleware) {
+						app.use(proxyDelayMiddleware, middleware);
+					} else {
+						app.use(middleware);
+					}
 				});
 			}
 		},

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -178,7 +178,7 @@ function Server(compiler, options) {
 					// However, the proxy middleware has no use in this case, and will fail to instantiate.
 					if(proxyConfig.target) {
 						proxyMiddleware = httpProxyMiddleware(context, proxyConfig);
-						if (typeof proxyConfig.delay === 'number') {
+						if(typeof proxyConfig.delay === 'number') {
 							proxyDelayMiddleware = function(req, res, next) {
 								console.log('Delaying %s for %sms ', req.originalUrl, proxyConfig.delay);
 								setTimeout(next, proxyConfig.delay);
@@ -197,7 +197,7 @@ function Server(compiler, options) {
 						}
 					}
 
-					if (proxyDelayMiddleware) {
+					if(proxyDelayMiddleware) {
 						app.use(proxyDelayMiddleware, middleware);
 					} else {
 						app.use(middleware);


### PR DESCRIPTION
This allows an optional `delay` parameter in the proxy config, which will then delay proxy responses with the specified amount of milliseconds.

``` javascript
proxy: {
  '/api': {
    target: 'https://other-server.example.com',
    delay: 2000 // 2 second delay
  }
}
```

I'm used to having this feature in https://github.com/typicode/json-server but couldn't find a way to do this with webpack-dev-server. I think it's a nice and easy way to simulate slow network responses and test your spinners etc.
