### PR TITLE
Avoid accessing `document` if `__resourceQuery` is defined

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -1,15 +1,16 @@
 var url = require('url');
 var SockJS = require("sockjs-client");
 var stripAnsi = require('strip-ansi');
-var scriptElements = document.getElementsByTagName("script");
-var scriptHost = scriptElements[scriptElements.length-1].getAttribute("src").replace(/\/[^\/]+$/, "");
 
 // If this bundle is inlined, use the resource query to get the correct url.
 // Else, get the url from the <script> this file was called with.
-var urlParts = url.parse(typeof __resourceQuery === "string" && __resourceQuery ?
-	__resourceQuery.substr(1) :
-	(scriptHost ? scriptHost : "/"), false, true
-);
+var urlParts;
+if (typeof __resourceQuery === "string" && __resourceQuery) {
+	urlParts = url.parse(__resourceQuery.substr(1));
+} else {
+	var scriptElements = document.getElementsByTagName("script");
+	urlParts = url.parse(scriptElements[scriptElements.length-1].getAttribute("src").replace(/\/[^\/]+$/, ""))
+}
 
 var sock = null;
 var hot = false;


### PR DESCRIPTION
Just as title says.
This is a cheery-pick from master branch.