### PR TITLE
Add option to control browser log level

### DIFF
--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -63,6 +63,12 @@ yargs.options({
 		group: DISPLAY_GROUP,
 		describe: "Quiet"
 	},
+	"client-log-level": {
+		type: "string",
+		group: DISPLAY_GROUP,
+		default: "info",
+		describe: "Log level in the browser (info, warning, error or none)"
+	},
 	"https": {
 		type: "boolean",
 		group: SSL_GROUP,
@@ -177,6 +183,9 @@ function processOptions(wpOpt) {
 
 	if(!options.hotOnly)
 		options.hotOnly = argv["hot-only"];
+
+	if(!options.clientLogLevel)
+		options.clientLogLevel = argv["client-log-level"];
 
 	if(argv["content-base"]) {
 		options.contentBase = argv["content-base"];

--- a/client/index.js
+++ b/client/index.js
@@ -16,6 +16,7 @@ if (typeof __resourceQuery === "string" && __resourceQuery) {
 var sock = null;
 var hot = false;
 var initial = true;
+var connected = false;
 var currentHash = "";
 var logLevel = "info";
 
@@ -81,7 +82,10 @@ var newConnection = function() {
 	}));
 
 	sock.onclose = function() {
-		log("error", "[WDS] Disconnected!");
+		if(connected)
+			log("error", "[WDS] Disconnected!");
+
+		connected = false;
 
 		// Try to reconnect.
 		sock = null;
@@ -91,6 +95,7 @@ var newConnection = function() {
 	};
 
 	sock.onmessage = function(e) {
+		connected = true;
 		// This assumes that all data sent via the websocket is JSON.
 		var msg = JSON.parse(e.data);
 		onSocketMsg[msg.type](msg.data);

--- a/client/index.js
+++ b/client/index.js
@@ -17,16 +17,14 @@ var sock = null;
 var hot = false;
 var initial = true;
 var currentHash = "";
-var quiet = false;
-var noInfo = true;
-var logLevel = 3; // 3 = all, 2 = warnings and errors, 1 = only errors, 0 = quiet
+var logLevel = "info";
 
 function log(level, msg) {
-	if(logLevel >= 3 && level === "info")
+	if(logLevel === "info" && level === "info")
 		return console.log(msg);
-	if(logLevel >= 2 && level === "warning")
+	if(["info", "warning"].indexOf(logLevel) >= 0 && level === "warning")
 		return console.warn(msg);
-	if(logLevel >= 1 && level === "error")
+	if(["info", "warning", "error"].indexOf(logLevel) >= 0 && level === "error")
 		return console.error(msg);
 }
 
@@ -54,14 +52,14 @@ var onSocketMsg = {
 	warnings: function(warnings) {
 		log("info", "[WDS] Warnings while compiling.");
 		for(var i = 0; i < warnings.length; i++)
-			log("warn", stripAnsi(warnings[i]));
+			console.warn(stripAnsi(warnings[i]));
 		if(initial) return initial = false;
 		reloadApp();
 	},
 	errors: function(errors) {
 		log("info", "[WDS] Errors while compiling.");
 		for(var i = 0; i < errors.length; i++)
-			log("error", stripAnsi(errors[i]));
+			console.error(stripAnsi(errors[i]));
 		if(initial) return initial = false;
 		reloadApp();
 	},

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -21,6 +21,8 @@ function Server(compiler, options) {
 
 	this.hot = options.hot || options.hotOnly;
 	this.headers = options.headers;
+	this.noInfo = options.noInfo;
+	this.quiet = options.quiet;
 	this.sockets = [];
 
 	// Listening for events
@@ -339,6 +341,9 @@ Server.prototype.listen = function() {
 		}.bind(this));
 
 		if(this.hot) this.sockWrite([conn], "hot");
+
+		if(this.quiet || this.noInfo)
+			this.sockWrite([conn], "log-level", this.quiet ? 0 : 2);
 		if(!this._stats) return;
 		this._sendStats([conn], this._stats.toJson(), true);
 	}.bind(this));

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -21,8 +21,7 @@ function Server(compiler, options) {
 
 	this.hot = options.hot || options.hotOnly;
 	this.headers = options.headers;
-	this.noInfo = options.noInfo;
-	this.quiet = options.quiet;
+	this.clientLogLevel = options.clientLogLevel;
 	this.sockets = [];
 
 	// Listening for events
@@ -342,8 +341,8 @@ Server.prototype.listen = function() {
 
 		if(this.hot) this.sockWrite([conn], "hot");
 
-		if(this.quiet || this.noInfo)
-			this.sockWrite([conn], "log-level", this.quiet ? 0 : 2);
+		if(this.clientLogLevel)
+			this.sockWrite([conn], "log-level", this.clientLogLevel);
 		if(!this._stats) return;
 		this._sendStats([conn], this._stats.toJson(), true);
 	}.bind(this));


### PR DESCRIPTION
Previously, when you used `quiet: true` or `noInfo: true` via the Node API or CLI, this only had effect on the output in the terminal (issue #109).

With this PR, these settings will be respected in the browser console as well.

Maybe it would be more flexible to add a separate option for this, but this would also mean more configuration. Looking for feedback on this.