### PR TITLE
Add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,38 @@
+## BEFORE YOU SUBMIT, please read the following:
+If you have a support request or question please 
+submit them to [StackOverflow](http://stackoverflow.com/questions/tagged/webpack) using the tag `[webpack]` or the [webpack Gitter](https://gitter.im/webpack/webpack). Future support requests will be closed.
+(remove this from issue)
+
+
+
+**I'm submitting a bug report**
+**I'm submitting a feature request**
+**I'm submitting a support request** => Please do not submit support request here, see note at the top of this template.
+(remove inappropriate sentences)
+
+
+**webpack and webpack-dev-server version:**
+webpack: 1.10.x/2.x 
+webpack-dev-server: 1.15.x/2.x
+
+
+**Please tell us about your environment:**
+OSX 10.x / Linux / Windows 10
+Docker / Vagrant
+
+
+**Current behavior:**
+
+
+**Expected/desired behavior:**
+
+
+* **If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem along with a gist/jsbin of your webpack configuration. Be sure to specify how you are running the server.** 
+
+
+* **What is the expected behavior?**
+
+
+* **What is the motivation / use case for changing the behavior?**
+
+ 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,34 @@
+**Please check if the PR fulfills these requirements**
+- [ ] An example has been added or updated in `examples/` (for features)
+- [ ] Docs have been added / updated (for bug fixes / features)
+
+
+**What kind of change does this PR introduce?**
+- [ ] Bugfix
+- [ ] Feature
+- [ ] Code style update (formatting, local variables)
+- [ ] Refactoring (no functional changes, no api changes)
+- [ ] Build related changes
+- [ ] CI related changes
+- [ ] Other... Please describe:
+
+**What is the current behavior?** (You can also link to an open issue here)
+
+
+
+**What is the new behavior?**
+
+
+
+**Does this PR introduce a breaking change?**
+- [ ] Yes
+- [ ] No
+
+If this PR contains a breaking change, please describe the following... 
+
+* Impact:
+* Migration path for existing applications: 
+* Github Issue(s) this is regarding:
+
+
+**Other information**:


### PR DESCRIPTION
This adds templates for issues and PRs. They are mostly [copied from webpack](https://github.com/webpack/webpack/tree/master/.github), but with a few changes.

@bebraw, would appreciate it if you could review this.

Fixes #587