### PR TITLE
CLI: Describe that `--inline` toggles livereload

### DIFF
--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -37,7 +37,7 @@ yargs.options({
 	"inline": {
 		type: "boolean",
 		default: true,
-		describe: "Inline mode"
+		describe: "Inline mode (set to false to disable including client scripts like livereload)"
 	},
 	"hot-only": {
 		type: "boolean",


### PR DESCRIPTION
**What kind of change does this PR introduce?**
- [x] Bugfix (CLI)
- [x] Feature (CLI)

**What is the current behavior?** (You can also link to an open issue here)

`webpack-dev-server --help | grep live` doesn't help me, and `webpack-dev-server --help | grep reload` doesn't help me.


**What is the new behavior?**

Both `webpack-dev-server --help | grep live` and `webpack-dev-server --help | grep reload` help me

**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No
