### PR TITLE
Don't use PWD as a default for --content-base in yargs

### DIFF
--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -90,7 +90,6 @@ yargs.options({
 	},
 	"content-base": {
 		type: "string",
-		default: process.cwd(),
 		describe: "A directory or URL to serve HTML content from.",
 		group: RESPONSE_GROUP
 	},
@@ -184,16 +183,21 @@ function processOptions(wpOpt) {
 	if(!options.clientLogLevel)
 		options.clientLogLevel = argv["client-log-level"];
 
-	if(!options.contentBase && argv["content-base"]) {
-		options.contentBase = argv["content-base"];
-		if(/^[0-9]$/.test(options.contentBase))
-			options.contentBase = +options.contentBase;
-		else if(!/^(https?:)?\/\//.test(options.contentBase))
-			options.contentBase = path.resolve(options.contentBase);
-	} else if(argv["content-base-target"]) {
-		options.contentBase = {
-			target: argv["content-base-target"]
-		};
+	if(!options.contentBase) {
+		if(argv["content-base"]) {
+			options.contentBase = argv["content-base"];
+			if(/^[0-9]$/.test(options.contentBase))
+				options.contentBase = +options.contentBase;
+			else if(!/^(https?:)?\/\//.test(options.contentBase))
+				options.contentBase = path.resolve(options.contentBase);
+		} else if(argv["content-base-target"]) {
+			options.contentBase = {
+				target: argv["content-base-target"]
+			};
+		// It is possible to disable the contentBase by using `--no-content-base`, which results in arg["content-base"] = false
+		} else if(argv["content-base"] !== false) {
+			options.contentBase = process.cwd();
+		}
 	}
 
 	if(!options.stats) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] An example has been added or updated in `examples/` (for features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?**
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

#598 fixed a bug where the `contentBase` from the webpack config was ignored in the CLI. However, there were more issues.

The default value according to `--help` is the PWD. This is not true. If `contentBase` is set in the webpack config, this default value is ignored.

**What is the new behavior?**

Yargs will not incorrectly display the default value of `--content-base` now.

Originally I intended to add an error message when `contentBase` was set from the config AND from the CLI, but this would be inconsistent with all other options. The config always gets preference.

**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No
