### PR TITLE
Fix historyApiFallback for nested paths

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -256,11 +256,11 @@ function Server(compiler, options) {
 	var defaultFeatures = ["setup", "headers", "middleware"];
 	if(options.proxy)
 		defaultFeatures.push("proxy");
-	if(options.historyApiFallback)
-		defaultFeatures.push("historyApiFallback", "middleware");
 	defaultFeatures.push("magicHtml");
 	if(options.contentBase !== false)
 		defaultFeatures.push("contentBase");
+	if(options.historyApiFallback)
+		defaultFeatures.push("historyApiFallback", "middleware");
 	// compress is placed last and uses unshift so that it will be the first middleware used
 	if(options.compress)
 		defaultFeatures.unshift("compress");


### PR DESCRIPTION
I don't quite understand how the files are serving, specifically why files on top level served fine while nested are not.

For example, i had follow sctructure:
```
/public
  /userpics/pic1.jpg
  index.html
  userpic.jpg
```
With config
```
devServer: {
  contentBase: 'public',
}
```
`GET /userpic.jpg` => `/public/userpic.jpg`
`GET /userpics/pic1.jpg` => `/public/userpics/pic1.jpg`

After adding `historyApiFallback: true` to config

`GET /userpic.jpg` => `/public/userpic.jpg`
`GET /userpics/pic1.jpg` => `/public/index.html`

But swaping `defaultFeatures.push("contentBase");`  and `defaultFeatures.push("historyApiFallback", "middleware");` fixes it.