### PR TITLE
Emit 'log-level' event before 'hot' event

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -363,10 +363,11 @@ Server.prototype.listen = function() {
 			}
 		}.bind(this));
 
-		if(this.hot) this.sockWrite([conn], "hot");
-
 		if(this.clientLogLevel)
 			this.sockWrite([conn], "log-level", this.clientLogLevel);
+
+		if(this.hot) this.sockWrite([conn], "hot");
+
 		if(!this._stats) return;
 		this._sendStats([conn], this._stats.toJson(), true);
 	}.bind(this));


### PR DESCRIPTION
**What kind of change does this PR introduce?**
- [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)

Even with `clientLogLevel: 'none'`, I see `[WDS] Hot Module Replacement enabled.` in the console.

**What is the new behavior?**

Client log level is respected for `[WDS] Hot Module Replacement enabled.`.

**Does this PR introduce a breaking change?**
- [x] No

**Other information**:

I would appreciate backporting this fix to 1.x.
Alternatively if you could give me commit access, I could backport it myself.