### PR TITLE
fix for #625 broken historyApiFallback

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -279,11 +279,11 @@ function Server(compiler, options) {
 	var defaultFeatures = ["setup", "headers", "middleware"];
 	if(options.proxy)
 		defaultFeatures.push("proxy", "middleware");
+	if(options.historyApiFallback)
+		defaultFeatures.push("historyApiFallback", "middleware");
 	defaultFeatures.push("magicHtml");
 	if(options.contentBase !== false)
 		defaultFeatures.push("contentBase");
-	if(options.historyApiFallback)
-		defaultFeatures.push("historyApiFallback", "middleware");
 	// compress is placed last and uses unshift so that it will be the first middleware used
 	if(options.compress)
 		defaultFeatures.unshift("compress");

--- a/test/HistoryApiFallback.test.js
+++ b/test/HistoryApiFallback.test.js
@@ -47,8 +47,7 @@ describe("HistoryApiFallback", function() {
 			server = helper.start(config2, {
 				contentBase: path.join(__dirname, "fixtures/historyapifallback-2-config"),
 				historyApiFallback: {
-					index: "/bar.html",
-					disableDotRule: true
+					index: "/bar.html"
 				}
 			}, done);
 			req = request(server.app);

--- a/test/HistoryApiFallback.test.js
+++ b/test/HistoryApiFallback.test.js
@@ -71,4 +71,43 @@ describe("HistoryApiFallback", function() {
 			.expect(200, /Other file/, done);
 		});
 	});
+
+	describe("as object with contentBase and rewrites", function() {
+		before(function(done) {
+			server = helper.start(config2, {
+				contentBase: path.join(__dirname, "fixtures/historyapifallback-2-config"),
+				historyApiFallback: {
+					rewrites: [
+						{
+							from: /other/,
+							to: "/other.html"
+						},
+						{
+							from: /.*/,
+							to: "/bar.html"
+						}
+					]
+				}
+			}, done);
+			req = request(server.app);
+		});
+
+		it("historyApiFallback respect rewrites for index", function(done) {
+			req.get("/")
+			.accept("html")
+			.expect(200, /Foobar/, done);
+		});
+
+		it("historyApiFallback respect rewrites and shows index for unknown urls", function(done) {
+			req.get("/acme")
+			.accept("html")
+			.expect(200, /Foobar/, done);
+		});
+
+		it("historyApiFallback respect any other specified rewrites", function(done) {
+			req.get("/other")
+			.accept("html")
+			.expect(200, /Other file/, done);
+		});
+	});
 });


### PR DESCRIPTION
fixing broken historyApiFallback, with this one - tests are passed and we can use custom index or rewrites property of historyApiFallback
