### PR TITLE
Add support for pfx files as ssl connection options [webpack-1]

### DIFF
--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -39,6 +39,10 @@ var optimist = require("optimist")
 
 .string("cacert").describe("cacert", "Path to a SSL CA certificate.")
 
+.string("pfx").describe("pfx", "Path to a SSL pfx file.")
+
+.string("pfx-passphrase").describe("pfx-passphrase", "Passphrase for pfx file.")
+
 .string("content-base").describe("content-base", "A directory or URL to serve HTML content from.")
 
 .string("content-base-target").describe("content-base-target", "Proxy requests to this target.")
@@ -151,6 +155,12 @@ if(argv["key"])
 
 if(argv["cacert"])
 	options.ca = fs.readFileSync(path.resolve(argv["cacert"]));
+
+if(argv["pfx"])
+	options.pfx = fs.readFileSync(path.resolve(argv["pfx"]));
+
+if(argv["pfx-passphrase"])
+	options.pfxPassphrase = argv["pfx-passphrase"];
 
 if(argv["inline"])
 	options.inline = true;

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -288,7 +288,9 @@ function Server(compiler, options) {
 			options.https = {
 				key: options.key,
 				cert: options.cert,
-				ca: options.ca
+				ca: options.ca,
+				pfx: options.pfx,
+				passphrase: options.pfxPassphrase
 			};
 		}
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] An example has been added or updated in `examples/` (for features) - **webpack 1 doesnt have ssl examples**
- [ ] Docs have been added / updated (for bug fixes / features) - **needs to be merged first**


**What kind of change does this PR introduce?**
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
It is not possible to provide a pfx file as supported by [https.createSearver](https://nodejs.org/api/https.html#https_https_createserver_options_requestlistener) 


**What is the new behavior?**
It will be possible to provide a pfx file, either by passing a commandline argument --pfx and --pfx-passphrase that will pass it on to https.createServer.


**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No


**Other information**:
This is for webpack 1 dev server.I'll add a seperate PR with similar functionality for webpack 2 web server. 
