### PR TITLE
Add support for pfx files as ssl connection options

### DIFF
--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -94,6 +94,16 @@ yargs.options({
 		describe: "Path to a SSL CA certificate.",
 		group: SSL_GROUP
 	},
+	"pfx": {
+		type: "string",
+		describe: "Path to a SSL pfx file.",
+		group: SSL_GROUP
+	},
+	"pfx-passphrase": {
+		type: "string",
+		describe: "Passphrase for pfx file.",
+		group: SSL_GROUP
+	},
 	"content-base": {
 		type: "string",
 		describe: "A directory or URL to serve HTML content from.",
@@ -232,6 +242,12 @@ function processOptions(wpOpt) {
 
 	if(argv["cacert"])
 		options.ca = fs.readFileSync(path.resolve(argv["cacert"]));
+
+	if(argv["pfx"])
+		options.pfx = fs.readFileSync(path.resolve(argv["pfx"]));
+
+	if(argv["pfx-passphrase"])
+		options.pfxPassphrase = argv["pfx-passphrase"];
 
 	if(argv["inline"] === false)
 		options.inline = false;

--- a/examples/https/README.md
+++ b/examples/https/README.md
@@ -6,6 +6,11 @@ node ../../bin/webpack-dev-server.js --open --https
 
 A fake certificate is used to enable https.
 
+You can provide the following SSL options to override the fake certificate:
+
+* Certificate options e.g. `node ../../bin/webpack-dev-server.js --open --https --cacert=pathToCacert --cert=pathToCert --key=pathToKey`
+* PFX and Passphrase e.g. `node ../../bin/webpack-dev-server.js --open --https --pfx=pathToPfx --pfx-passphrase=PASSPHRASE`
+
 ## What should happen
 
 The script should open `https://localhost:8080/`. Your browser will probably give you a warning about using an invalid certificate. After ignoring this warning, you should see "It's working."

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -302,19 +302,28 @@ function Server(compiler, options) {
 	}, this);
 
 	if(options.https) {
-		// for keep supporting CLI parameters
-		if(typeof options.https === "boolean") {
+		// pfx support
+		if(options.pfx) {
 			options.https = {
-				key: options.key,
-				cert: options.cert,
-				ca: options.ca
+				pfx: options.pfx,
+				passphrase: options.pfxPassphrase
 			};
+		} else {
+			// for keep supporting CLI parameters
+			if(typeof options.https === "boolean") {
+				options.https = {
+					key: options.key,
+					cert: options.cert,
+					ca: options.ca
+				};
+			}
+
+			// using built-in self-signed certificate if no certificate was configured
+			options.https.key = options.https.key || fs.readFileSync(path.join(__dirname, "../ssl/server.key"));
+			options.https.cert = options.https.cert || fs.readFileSync(path.join(__dirname, "../ssl/server.crt"));
+			options.https.ca = options.https.ca || fs.readFileSync(path.join(__dirname, "../ssl/ca.pem"));
 		}
 
-		// using built-in self-signed certificate if no certificate was configured
-		options.https.key = options.https.key || fs.readFileSync(path.join(__dirname, "../ssl/server.key"));
-		options.https.cert = options.https.cert || fs.readFileSync(path.join(__dirname, "../ssl/server.crt"));
-		options.https.ca = options.https.ca || fs.readFileSync(path.join(__dirname, "../ssl/ca.pem"));
 
 		if(!options.https.spdy) {
 			options.https.spdy = {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] An example has been added or updated in `examples/` (for features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?**
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
It is not possible to provide a pfx file as supported by [https.createSearver](https://nodejs.org/api/https.html#https_https_createserver_options_requestlistener) 



**What is the new behavior?**
It will be possible to provide a pfx file, either by passing a commandline argument --pfx and --pfx-passphrase that will pass it on to https.createServer.


**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the following... 

* Impact:
* Migration path for existing applications: 
* Github Issue(s) this is regarding:


**Other information**:
Another PR has been created for webpack 1
