### PR TITLE
sanity check that conn exists on connection

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -366,13 +366,15 @@ Server.prototype.listen = function() {
 		this.sockets.push(conn);
 
 		// Remove the connection when it's closed
-		conn.on("close", function() {
-			var connIndex = this.sockets.indexOf(conn);
-			if(connIndex >= 0) {
-				this.sockets.splice(connIndex, 1);
-			}
-		}.bind(this));
-
+		if(conn) {
+			conn.on("close", function() {
+				var connIndex = this.sockets.indexOf(conn);
+				if(connIndex >= 0) {
+					this.sockets.splice(connIndex, 1);
+				}
+			}.bind(this));
+		}
+				  
 		if(this.clientLogLevel)
 			this.sockWrite([conn], "log-level", this.clientLogLevel);
 

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -363,18 +363,16 @@ Server.prototype.listen = function() {
 		}
 	});
 	sockServer.on("connection", function(conn) {
+		if(!conn) return;
 		this.sockets.push(conn);
 
-		// Remove the connection when it's closed
-		if(conn) {
-			conn.on("close", function() {
-				var connIndex = this.sockets.indexOf(conn);
-				if(connIndex >= 0) {
-					this.sockets.splice(connIndex, 1);
-				}
-			}.bind(this));
-		}
-				  
+		conn.on("close", function() {
+			var connIndex = this.sockets.indexOf(conn);
+			if(connIndex >= 0) {
+				this.sockets.splice(connIndex, 1);
+			}
+		}.bind(this));
+
 		if(this.clientLogLevel)
 			this.sockWrite([conn], "log-level", this.clientLogLevel);
 


### PR DESCRIPTION
Low-impact bug fix that prevents an edge case where null is passed (and consequently aborts the server, which is the current behaviour) on a new connection if all handles are occupied.

I am able to reliably trigger this by rapidly refreshing on a page in development.