### PR TITLE
Update connect-history-api-fallback to enable disableDotRule use

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "compression": "^1.5.2",
-    "connect-history-api-fallback": "^1.2.0",
+    "connect-history-api-fallback": "^1.3.0",
     "express": "^4.13.3",
     "http-proxy-middleware": "~0.17.1",
     "opn": "4.0.2",


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] An example has been added or updated in `examples/` (for features) 
(example already present in https://github.com/webpack/webpack-dev-server/blob/master/examples/history-api-fallback/webpack.config.js)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?**
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Currently, `webpack-dev-server` is requiring `connect-history-api-fallback@^1.2.0` which might resolve to `1.2.0` on existing installs. 

This version doesn't yet allow for the `disableDotRule` option enabled in https://github.com/bripkens/connect-history-api-fallback/commit/ee8611164c4a06ed87d7b98b16dedb89f60ff3a3.

Using the following in the Webpack Dev Server config works only when `connect-history-api-fallback@1.3.0` is installed:
```
      historyApiFallback: {
        disableDotRule: true,
      },
```

**What is the new behavior?**

Package always requires `connect-history-api-fallback` at least `1.3.0`.

**Does this PR introduce a breaking change?**
- [ ] Yes
- [X] No

**Other information**:

