### PR TITLE
Add watch-content-base option to Webpack-1

### DIFF
--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -45,6 +45,8 @@ var optimist = require("optimist")
 
 .string("content-base").describe("content-base", "A directory or URL to serve HTML content from.")
 
+.boolean("watch-content-base").describe("watch-content-base", "Enable live-reloading of the content-base.")
+
 .string("content-base-target").describe("content-base-target", "Proxy requests to this target.")
 
 .boolean("history-api-fallback").describe("history-api-fallback", "Fallback to /index.html for Single Page Applications.")
@@ -124,6 +126,9 @@ if(argv["content-base"]) {
 } else if(!options.contentBase) {
 	options.contentBase = process.cwd();
 }
+
+if(argv["watch-content-base"])
+	options.watchContentBase = true
 
 if(!options.stats) {
 	options.stats = {

--- a/client/index.js
+++ b/client/index.js
@@ -62,6 +62,10 @@ var onSocketMsg = {
 		if(initial) return initial = false;
 		reloadApp();
 	},
+	"content-changed": function() {
+		log("info", "[WDS] Content base changed. Reloading...")
+		self.location.reload();
+	},
 	warnings: function(warnings) {
 		log("info", "[WDS] Warnings while compiling.");
 		for(var i = 0; i < warnings.length; i++)

--- a/example/README.md
+++ b/example/README.md
@@ -64,3 +64,14 @@ http://localhost:8080/some/url/from/spa
 ```
 
 The contents of /index.html is served.
+
+## Watching `devServer.contentBase`
+
+``` text
+webpack-dev-server --inline --content-base assets --watch-content-base
+http://localhost:8080/
+```
+
+Try to update `assets/index.html`.
+
+The browser should reflect your changes.

--- a/example/assets/index.html
+++ b/example/assets/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<link rel="stylesheet" href="styles.css" type="text/css" charset="utf-8">
+	</head>
+	<body>
+		<h1>Watch content base</h1>
+		<div id="mytext"></div>
+		<script src="bundle.js" type="text/javascript" charset="utf-8"></script>
+	</body>
+</html>

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -1,4 +1,5 @@
 var fs = require("fs");
+var chokidar = require("chokidar");
 var path = require("path");
 var webpackDevMiddleware = require("webpack-dev-middleware");
 var express = require("express");
@@ -23,6 +24,7 @@ function Server(compiler, options) {
 	this.headers = options.headers;
 	this.clientLogLevel = options.clientLogLevel;
 	this.sockets = [];
+	this.contentBaseWatchers = [];
 
 	// Listening for events
 	var invalidPlugin = function() {
@@ -247,6 +249,19 @@ function Server(compiler, options) {
 			}
 		}.bind(this),
 
+		watchContentBase: function() {
+			var contentBase = options.contentBase || process.cwd();
+			if(/^(https?:)?\/\//.test(contentBase) || typeof contentBase === "number") {
+				throw new Error("Watching remote files is not supported.");
+			} else if(Array.isArray(contentBase)) {
+				contentBase.forEach(function(item) {
+					this._watch(item);
+				}.bind(this));
+			} else {
+				this._watch(contentBase);
+			}
+		}.bind(this),
+
 		middleware: function() {
 			// include our middleware to ensure it is able to handle '/index.html' request after redirect
 			app.use(this.middleware);
@@ -274,6 +289,8 @@ function Server(compiler, options) {
 	defaultFeatures.push("magicHtml");
 	if(options.contentBase !== false)
 		defaultFeatures.push("contentBase");
+	if(options.watchContentBase)
+		defaultFeatures.push("watchContentBase");
 	// compress is placed last and uses unshift so that it will be the first middleware used
 	if(options.compress)
 		defaultFeatures.unshift("compress");
@@ -362,6 +379,10 @@ Server.prototype.close = function() {
 	this.sockets = [];
 	this.middleware.close();
 	this.listeningApp.close();
+	this.contentBaseWatchers.forEach(function(watcher) {
+		watcher.close();
+	});
+	this.contentBaseWatchers = [];
 }
 
 Server.prototype.sockWrite = function(sockets, type, data) {
@@ -407,6 +428,14 @@ Server.prototype._sendStats = function(sockets, stats, force) {
 		this.sockWrite(sockets, "warnings", stats.warnings);
 	else
 		this.sockWrite(sockets, "ok");
+}
+
+Server.prototype._watch = function(path) {
+	var watcher = chokidar.watch(path).on("change", function() {
+		this.sockWrite(this.sockets, "content-changed");
+	}.bind(this))
+
+	this.contentBaseWatchers.push(watcher);
 }
 
 Server.prototype.invalidate = function() {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "webpack": ">=1.3.0 <3"
   },
   "dependencies": {
+    "chokidar": "^1.6.0",
     "compression": "^1.5.2",
     "connect-history-api-fallback": "^1.3.0",
     "express": "^4.13.3",


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] An example has been added or updated in `examples/` (for features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?**
- [x] Feature

**What is the current behavior?** (You can also link to an open issue here)
Content-base changes, nothing happens #350 


**What is the new behavior?**
Content-base changes, app reloads.


**Does this PR introduce a breaking change?**
- [x] No

**Other information**:

I want those features in `webpack-1` as well :)

Fixes #350