### PR TITLE
Read files supplied through https config for key, cert and ca

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -334,16 +334,15 @@ function Server(compiler, options) {
 		}
 
 		// using built-in self-signed certificate if no certificate was configured
-		options.https.key = options.https.key || fs.readFileSync(path.join(__dirname, "../ssl/server.key"));
-		options.https.cert = options.https.cert || fs.readFileSync(path.join(__dirname, "../ssl/server.crt"));
-		options.https.ca = options.https.ca || fs.readFileSync(path.join(__dirname, "../ssl/ca.pem"));
+		options.https.key = fs.readFileSync(options.https.key || path.join(__dirname, "../ssl/server.key"));
+		options.https.cert = fs.readFileSync(options.https.cert || path.join(__dirname, "../ssl/server.crt"));
+		options.https.ca = fs.readFileSync(options.https.ca || path.join(__dirname, "../ssl/ca.pem"));
 
 		if(!options.https.spdy) {
 			options.https.spdy = {
 				protocols: ["h2", "http/1.1"]
 			};
 		}
-
 		this.listeningApp = spdy.createServer(options.https, app);
 	} else {
 		this.listeningApp = http.createServer(app);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] An example has been added or updated in `examples/` (for features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?**
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Fix for https://github.com/webpack/webpack-dev-server/issues/651

Currently, the options (key, cert, ca) supplied through `https` are treated as if they were the output of `fs.ReadFileSync`.


**What is the new behavior?**
Now the options are assumed to be paths to these files instead, and we read them before sending to spdy.


**Does this PR introduce a breaking change?**
- [x] Yes
- [ ] No

If this PR contains a breaking change, please describe the following... 

* Impact:
* Migration path for existing applications: 
* Github Issue(s) this is regarding:


**Other information**:
