### PR TITLE
Option for listening to unix socket

### DIFF
--- a/examples/listen-socket/README.md
+++ b/examples/listen-socket/README.md
@@ -1,0 +1,43 @@
+# Listen to socket
+
+Start dev server in socket mode:
+
+```shell
+node ../../bin/webpack-dev-server.js --socket ./webpack.sock
+```
+
+And then start node server that will use that socket:
+
+```shell
+node check-socket.js
+```
+
+You should see this responses to this command:
+
+```shell
+Successfully connected to socket, exiting
+```
+
+Common use-case for this feature is configuring upstream in nginx that points to webpack socket.
+Listening to socket instead of port is much more convenient because if you have many applications you don't have to resolve port conflicts since each of them has own unique socket.
+
+Example of configuring upstream with Websockets support in nginx:
+
+```
+location /webpack/ {
+	proxy_pass http://unix:/home/happywebpackuser/apps/todo/webpack.sock;
+	proxy_set_header Host $host;
+	proxy_set_header X-Real-IP $remote_addr;
+	proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+	proxy_pass http://unix:/home/resure/code/statface-raw/app/run/statbox.sock;
+	proxy_redirect off;
+}
+location /sockjs-node/ {
+	proxy_pass http://unix:/home/happywebpackuser/apps/todo/webpack.sock;
+	proxy_http_version 1.1;
+	proxy_set_header Upgrade $http_upgrade;
+	proxy_set_header Connection "upgrade";
+}
+```
+
+Replace `/webpack/` with your `publicPath` param value and path in `proxy_pass` to your actual proxy location.

--- a/examples/listen-socket/app.js
+++ b/examples/listen-socket/app.js
@@ -1,0 +1,1 @@
+document.write("It's working.");

--- a/examples/listen-socket/check-socket.js
+++ b/examples/listen-socket/check-socket.js
@@ -1,0 +1,9 @@
+"use strict";
+
+var net = require("net");
+
+var client = net.createConnection("./webpack.sock");
+client.on("connect", function() {
+	console.log("Successfully connected to socket, exiting");
+	process.exit(1); // eslint-disable-line
+});

--- a/examples/listen-socket/webpack.config.js
+++ b/examples/listen-socket/webpack.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+	context: __dirname,
+	entry: "./app.js",
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] An example has been added or updated in `examples/` (for features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?**
- [x] Feature

**What is the current behavior?**
#659

It's possible to pass socket path as port param but it won't correctly handle access rights (chmod) to socket and `EADDRINUSE` errors.


**What is the new behavior?**

New option `--socket` added. It overrides port if present and adds additional handling to listen:

- If connection is successful, then it works like before
- If connection is failing (with `EADDRINUSE` error) then socket file is already present. In this case, we're trying to connect to that socket file.
  - If connection is successful, then socket is already used by some other server and current instance of webpack-dev-server stops
  - If connection failed, then socket is not used by other processes and can be safely unlinked. After that, it starts listen() like usually.
- After listen() successfully started, it sets socket chmod to 666 (read-write for everybody, it necessary since servers like nginx are usually launched from other users like `www-data`).

**Does this PR introduce a breaking change?**
- [x] No

