### PR TITLE
customize hot reload, level 1 and level 2

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -25,6 +25,9 @@ function Server(compiler, options) {
 	this.sockets = [];
 	this.contentBaseWatchers = [];
 
+    if(this.hot === true){
+        compiler._hot = 2;
+    }
 	// Listening for events
 	var invalidPlugin = function() {
 		this.sockWrite(this.sockets, "invalid");
@@ -32,7 +35,9 @@ function Server(compiler, options) {
 	compiler.plugin("compile", invalidPlugin);
 	compiler.plugin("invalid", invalidPlugin);
 	compiler.plugin("done", function(stats) {
-		this._sendStats(this.sockets, stats.toJson());
+		if(compiler._hot == 2){
+			this._sendStats(this.sockets, stats.toJson());
+		}
 		this._stats = stats;
 	}.bind(this));
 
@@ -41,6 +46,23 @@ function Server(compiler, options) {
 
 	// middleware for serving webpack bundle
 	this.middleware = webpackDevMiddleware(compiler, options);
+
+    // refresh the page by a get request
+	self = this;
+	app.get("/refresh",function(req,res){
+		self.sockWrite(self.sockets,"invalid");
+		self._sendStats(self.sockets,self._stats.toJson());
+		res.end("");
+	})
+
+    // toggle the hot reload level
+	app.get("/toggleHot",function(req,res){
+		if(compiler.hot_){
+			compiler.hot_ = compiler.hot_ == 2 ? compiler.hot_ >> 1 : compiler.hot_ << 1;
+		}
+		res.end("");
+	})
+
 
 	app.get("/__webpack_dev_server__/live.bundle.js", function(req, res) {
 		res.setHeader("Content-Type", "application/javascript");


### PR DESCRIPTION
**Split the hot reload to two level**
- Level 2: when you change anything, it will recompile and reload the page
- Level 1: just recompile
- If set the options.hot to true, the level will be 2

**What kind of change does this PR introduce?**
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**Other information**:

Sometimes there is no need to reload the page on every change, especially when you are debuging in the developer console.
Set the options.hot to 1, it will just recompile.
If you want to reload, just get http://localhost:9000/refresh, this can be done by emacs shortcut.
If you want to toggle the level, request http://localhost:9000/toggleHot .

```
(defun save-and-refresh-webpack ()
     (interactive)
     (save-buffer)
     (request "http://localhost:9000/refresh"))
(global-set-key (kbd "the_key_you_want") 'save-and-refresh-webpack)
```
