### PR TITLE
CLI finds and uses 1st available port when none specified.

### DIFF
--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -5,6 +5,7 @@ var open = require("opn");
 var fs = require("fs");
 var net = require("net");
 var url = require("url");
+var portfinder = require("portfinder");
 
 // Local version replaces global one
 try {
@@ -45,6 +46,11 @@ var SSL_GROUP = "SSL options:";
 var CONNECTION_GROUP = "Connection options:";
 var RESPONSE_GROUP = "Response options:";
 var BASIC_GROUP = "Basic options:";
+
+// Taken out of yargs because we must know if
+// it wasn't given by the user, in which case
+// we should use portfinder.
+var DEFAULT_PORT = 8080;
 
 yargs.options({
 	"lazy": {
@@ -143,7 +149,6 @@ yargs.options({
 	},
 	"port": {
 		describe: "The port",
-		default: 8080,
 		group: CONNECTION_GROUP
 	},
 	"socket": {
@@ -189,9 +194,6 @@ function processOptions(wpOpt) {
 
 	if(argv.public)
 		options.public = argv.public;
-
-	if(argv.port !== 8080 || !options.port)
-		options.port = argv.port;
 
 	if(argv.socket)
 		options.socket = argv.socket;
@@ -294,6 +296,25 @@ function processOptions(wpOpt) {
 	if(argv["open"])
 		options.open = true;
 
+	// Kind of weird, but ensures prior behavior isn't broken in cases
+	// that wouldn't throw errors. E.g. both argv port and options port
+	// were specified, but since argv port is 8080, options port will be
+	// used instead.
+	options.port = argv.port === DEFAULT_PORT ? options.port || argv.port : argv.port;
+	if(options.port) {
+		startDevServer(wpOpt, options);
+		return;
+	}
+
+	portfinder.basePort = DEFAULT_PORT;
+	portfinder.getPort(function(err, port) {
+		if(err) throw err;
+		options.port = port;
+		startDevServer(wpOpt, options);
+	});
+}
+
+function startDevServer(wpOpt, options) {
 	var protocol = options.https ? "https" : "http";
 
 	// the formatted domain (url without path) of the webpack server

--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -297,10 +297,10 @@ function processOptions(wpOpt) {
 		options.open = true;
 
 	// Kind of weird, but ensures prior behavior isn't broken in cases
-	// that wouldn't throw errors. E.g. both argv port and options port
-	// were specified, but since argv port is 8080, options port will be
-	// used instead.
-	options.port = argv.port === DEFAULT_PORT ? options.port || argv.port : argv.port;
+	// that wouldn't throw errors. E.g. both argv.port and options.port
+	// were specified, but since argv.port is 8080, options.port will be
+	// tried first instead.
+	options.port = argv.port === DEFAULT_PORT ? (options.port || argv.port) : (argv.port || options.port);
 	if(options.port) {
 		startDevServer(wpOpt, options);
 		return;

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "express": "^4.13.3",
     "http-proxy-middleware": "~0.17.1",
     "opn": "4.0.2",
+    "portfinder": "^1.0.9",
     "serve-index": "^1.7.2",
     "sockjs": "0.3.18",
     "sockjs-client": "1.1.1",


### PR DESCRIPTION
Addresses #683.

**Please check if the PR fulfills these requirements**
- [ ] An example has been added or updated in `examples/` (for features)

I'm not sure about a new example - is there an easy way to verify that two webpack dev servers are running simultaneously at expected ports? *ETA: I imagine this could be tested via a SharedWorker or the localStorage polyfill that does the same thing - allowing two browser tabs to talk to one another. But a system-level test maybe would be better?*

- [ ] Docs have been added / updated (for bug fixes / features)

As for docs, if it's important to document the use of `portfinder` on the wiki I can do so as soon as the PR is merged.

**What kind of change does this PR introduce?**
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)

Because `portfinder` is async, `startDevServer` had to be spun out into a new function.

- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

### For details see #683

**Does this PR introduce a breaking change?**
- [X] Yes
- [X] No

Only in the sense that if two dev servers are run with no port config, one of them will now use a different port (and work). If someone *wanted* their server not to work before, now they might be out of luck! Probably not serious enough for a major version number, you know?

**Note:** There was one situation where a real breaking change could take place but it was [mitigated](https://github.com/webpack/webpack-dev-server/pull/685/commits/33dad8f8ecfd3655c96e76e004030284e2232e60#diff-83c4482ab4d62154c877147880243858R299).
