### PR TITLE
strip ANSI code before sending the message

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -82,15 +82,21 @@ var onSocketMsg = {
 	},
 	warnings: function(warnings) {
 		log("info", "[WDS] Warnings while compiling. Reload prevented.");
-		sendMsg("Warnings", warnings);
-		for(var i = 0; i < warnings.length; i++)
-			console.warn(stripAnsi(warnings[i]));
+		var strippedWarnings = warnings.map(function(warning) {
+			return stripAnsi(warning);
+		});
+		sendMsg("Warnings", strippedWarnings);
+		for(var i = 0; i < strippedWarnings.length; i++)
+			console.warn(strippedWarnings[i]);
 	},
 	errors: function(errors) {
 		log("info", "[WDS] Errors while compiling. Reload prevented.");
-		sendMsg("Errors", errors);
-		for(var i = 0; i < errors.length; i++)
-			console.error(stripAnsi(errors[i]));
+		var strippedErrors = errors.map(function(error) {
+			return stripAnsi(error);
+		});
+		sendMsg("Errors", strippedErrors);
+		for(var i = 0; i < strippedErrors.length; i++)
+			console.error(strippedErrors[i]);
 	},
 	close: function() {
 		log("error", "[WDS] Disconnected!");


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] An example has been added or updated in `examples/` (for features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?**
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

The data passed to `sendMsg` contains ANSI escape code, which is probably never used by the browser users.

**What is the new behavior?**

Those escape code are stripped.

**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the following... 

* Impact:
* Migration path for existing applications: 
* Github Issue(s) this is regarding:

Previous context in #481 

**Other information**:

I run the code with my demo and it worked. No further checking.