### PR TITLE
(fix) proxy config with bypass and without target

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -220,8 +220,8 @@ function Server(compiler, options) {
 						} else if(proxyMiddleware) {
 							return proxyMiddleware(req, res, next);
 						} else {
-                            next();
-                        }
+							next();
+						}
 					});
 				});
 			}

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -219,7 +219,9 @@ function Server(compiler, options) {
 							next();
 						} else if(proxyMiddleware) {
 							return proxyMiddleware(req, res, next);
-						}
+						} else {
+                            next();
+                        }
 					});
 				});
 			}


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bugfix.

**Did you add or update the `examples/`?**
No.

**Summary**
When there is a proxy configuration object which includes the bypass property but does not include the target property, the response is never sent back to the browser.
This is a regression from version 1.16.2.

**Does this PR introduce a breaking change?**
No.