### PR TITLE
Replace 0.0.0.0 with localhost on open

### DIFF
--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -434,7 +434,7 @@ function reportReadiness(uri, options) {
 	if(options.historyApiFallback)
 		console.log("404s will fallback to " + colorInfo(useColor, options.historyApiFallback.index || "/index.html"));
 	if(options.open)
-		open(uri);
+		open(uri.replace(/0\.0\.0\.0/, 'localhost'));
 }
 
 processOptions(wpOpt);

--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -434,7 +434,7 @@ function reportReadiness(uri, options) {
 	if(options.historyApiFallback)
 		console.log("404s will fallback to " + colorInfo(useColor, options.historyApiFallback.index || "/index.html"));
 	if(options.open)
-		open(uri.replace(/0\.0\.0\.0/, "localhost"));
+		open(uri.replace("0.0.0.0", "localhost"));
 }
 
 processOptions(wpOpt);

--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -434,7 +434,7 @@ function reportReadiness(uri, options) {
 	if(options.historyApiFallback)
 		console.log("404s will fallback to " + colorInfo(useColor, options.historyApiFallback.index || "/index.html"));
 	if(options.open)
-		open(uri.replace(/0\.0\.0\.0/, 'localhost'));
+		open(uri.replace(/0\.0\.0\.0/, "localhost"));
 }
 
 processOptions(wpOpt);


### PR DESCRIPTION
**Summary**
It's common to set `host: '0.0.0.0'` to enable access to the development server from the network, but that doesn't play well if `open: true` is set. 
Chrome displays an error instead of the application.

The fix is simple. Replace `0.0.0.0` with `localhost` before passing the URL to the browser. 

**Does this PR introduce a breaking change?**
No

**Other information**
See http://superuser.com/questions/846721/chrome-wont-access-http-0-0-0-04200.
