### PR TITLE
handling [enhancement] Trigger webpack devserver from console using 'rs' like nodemon #736

### DIFF
--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -8,8 +8,6 @@ const net = require("net");
 const url = require("url");
 const portfinder = require("portfinder");
 
-const _ = require("lodash");
-
 // Local version replaces global one
 try {
 	const localWebpackDevServer = require.resolve(path.join(process.cwd(), "node_modules", "webpack-dev-server", "bin", "webpack-dev-server.js"));
@@ -386,7 +384,7 @@ function startDevServer(wpOpt, options) {
 function liftDevServer(compiler, options, uri) {
 	let server;
 	try {
-		server = new Server(compiler, _.cloneDeep(options));
+		server = new Server(compiler, Object.assign({}, options));
 	} catch(e) {
 		const OptionsValidationError = require("../lib/OptionsValidationError");
 		if(e instanceof OptionsValidationError) {
@@ -477,7 +475,7 @@ function stopDevServer() {
 (function attachRSEventlistener() {
 	process.stdin.setEncoding("utf8");
 	process.stdin.on("data", function(data) {
- 		data = (data + "").trim().toLowerCase();
+		data = (data + "").trim().toLowerCase();
 		if(data === "rs") return reStartDevServer();
 	});
 })();

--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -453,6 +453,7 @@ processOptions(wpOpt);
 
 /**
  * Stop and start the devServer using the first passed args
+ * @returns {void}
  */
 function reStartDevServer() {
 	stopDevServer();
@@ -462,9 +463,10 @@ function reStartDevServer() {
 /**
  * Stop the devServer, mainly express server by calling
  * close() on http server
+ * @returns {void}
  */
 function stopDevServer() {
-	console.log('\n\t\u27F3 Restarting devServer..\n\t------------------------');
+	console.log("\n\t\u27F3 Restarting devServer..\n\t------------------------");
 	httpServerWrapper.close();
 }
 
@@ -473,9 +475,9 @@ function stopDevServer() {
  * and restart the devServer if so
  */
 (function attachRSEventlistener() {
-	process.stdin.setEncoding('utf8');
-	process.stdin.on('data', function (data) {
-    	data = (data + '').trim().toLowerCase();
-    	if (data === 'rs') return reStartDevServer();
-  	});
+	process.stdin.setEncoding("utf8");
+	process.stdin.on("data", function(data) {
+ 		data = (data + "").trim().toLowerCase();
+		if(data === "rs") return reStartDevServer();
+	});
 })();

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "connect-history-api-fallback": "^1.3.0",
     "express": "^4.13.3",
     "http-proxy-middleware": "~0.17.1",
+    "lodash": "^4.17.4",
     "opn": "4.0.2",
     "portfinder": "^1.0.9",
     "serve-index": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "connect-history-api-fallback": "^1.3.0",
     "express": "^4.13.3",
     "http-proxy-middleware": "~0.17.1",
-    "lodash": "^4.17.4",
     "opn": "4.0.2",
     "portfinder": "^1.0.9",
     "serve-index": "^1.7.2",


### PR DESCRIPTION
Handling [enhancement] Trigger webpack devServer from console using 'rs' like nodemon #736

Some logs:
[at-loader] Ok, 0.616 sec.
rs

	⟳ Restarting devServer..
	------------------------
Project is running at http://localhost:3000/
webpack output is served from /
Content not from webpack is served from /Users/deep/Code/my-starter/src

[at-loader] Checking started in a separate process...

[at-loader] Ok, 0.001 sec.
r
s
rs

	⟳ Restarting devServer..
	------------------------
Project is running at http://localhost:3000/
webpack output is served from /
Content not from webpack is served from /Users/deep/Code/my-starter/src

[at-loader] Checking started in a separate process...

[at-loader] Ok, 0 sec.