### PR TITLE
have --open use the --public path if it exists (version 1 fix)

### DIFF
--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -196,7 +196,7 @@ if(options.inline) {
 }
 
 new Server(webpack(wpOpt), options).listen(options.port, options.host, function(err) {
-	var uri = protocol + "://" + options.host + ":" + options.port + "/";
+	var uri = protocol + "://" + (options.public || (options.host + ":" + options.port)) + "/";
 	if(!options.inline)
 		uri += "webpack-dev-server/";
 


### PR DESCRIPTION
This changes the behavior of the --open flag to open the browser to the --public url if it is specified. (the default will be the same).

The original issue is #739 , though it will also address #725 by letting you specify localhost as the --public url.

This is not a breaking change.

This fixes the behavior for version 1. Master is fixed in #747 
