### PR TITLE
have --open use the options.public path if it exists

### DIFF
--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -330,14 +330,14 @@ function startDevServer(wpOpt, options) {
 	const protocol = options.https ? "https" : "http";
 
 	// the formatted domain (url without path) of the webpack server
-	const domain = url.format({
+	const domain = options.public ? `${protocol}://${options.public}` : url.format({
 		protocol: protocol,
 		hostname: options.host,
 		port: options.socket ? 0 : options.port.toString()
 	});
 
 	if(options.inline !== false) {
-		const devClient = [`${require.resolve("../client/")}?${options.public ? `${protocol}://${options.public}` : domain}`];
+		const devClient = [`${require.resolve("../client/")}?${domain}`];
 
 		if(options.hotOnly)
 			devClient.push("webpack/hot/only-dev-server");


### PR DESCRIPTION
This changes the behavior of the --open flag to open the browser to the --public url if it is specified. (the default will be the same).

The original issue is #739 , though it will also address #725 by letting you specify localhost as the --public url.

This is not a breaking change.

This is also addressed for version 1 with #746 