### PR TITLE
Implement error overlay

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -2,6 +2,7 @@
 var url = require("url");
 var stripAnsi = require("strip-ansi");
 var socket = require("./socket");
+var overlay = require("./overlay");
 
 function getCurrentScriptSource() {
 	// `document.currentScript` is the most accurate way to find the current script,
@@ -32,6 +33,7 @@ var hot = false;
 var initial = true;
 var currentHash = "";
 var logLevel = "info";
+var useOverlay = false;
 
 function log(level, msg) {
 	if(logLevel === "info" && level === "info")
@@ -71,8 +73,14 @@ var onSocketMsg = {
 	"log-level": function(level) {
 		logLevel = level;
 	},
+	"overlay": function(overlay) {
+		if(typeof document !== "undefined") {
+			useOverlay = overlay;
+		}
+	},
 	ok: function() {
 		sendMsg("Ok");
+		if(useOverlay) overlay.clear();
 		if(initial) return initial = false;
 		reloadApp();
 	},
@@ -99,6 +107,7 @@ var onSocketMsg = {
 		sendMsg("Errors", strippedErrors);
 		for(var i = 0; i < strippedErrors.length; i++)
 			console.error(strippedErrors[i]);
+		if(useOverlay) overlay.showErrors(errors);
 	},
 	close: function() {
 		log("error", "[WDS] Disconnected!");

--- a/client/overlay.js
+++ b/client/overlay.js
@@ -1,0 +1,126 @@
+// The error overlay is inspired (and mostly copied) from Create React App (https://github.com/facebookincubator/create-react-app)
+// They, in turn, got inspired by webpack-hot-middleware (https://github.com/glenjamin/webpack-hot-middleware).
+var ansiHTML = require("ansi-html");
+var Entities = require("html-entities").AllHtmlEntities;
+var entities = new Entities();
+
+var colors = {
+	reset: ["transparent", "transparent"],
+	black: "181818",
+	red: "E36049",
+	green: "B3CB74",
+	yellow: "FFD080",
+	blue: "7CAFC2",
+	magenta: "7FACCA",
+	cyan: "C3C2EF",
+	lightgrey: "EBE7E3",
+	darkgrey: "6D7891"
+};
+ansiHTML.setColors(colors);
+
+function createOverlayIframe(onIframeLoad) {
+	var iframe = document.createElement("iframe");
+	iframe.id = "webpack-dev-server-client-overlay";
+	iframe.src = "about:blank";
+	iframe.style.position = "fixed";
+	iframe.style.left = 0;
+	iframe.style.top = 0;
+	iframe.style.right = 0;
+	iframe.style.bottom = 0;
+	iframe.style.width = "100vw";
+	iframe.style.height = "100vh";
+	iframe.style.border = "none";
+	iframe.style.zIndex = 9999999999;
+	iframe.onload = onIframeLoad;
+	return iframe;
+}
+
+function addOverlayDivTo(iframe) {
+	var div = iframe.contentDocument.createElement("div");
+	div.id = "webpack-dev-server-client-overlay-div";
+	div.style.position = "fixed";
+	div.style.boxSizing = "border-box";
+	div.style.left = 0;
+	div.style.top = 0;
+	div.style.right = 0;
+	div.style.bottom = 0;
+	div.style.width = "100vw";
+	div.style.height = "100vh";
+	div.style.backgroundColor = "black";
+	div.style.color = "#E8E8E8";
+	div.style.fontFamily = "Menlo, Consolas, monospace";
+	div.style.fontSize = "large";
+	div.style.padding = "2rem";
+	div.style.lineHeight = "1.2";
+	div.style.whiteSpace = "pre-wrap";
+	div.style.overflow = "auto";
+	iframe.contentDocument.body.appendChild(div);
+	return div;
+}
+
+var overlayIframe = null;
+var overlayDiv = null;
+var lastOnOverlayDivReady = null;
+
+function ensureOverlayDivExists(onOverlayDivReady) {
+	if(overlayDiv) {
+	// Everything is ready, call the callback right away.
+		onOverlayDivReady(overlayDiv);
+		return;
+	}
+
+	// Creating an iframe may be asynchronous so we'll schedule the callback.
+	// In case of multiple calls, last callback wins.
+	lastOnOverlayDivReady = onOverlayDivReady;
+
+	if(overlayIframe) {
+		// We're already creating it.
+		return;
+	}
+
+	// Create iframe and, when it is ready, a div inside it.
+	overlayIframe = createOverlayIframe(function onIframeLoad() {
+		overlayDiv = addOverlayDivTo(overlayIframe);
+		// Now we can talk!
+		lastOnOverlayDivReady(overlayDiv);
+	});
+
+	// Zalgo alert: onIframeLoad() will be called either synchronously
+	// or asynchronously depending on the browser.
+	// We delay adding it so `overlayIframe` is set when `onIframeLoad` fires.
+	document.body.appendChild(overlayIframe);
+}
+
+function showErrorOverlay(message) {
+	ensureOverlayDivExists(function onOverlayDivReady(overlayDiv) {
+		// Make it look similar to our terminal.
+		overlayDiv.innerHTML =
+			"<span style=\"color: #" +
+			colors.red +
+			"\">Failed to compile.</span><br><br>" +
+			ansiHTML(entities.encode(message));
+	});
+}
+
+function destroyErrorOverlay() {
+	if(!overlayDiv) {
+		// It is not there in the first place.
+		return;
+	}
+
+	// Clean up and reset internal state.
+	document.body.removeChild(overlayIframe);
+	overlayDiv = null;
+	overlayIframe = null;
+	lastOnOverlayDivReady = null;
+}
+
+// Successful compilation.
+exports.clear = function handleSuccess() {
+	destroyErrorOverlay();
+}
+
+// Compilation with errors (e.g. syntax error or missing modules).
+exports.showErrors = function handleErrors(errors) {
+	showErrorOverlay(errors[0]);
+}

--- a/examples/overlay/README.md
+++ b/examples/overlay/README.md
@@ -1,0 +1,11 @@
+# Overlay
+
+```shell
+node ../../bin/webpack-dev-server.js --open
+```
+
+## What should happen
+
+The script should open the browser and show a heading with "Example: overlay".
+
+In `app.js`, make a syntax error. The page should now refresh and show a full screen error overlay that shows the syntax error.

--- a/examples/overlay/app.js
+++ b/examples/overlay/app.js
@@ -1,0 +1,4 @@
+document.write("It's working.");
+
+// This results in an error:
+// if(!window) require("test");

--- a/examples/overlay/index.html
+++ b/examples/overlay/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<script src="/bundle.js" type="text/javascript" charset="utf-8"></script>
+	</head>
+	<body>
+		<h1>Example: overlay</h1>
+	</body>
+</html>

--- a/examples/overlay/webpack.config.js
+++ b/examples/overlay/webpack.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+	context: __dirname,
+	entry: "./app.js",
+	devServer: {
+		overlay: true
+	}
+}

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -34,6 +34,7 @@ function Server(compiler, options) {
 	this.hot = options.hot || options.hotOnly;
 	this.headers = options.headers;
 	this.clientLogLevel = options.clientLogLevel;
+	this.clientOverlay = options.overlay;
 	this.sockets = [];
 	this.contentBaseWatchers = [];
 
@@ -399,6 +400,9 @@ Server.prototype.listen = function() {
 
 		if(this.clientLogLevel)
 			this.sockWrite([conn], "log-level", this.clientLogLevel);
+
+		if(this.clientOverlay)
+			this.sockWrite([conn], "overlay", this.clientOverlay);
 
 		if(this.hot) this.sockWrite([conn], "hot");
 

--- a/lib/optionsSchema.json
+++ b/lib/optionsSchema.json
@@ -60,6 +60,10 @@
         "error"
       ]
     },
+    "overlay": {
+      "description": "Shows an error overlay in browser.",
+      "type": "boolean"
+    },
     "key": {
       "description": "The contents of a SSL key.",
       "anyOf": [

--- a/package.json
+++ b/package.json
@@ -7,10 +7,12 @@
     "webpack": "^2.2.0"
   },
   "dependencies": {
+    "ansi-html": "0.0.7",
     "chokidar": "^1.6.0",
     "compression": "^1.5.2",
     "connect-history-api-fallback": "^1.3.0",
     "express": "^4.13.3",
+    "html-entities": "^1.2.0",
     "http-proxy-middleware": "~0.17.1",
     "opn": "4.0.2",
     "portfinder": "^1.0.9",
@@ -64,7 +66,7 @@
     "client-live": "webpack ./client/live.js client/live.bundle.js --color --config client/webpack.config.js -p",
     "client-index": "webpack ./client/index.js client/index.bundle.js --color --config client/webpack.config.js -p",
     "client-sockjs": "webpack ./client/sockjs.js client/sockjs.bundle.js --color --config client/webpack.sockjs.config.js -p",
-    "lint": "eslint bin lib test examples client/{index,live,socket,sockjs,webpack.config}.js",
+    "lint": "eslint bin lib test examples client/{index,live,socket,sockjs,overlay,webpack.config}.js",
     "beautify": "npm run lint -- --fix",
     "test": "mocha --full-trace --check-leaks",
     "posttest": "npm run -s lint",

--- a/test/Validation.test.js
+++ b/test/Validation.test.js
@@ -36,7 +36,7 @@ describe("Validation", function() {
 		message: [
 			" - configuration has an unknown property 'asdf'. These properties are valid:",
 			"   object { hot?, hotOnly?, lazy?, host?, filename?, publicPath?, port?, socket?, " +
-			"watchOptions?, headers?, clientLogLevel?, key?, cert?, ca?, pfx?, pfxPassphrase?, " +
+			"watchOptions?, headers?, clientLogLevel?, overlay?, key?, cert?, ca?, pfx?, pfxPassphrase?, " +
 			"inline?, public?, https?, contentBase?, watchContentBase?, open?, features?, " +
 			"compress?, proxy?, historyApiFallback?, staticOptions?, setup?, stats?, reporter?, " +
 			"noInfo?, quiet?, serverSideRender?, index?, log?, warn? }"


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Feature

**Did you add or update the `examples/`?**
Yes

**Summary**
This adds an error overlay in the browser, like create-react-app has. It works very much like create-react-app's error overlay. In fact, I copied much code from it 😅 .

I asked on Twitter if people would [like this feature](https://twitter.com/keeskluskens/status/825008478536228865), and ~~everyone forgot Trump for a while~~ people were happy.

The error overlay is only enabled when you add the option `overlay: true` in your `devServer` config. It could be enabled by default, but that would kinda be a breaking change so *maybe* in v3.

Furthermore, it will only show errors, not warnings. I'm not sure yet if we should display warnings the same way. If we would do that, there also needs to be a way to disable it.

**Does this PR introduce a breaking change?**
Nope