### PR TITLE
Allow a string to be passed as the `port` config option

### DIFF
--- a/lib/optionsSchema.json
+++ b/lib/optionsSchema.json
@@ -34,7 +34,14 @@
     },
     "port": {
       "description": "The port the server listens to.",
-      "type": "number"
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "string"
+        }
+      ]
     },
     "socket": {
       "description": "The Unix socket to listen to (instead of on a host).",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Bugfix

**Did you add or update the `examples/`?**
N/A

**Summary**
Since the new config validation, only integers are accepted for the `port` option. See #761.

**Does this PR introduce a breaking change?**
No

**Other information**
Fixes #761