### PR TITLE
Handle `opn` promise rejection

### DIFF
--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -434,8 +434,11 @@ function reportReadiness(uri, options) {
 		console.log(`Content not from webpack is served from ${colorInfo(useColor, contentBase)}`);
 	if(options.historyApiFallback)
 		console.log(`404s will fallback to ${colorInfo(useColor, options.historyApiFallback.index || "/index.html")}`);
-	if(options.open)
-		open(uri);
+	if(options.open) {
+		open(uri).catch(function() {
+			console.log("Unable to open browser. If you are running in a headless environment, please do not use the open flag.");
+		});
+	}
 }
 
 processOptions(wpOpt);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

bugfix

**Did you add or update the `examples/`?**

No

**Summary**
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

The dev server uses `opn` to open the browser, which returns a promise. In headless environments, this call will fail and the promise will be rejected. Since node v6.6.0, a `UnhandledPromiseRejectionWarning` will be output when a rejected promise has no handler.

This PR adds a `.catch` handler and outputs a user friendly message that the browser could not be opened, and not to use the open flag in headless environments.

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No

**Other information**

None