### PR TITLE
Export logic of adding entry points to webpack config

### DIFF
--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -5,8 +5,9 @@ const path = require("path");
 const open = require("opn");
 const fs = require("fs");
 const net = require("net");
-const url = require("url");
 const portfinder = require("portfinder");
+const addDevServerEntrypoints = require("../lib/util/addDevServerEntrypoints");
+const createDomain = require("../lib/util/createDomain");
 
 // Local version replaces global one
 try {
@@ -327,33 +328,7 @@ function processOptions(wpOpt) {
 }
 
 function startDevServer(wpOpt, options) {
-	const protocol = options.https ? "https" : "http";
-
-	// the formatted domain (url without path) of the webpack server
-	const domain = options.public ? `${protocol}://${options.public}` : url.format({
-		protocol: protocol,
-		hostname: options.host,
-		port: options.socket ? 0 : options.port.toString()
-	});
-
-	if(options.inline !== false) {
-		const devClient = [`${require.resolve("../client/")}?${domain}`];
-
-		if(options.hotOnly)
-			devClient.push("webpack/hot/only-dev-server");
-		else if(options.hot)
-			devClient.push("webpack/hot/dev-server");
-
-		[].concat(wpOpt).forEach(function(wpOpt) {
-			if(typeof wpOpt.entry === "object" && !Array.isArray(wpOpt.entry)) {
-				Object.keys(wpOpt.entry).forEach(function(key) {
-					wpOpt.entry[key] = devClient.concat(wpOpt.entry[key]);
-				});
-			} else {
-				wpOpt.entry = devClient.concat(wpOpt.entry);
-			}
-		});
-	}
+	addDevServerEntrypoints(wpOpt, options);
 
 	let compiler;
 	try {
@@ -372,7 +347,7 @@ function startDevServer(wpOpt, options) {
 		}));
 	}
 
-	const uri = domain + (options.inline !== false || options.lazy === true ? "/" : "/webpack-dev-server/");
+	const uri = createDomain(options) + (options.inline !== false || options.lazy === true ? "/" : "/webpack-dev-server/");
 
 	let server;
 	try {

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -490,4 +490,7 @@ Server.prototype.invalidate = function() {
 	if(this.middleware) this.middleware.invalidate();
 }
 
+// Export this logic, so that other implementations, like task-runners can use it
+Server.addDevServerEntrypoints = require("./util/addDevServerEntrypoints");
+
 module.exports = Server;

--- a/lib/util/addDevServerEntrypoints.js
+++ b/lib/util/addDevServerEntrypoints.js
@@ -1,0 +1,24 @@
+"use strict";
+const createDomain = require("./createDomain");
+
+module.exports = function addDevServerEntrypoints(webpackOptions, devServerOptions) {
+	if(devServerOptions.inline !== false) {
+		const domain = createDomain(devServerOptions);
+		const devClient = [`${require.resolve("../../client/")}?${domain}`];
+
+		if(devServerOptions.hotOnly)
+			devClient.push("webpack/hot/only-dev-server");
+		else if(devServerOptions.hot)
+			devClient.push("webpack/hot/dev-server");
+
+		[].concat(webpackOptions).forEach(function(wpOpt) {
+			if(typeof wpOpt.entry === "object" && !Array.isArray(wpOpt.entry)) {
+				Object.keys(wpOpt.entry).forEach(function(key) {
+					wpOpt.entry[key] = devClient.concat(wpOpt.entry[key]);
+				});
+			} else {
+				wpOpt.entry = devClient.concat(wpOpt.entry);
+			}
+		});
+	}
+};

--- a/lib/util/createDomain.js
+++ b/lib/util/createDomain.js
@@ -1,0 +1,13 @@
+"use strict";
+const url = require("url");
+
+module.exports = function createDomain(options) {
+	const protocol = options.https ? "https" : "http";
+
+	// the formatted domain (url without path) of the webpack server
+	return options.public ? `${protocol}://${options.public}` : url.format({
+		protocol: protocol,
+		hostname: options.host,
+		port: options.socket ? 0 : options.port.toString()
+	});
+};


### PR DESCRIPTION
**What kind of change does this PR introduce?**

This is a refactoring and adds a new feature.

**Did you add or update the `examples/`?**

No

**Summary**

It adds a new static method `addDevServerEntrypoints()` to the exports. This method could be reused in alternative implementations like the grunt plugin instead of[ copying the code](https://github.com/webpack-contrib/grunt-webpack/blob/master/tasks/webpack-dev-server.js#L43-L60).

**Does this PR introduce a breaking change?**

no

**Other information**
