### PR TITLE
feat - Allow overlay to be enabled for warnings (#789)

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -33,7 +33,8 @@ var hot = false;
 var initial = true;
 var currentHash = "";
 var logLevel = "info";
-var useOverlay = false;
+var useWarningOverlay = false;
+var useErrorOverlay = false;
 
 function log(level, msg) {
 	if(logLevel === "info" && level === "info")
@@ -75,12 +76,18 @@ var onSocketMsg = {
 	},
 	"overlay": function(overlay) {
 		if(typeof document !== "undefined") {
-			useOverlay = overlay;
+			if(typeof(overlay) === "boolean") {
+				useWarningOverlay = overlay;
+				useErrorOverlay = overlay;
+			} else if(overlay) {
+				useWarningOverlay = overlay.warnings;
+				useErrorOverlay = overlay.errors;
+			}
 		}
 	},
 	ok: function() {
 		sendMsg("Ok");
-		if(useOverlay) overlay.clear();
+		if(useWarningOverlay || useErrorOverlay) overlay.clear();
 		if(initial) return initial = false;
 		reloadApp();
 	},
@@ -96,6 +103,8 @@ var onSocketMsg = {
 		sendMsg("Warnings", strippedWarnings);
 		for(var i = 0; i < strippedWarnings.length; i++)
 			console.warn(strippedWarnings[i]);
+		if(useWarningOverlay) overlay.showMessage(warnings);
+
 		if(initial) return initial = false;
 		reloadApp();
 	},
@@ -107,7 +116,7 @@ var onSocketMsg = {
 		sendMsg("Errors", strippedErrors);
 		for(var i = 0; i < strippedErrors.length; i++)
 			console.error(strippedErrors[i]);
-		if(useOverlay) overlay.showErrors(errors);
+		if(useErrorOverlay) overlay.showMessage(errors);
 	},
 	close: function() {
 		log("error", "[WDS] Disconnected!");

--- a/client/overlay.js
+++ b/client/overlay.js
@@ -91,7 +91,7 @@ function ensureOverlayDivExists(onOverlayDivReady) {
 	document.body.appendChild(overlayIframe);
 }
 
-function showErrorOverlay(message) {
+function showMessageOverlay(message) {
 	ensureOverlayDivExists(function onOverlayDivReady(overlayDiv) {
 		// Make it look similar to our terminal.
 		overlayDiv.innerHTML =
@@ -121,6 +121,6 @@ exports.clear = function handleSuccess() {
 }
 
 // Compilation with errors (e.g. syntax error or missing modules).
-exports.showErrors = function handleErrors(errors) {
-	showErrorOverlay(errors[0]);
+exports.showMessage = function handleMessage(messages) {
+	showMessageOverlay(messages[0]);
 }

--- a/examples/overlay-warnings/README.md
+++ b/examples/overlay-warnings/README.md
@@ -1,0 +1,11 @@
+# Overlay
+
+```shell
+node ../../bin/webpack-dev-server.js --open
+```
+
+## What should happen
+
+The script should open the browser and show a heading with "Example: overlay with warnings".
+
+In `app.js`, make a syntax error. The page should now refresh and show a full screen error overlay that shows the syntax error.

--- a/examples/overlay-warnings/README.md
+++ b/examples/overlay-warnings/README.md
@@ -8,4 +8,4 @@ node ../../bin/webpack-dev-server.js --open
 
 The script should open the browser and show a heading with "Example: overlay with warnings".
 
-In `app.js`, make a syntax error. The page should now refresh and show a full screen error overlay that shows the syntax error.
+In `app.js`, uncomment the lines that should cause a warning to appear. The page should now refresh and show a full screen overlay that shows the warning.

--- a/examples/overlay-warnings/app.js
+++ b/examples/overlay-warnings/app.js
@@ -1,0 +1,8 @@
+document.write("It's working.");
+
+// This results in a warning:
+// require("./casesensitive.js");
+// require("./caseSensitive.js");
+
+// This results in an error:
+// if(!window) require("test");

--- a/examples/overlay-warnings/caseSensitive.js
+++ b/examples/overlay-warnings/caseSensitive.js
@@ -1,2 +1,2 @@
-console.log('case sensitive');
+console.log("case sensitive");
 

--- a/examples/overlay-warnings/caseSensitive.js
+++ b/examples/overlay-warnings/caseSensitive.js
@@ -1,0 +1,2 @@
+console.log('case sensitive');
+

--- a/examples/overlay-warnings/index.html
+++ b/examples/overlay-warnings/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<script src="/bundle.js" type="text/javascript" charset="utf-8"></script>
+	</head>
+	<body>
+		<h1>Example: overlay with warnings</h1>
+	</body>
+</html>

--- a/examples/overlay-warnings/webpack.config.js
+++ b/examples/overlay-warnings/webpack.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+	context: __dirname,
+	entry: "./app.js",
+	devServer: {
+		overlay: {
+			errors: true,
+			warnings: true
+		}
+	}
+}

--- a/lib/optionsSchema.json
+++ b/lib/optionsSchema.json
@@ -69,7 +69,22 @@
     },
     "overlay": {
       "description": "Shows an error overlay in browser.",
-      "type": "boolean"
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "errors": {
+              "type": "boolean"
+            },
+            "warnings": {
+              "type": "boolean"
+            }
+          }
+        }
+      ]
     },
     "key": {
       "description": "The contents of a SSL key.",


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Feature.

**Did you add or update the `examples/`?**

Yes.

**Summary**

Now you can use

```javascript
{
  overlay: {
    errors: true,
    warnings: true
  }
}
```

Closes #789.

**Does this PR introduce a breaking change?**

No.