### PR TITLE
Fix to share proxy option between proxy settings when the proxy option is a same object

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -159,7 +159,7 @@ function Server(compiler, options) {
 								target: options.proxy[context]
 							};
 						} else {
-							proxyOptions = options.proxy[context];
+							proxyOptions = Object.assign({}, options.proxy[context]);
 							proxyOptions.context = correctedContext;
 						}
 						proxyOptions.logLevel = proxyOptions.logLevel || "warn";

--- a/test/Proxy.test.js
+++ b/test/Proxy.test.js
@@ -144,4 +144,44 @@ describe("Proxy", function() {
 			.expect(200, "from proxy2", done);
 		});
 	});
+
+	context("sharing a proxy option", function() {
+		let server;
+		let req;
+		let listener;
+		const proxyTarget = {
+			target: "http://localhost:9000"
+		};
+
+		before(function(done) {
+			const proxy = express();
+			proxy.get("*", function(req, res) {
+				res.send("from proxy");
+			});
+			listener = proxy.listen(9000);
+			server = helper.start(config, {
+				contentBase,
+				proxy: {
+					"/proxy1": proxyTarget,
+					"/proxy2": proxyTarget,
+				}
+			}, done);
+			req = request(server.app);
+		});
+
+		after(function(done) {
+			helper.close(function() {
+				listener.close();
+				done();
+			});
+		});
+
+		it("respects proxy1 option", function(done) {
+			req.get("/proxy1").expect(200, "from proxy", done);
+		});
+
+		it("respects proxy2 option", function(done) {
+			req.get("/proxy2").expect(200, "from proxy", done);
+		});
+	});
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

a bugfix

**Did you add or update the `examples/`?**

No

**Summary**
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

Currently, `webpack-dev-server` mutates the proxy options, which is a cause of bug when the proxy options share a same option object.

For an instance, the following option creates different results after this PR.

* A proxy option

```js
const proxyTarget = {
    target: "http://localhost:9000"
};
proxy: {
    "/proxy1": proxyTarget,
    "/proxy2": proxyTarget,
}
```

* Before this PR

```
[ { target: 'http://localhost:9000',
    context: '/proxy2',
    logLevel: 'warn' },
  { target: 'http://localhost:9000',
    context: '/proxy2',
    logLevel: 'warn' } ]
```

* After this PR

```
[ { target: 'http://localhost:9000',
    context: '/proxy1',
    logLevel: 'warn' },
  { target: 'http://localhost:9000',
    context: '/proxy2',
    logLevel: 'warn' } ]
```

I think it should not override the `context` value.

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

Maybe not. it is a bug fix.

**Other information**
