### PR TITLE
Added beforeunload check to index.js (#544)

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -157,7 +157,15 @@ var socketUrl = url.format({
 
 socket(socketUrl, onSocketMsg);
 
+var isUnloading = false;
+self.addEventListener("beforeunload", function() {
+	isUnloading = true;
+});
+
 function reloadApp() {
+	if(isUnloading) {
+		return;
+	}
 	if(hot) {
 		log("info", "[WDS] App hot update...");
 		var hotEmitter = require("webpack/hot/emitter");


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bugfix
**Did you add or update the `examples/`?**
No
**Summary**
This fixes #544. In Firefox on Linux and Mac, with a slow proxied server (> 1s), when the page is refreshed (or the server refreshes is for a code change), the web socket reconnection timeout triggers, which causes the webpage to reload (again), causing a loop. This code adds a `beforeunload` event check, so that the reload doesn't happen if the page is already refreshing.
**Does this PR introduce a breaking change?**
I wouldn't not expect this to cause a BR break, but I'm not super familiar with webpack-dev-server's official API.
**Other information**
This is a naive implementation that just fixes the problem for my limited test case. For example, this would throw in browsers where `addEventListener` is undefined (this probably isn't a problem in 2017, but gives an idea of what I mean).

A test case which should pass with this pull can be found here: https://github.com/samsch/reload-loop-test-webpack-dev-server