### PR TITLE
Handle external upgrade for all websocket proxies

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -372,7 +372,7 @@ function Server(compiler, options) {
 	// https://github.com/chimurai/http-proxy-middleware#external-websocket-upgrade
 	websocketProxies.forEach(function(wsProxy) {
 		this.listeningApp.on("upgrade", wsProxy.upgrade);
-	});
+	}, this);
 }
 
 Server.prototype.use = function() {

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -127,6 +127,9 @@ function Server(compiler, options) {
 		contentBase = process.cwd();
 	}
 
+	// Keep track of websocket proxies for external websocket upgrade.
+	const websocketProxies = [];
+
 	const features = {
 		compress() {
 			if(options.compress) {
@@ -205,6 +208,9 @@ function Server(compiler, options) {
 					}
 
 					proxyMiddleware = getProxyMiddleware(proxyConfig);
+					if(proxyConfig.ws) {
+						websocketProxies.push(proxyMiddleware);
+					}
 
 					app.use((req, res, next) => {
 						if(typeof proxyConfigOrCallback === "function") {
@@ -361,6 +367,12 @@ function Server(compiler, options) {
 	} else {
 		this.listeningApp = http.createServer(app);
 	}
+
+	// Proxy websockets without the initial http request
+	// https://github.com/chimurai/http-proxy-middleware#external-websocket-upgrade
+	websocketProxies.forEach(function(wsProxy) {
+		this.listeningApp.on("upgrade", wsProxy.upgrade);
+	});
 }
 
 Server.prototype.use = function() {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "style-loader": "~0.13.0",
     "supertest": "^2.0.1",
     "url-loader": "~0.5.6",
-    "webpack": "^2.2.0"
+    "webpack": "^2.2.0",
+    "ws": "^1.1.1"
   },
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
This change upgrades websocket proxies so that an inital http request doesn't have to be made.
https://github.com/chimurai/http-proxy-middleware#external-websocket-upgrade

It supports a proposed change in Create React App by handling the upgrade of any websocket proxy passed in. facebookincubator/create-react-app#1790

I added a test to confirm the upgrade
