### PR TITLE
feat: Add a stub for WebpackDevServerPlugin (WIP)

### DIFF
--- a/examples/plugin/README.md
+++ b/examples/plugin/README.md
@@ -1,0 +1,21 @@
+# Plugin
+
+```shell
+node ../../bin/webpack-dev-server.js --open
+```
+
+```javascript
+const { WebpackDevServerPlugin } = require('webpack-dev-server');
+
+module.exports = {
+	plugins: [
+		new WebpackDevServerPlugin({
+			hot: true
+		})
+	]
+}
+```
+
+## What should happen
+
+It should inject `HotModuleReplacementPlugin` if the `hot` flag is set. Other options are passed normally as you might expect.

--- a/examples/plugin/app.js
+++ b/examples/plugin/app.js
@@ -1,0 +1,1 @@
+document.write("It's working.");

--- a/examples/plugin/index.html
+++ b/examples/plugin/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<script src="/bundle.js" type="text/javascript" charset="utf-8"></script>
+	</head>
+	<body>
+		<h1>Example: plugin</h1>
+	</body>
+</html>

--- a/examples/plugin/webpack.config.js
+++ b/examples/plugin/webpack.config.js
@@ -1,0 +1,11 @@
+const{ WebpackDevServerPlugin } = require("../../lib/Server");
+
+module.exports = {
+	context: __dirname,
+	entry: "./app.js",
+	plugins: [
+		new WebpackDevServerPlugin({
+			hot: true
+		})
+	]
+}

--- a/lib/Plugin.js
+++ b/lib/Plugin.js
@@ -1,0 +1,23 @@
+const webpack = require("webpack");
+const parseOptions = require("./parseOptions");
+
+class WebpackDevServerPlugin {
+	constructor(options) {
+		this.options = parseOptions(options);
+	}
+	apply(compiler) {
+		if(this.options.hot) {
+			const HotModuleReplacementPlugin = new webpack.HotModuleReplacementPlugin();
+
+			if(compiler.options.plugins) {
+				compiler.options.plugins.push(HotModuleReplacementPlugin);
+			} else {
+				compiler.options.plugins = [HotModuleReplacementPlugin];
+			}
+		}
+
+		compiler.options.devServer = this.options;
+	}
+}
+
+module.exports = WebpackDevServerPlugin;

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -12,24 +12,13 @@ const spdy = require("spdy");
 const httpProxyMiddleware = require("http-proxy-middleware");
 const serveIndex = require("serve-index");
 const historyApiFallback = require("connect-history-api-fallback");
-const webpack = require("webpack");
-const OptionsValidationError = require("./OptionsValidationError");
-const optionsSchema = require("./optionsSchema.json");
+const WebpackDevServerPlugin = require("./Plugin");
+const parseOptions = require("./parseOptions");
 
 const clientStats = { errorDetails: false };
 
 function Server(compiler, options) {
-	// Default options
-	if(!options) options = {};
-
-	const validationErrors = webpack.validateSchema(optionsSchema, options);
-	if(validationErrors.length) {
-		throw new OptionsValidationError(validationErrors);
-	}
-
-	if(options.lazy && !options.filename) {
-		throw new Error("'filename' option must be set in lazy mode.");
-	}
+	options = parseOptions(options);
 
 	this.hot = options.hot || options.hotOnly;
 	this.headers = options.headers;
@@ -491,3 +480,4 @@ Server.prototype.invalidate = function() {
 }
 
 module.exports = Server;
+module.exports.WebpackDevServerPlugin = WebpackDevServerPlugin;

--- a/lib/parseOptions.js
+++ b/lib/parseOptions.js
@@ -1,0 +1,21 @@
+const webpack = require("webpack");
+const OptionsValidationError = require("./OptionsValidationError");
+const optionsSchema = require("./optionsSchema.json");
+
+function parseOptions(options) {
+	// Default options
+	if(!options) options = {};
+
+	const validationErrors = webpack.validateSchema(optionsSchema, options);
+	if(validationErrors.length) {
+		throw new OptionsValidationError(validationErrors);
+	}
+
+	if(options.lazy && !options.filename) {
+		throw new Error("'filename' option must be set in lazy mode.");
+	}
+
+	return options;
+}
+
+module.exports = parseOptions;


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Feature.

**Did you add or update the `examples/`?**

Yes.

**Summary**

The idea is that this will replace `devServer` field eventually. Compared to `devServer` this can inject `HotModuleReplaceMentPlugin` making the UX consistent with `--hot`.

**Does this PR introduce a breaking change?**

No.

**Other information**

To work, the implementation has to be attached to the right hooks. The cli side might need some work as well. Any idea on that would be appreciated.