### PR TITLE
Update webpack-dev-server.js

### DIFF
--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -91,7 +91,7 @@ function processOptions(wpOpt) {
 
 	if(argv.port !== 8080 || !options.port)
 		options.port = argv.port;
-	
+
 	if(argv.disableHostCheck)
 		options.disableHostCheck = true;
 

--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -91,6 +91,9 @@ function processOptions(wpOpt) {
 
 	if(argv.port !== 8080 || !options.port)
 		options.port = argv.port;
+	
+	if(argv.disableHostCheck)
+		options.disableHostCheck = true;
 
 	if(!options.publicPath) {
 		options.publicPath = firstWpOpt.output && firstWpOpt.output.publicPath || "";


### PR DESCRIPTION
add disableHostCheck to argv

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
bugfix

**Did you add or update the `examples/`?**
No

**Summary**
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

In my package.json，I use webpack-dev-server as a develop server, and my page will be visited from telphones, and my ip often changes，so i use `--host 0.0.0.0`

```js
 "scripts": {
    "dev": "webpack-dev-server --devtool source-map --inline --hot --host 0.0.0.0"
  }
```

but in the new `1.16.4`, we should use `disableHostCheck`。But I found it not works

```js
 "scripts": {
    "dev": "webpack-dev-server --devtool source-map --inline --hot --host 0.0.0.0 --disableHostCheck"
  }
```

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No

**Other information**
