### PR TITLE
Use correct index when parsing publicHost

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -417,7 +417,7 @@ Server.prototype.checkHost = function(headers) {
 	// also allow public hostname if provided
 	if(typeof this.publicHost === "string") {
 		const idxPublic = this.publicHost.indexOf(":");
-		const publicHostname = idxPublic >= 0 ? this.publicHost.substr(0, idx) : this.publicHost;
+		const publicHostname = idxPublic >= 0 ? this.publicHost.substr(0, idxPublic) : this.publicHost;
 		if(hostname === publicHostname) return true;
 	}
 

--- a/test/Validation.test.js
+++ b/test/Validation.test.js
@@ -61,4 +61,59 @@ describe("Validation", function() {
 			throw new Error("Validation didn't fail");
 		})
 	});
+
+	describe("checkHost", function() {
+		it("should always allow any host if options.disableHostCheck is set", function() {
+			const options = {
+				public: "test.host:80",
+				disableHostCheck: true
+			};
+			const headers = {
+				host: "bad.host"
+			};
+			const server = new Server(compiler, options);
+			if(!server.checkHost(headers)) {
+				throw new Error("Validation didn't fail");
+			}
+		});
+
+		it("should allow any valid options.public when host is localhost", function() {
+			const options = {
+				public: "test.host:80"
+			};
+			const headers = {
+				host: "localhost"
+			};
+			const server = new Server(compiler, options);
+			if(!server.checkHost(headers)) {
+				throw new Error("Validation didn't fail");
+			}
+		});
+
+		it("should allow any valid options.public when host is 127.0.0.1", function() {
+			const options = {
+				public: "test.host:80"
+			};
+			const headers = {
+				host: "127.0.0.1"
+			};
+			const server = new Server(compiler, options);
+			if(!server.checkHost(headers)) {
+				throw new Error("Validation didn't fail");
+			}
+		});
+
+		it("should not allow hostnames that don't match options.public", function() {
+			const options = {
+				public: "test.host:80",
+			};
+			const headers = {
+				host: "test.hostname:80"
+			};
+			const server = new Server(compiler, options);
+			if(server.checkHost(headers)) {
+				throw new Error("Validation didn't fail");
+			}
+		});
+	})
 });


### PR DESCRIPTION
2.4.3 introduced checking of the host header and options for setting the public host however when parsing the publicHost it was still using the index of `:` from the host header hostname. This corrects that.