### PR TITLE
fix: disableHostCheck should be defaulted to true

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -35,7 +35,8 @@ function Server(compiler, options) {
 	this.headers = options.headers;
 	this.clientLogLevel = options.clientLogLevel;
 	this.clientOverlay = options.overlay;
-	this.disableHostCheck = !!options.disableHostCheck;
+	// TODO: Default this to false when the next major version is released
+	this.disableHostCheck = options.disableHostCheck === undefined ? true : !!options.disableHostCheck;
 	this.publicHost = options.public;
 	this.sockets = [];
 	this.contentBaseWatchers = [];

--- a/test/Compress.test.js
+++ b/test/Compress.test.js
@@ -10,7 +10,8 @@ describe("Compress", function() {
 
 	before(function(done) {
 		server = helper.start(config, {
-			compress: true
+			compress: true,
+			disableHostCheck: false,
 		}, done);
 		req = request(server.app);
 	});

--- a/test/ContentBase.test.js
+++ b/test/ContentBase.test.js
@@ -18,6 +18,7 @@ describe("ContentBase", function() {
 		before(function(done) {
 			server = helper.start(config, {
 				contentBase: contentBasePublic,
+				disableHostCheck: false,
 			}, done);
 			req = request(server.app);
 		});
@@ -37,6 +38,7 @@ describe("ContentBase", function() {
 		before(function(done) {
 			server = helper.start(config, {
 				contentBase: [contentBasePublic, contentBaseOther],
+				disableHostCheck: false,
 			}, done);
 			req = request(server.app);
 		});
@@ -56,6 +58,7 @@ describe("ContentBase", function() {
 		before(function(done) {
 			server = helper.start(config, {
 				contentBase: 9099999,
+				disableHostCheck: false,
 			}, done);
 			req = request(server.app);
 		});
@@ -71,6 +74,7 @@ describe("ContentBase", function() {
 		before(function(done) {
 			server = helper.start(config, {
 				contentBase: "http://example.com/",
+				disableHostCheck: false,
 			}, done);
 			req = request(server.app);
 		});
@@ -111,7 +115,8 @@ describe("ContentBase", function() {
 			this.sinon.stub(process, "cwd");
 			process.cwd.returns(contentBasePublic);
 			server = helper.start(config, {
-				contentBase: false
+				contentBase: false,
+				disableHostCheck: false,
 			}, done);
 			req = request(server.app);
 		});

--- a/test/HistoryApiFallback.test.js
+++ b/test/HistoryApiFallback.test.js
@@ -16,7 +16,8 @@ describe("HistoryApiFallback", function() {
 	describe("as boolean", function() {
 		before(function(done) {
 			server = helper.start(config, {
-				historyApiFallback: true
+				historyApiFallback: true,
+				disableHostCheck: false,
 			}, done);
 			req = request(server.app);
 		});
@@ -33,7 +34,8 @@ describe("HistoryApiFallback", function() {
 			server = helper.start(config, {
 				historyApiFallback: {
 					index: "/bar.html"
-				}
+				},
+				disableHostCheck: false,
 			}, done);
 			req = request(server.app);
 		});
@@ -51,7 +53,8 @@ describe("HistoryApiFallback", function() {
 				contentBase: path.join(__dirname, "fixtures/historyapifallback-2-config"),
 				historyApiFallback: {
 					index: "/bar.html"
-				}
+				},
+				disableHostCheck: false,
 			}, done);
 			req = request(server.app);
 		});
@@ -81,7 +84,8 @@ describe("HistoryApiFallback", function() {
 				contentBase: false,
 				historyApiFallback: {
 					index: "/bar.html"
-				}
+				},
+				disableHostCheck: false,
 			}, done);
 			req = request(server.app);
 		});
@@ -108,7 +112,8 @@ describe("HistoryApiFallback", function() {
 							to: "/bar.html"
 						}
 					]
-				}
+				},
+				disableHostCheck: false,
 			}, done);
 			req = request(server.app);
 		});
@@ -136,7 +141,8 @@ describe("HistoryApiFallback", function() {
 		before(function(done) {
 			server = helper.start(config3, {
 				contentBase: path.join(__dirname, "fixtures/historyapifallback-3-config"),
-				historyApiFallback: true
+				historyApiFallback: true,
+				disableHostCheck: false,
 			}, done);
 			req = request(server.app);
 		});

--- a/test/Lazy.test.js
+++ b/test/Lazy.test.js
@@ -10,7 +10,8 @@ describe("Lazy", function() {
 	it("without filename option it should throw an error", function() {
 		should.throws(function() {
 			helper.start(config, {
-				lazy: true
+				lazy: true,
+				disableHostCheck: false,
 			});
 		}, /'filename' option must be set/);
 	});
@@ -18,7 +19,8 @@ describe("Lazy", function() {
 	it("with filename option should not throw an error", function(done) {
 		helper.start(config, {
 			lazy: true,
-			filename: "bundle.js"
+			filename: "bundle.js",
+			disableHostCheck: false,
 		}, done);
 	});
 });

--- a/test/Proxy.test.js
+++ b/test/Proxy.test.js
@@ -73,6 +73,7 @@ describe("Proxy", function() {
 			server = helper.start(config, {
 				contentBase,
 				proxy: proxyOption,
+				disableHostCheck: false,
 			}, done);
 			req = request(server.app);
 		});
@@ -126,6 +127,7 @@ describe("Proxy", function() {
 			server = helper.start(config, {
 				contentBase,
 				proxy: proxyOptionOfArray,
+				disableHostCheck: false,
 			}, done);
 			req = request(server.app);
 		});
@@ -167,7 +169,8 @@ describe("Proxy", function() {
 				proxy: {
 					"/proxy1": proxyTarget,
 					"/proxy2": proxyTarget,
-				}
+				},
+				disableHostCheck: false,
 			}, done);
 			req = request(server.app);
 		});
@@ -200,7 +203,8 @@ describe("Proxy", function() {
 					context: "/",
 					target: "http://localhost:9003",
 					ws: true
-				}]
+				}],
+				disableHostCheck: false,
 			}, done);
 
 			wsServer = new WebSocketServer({ port: 9003 });

--- a/test/Routes.test.js
+++ b/test/Routes.test.js
@@ -15,7 +15,8 @@ describe("Routes", function() {
 
 	before(function(done) {
 		server = helper.start(config, {
-			headers: { "X-Foo": "1" }
+			headers: { "X-Foo": "1" },
+			disableHostCheck: false,
 		}, done);
 		req = request(server.app);
 	});


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Fixes a breaking change in 29578537c1ad38f29a445237c57a52c373183e75 by defaulting `disableHostCheck` to true.

**Did you add or update the `examples/`?**

No.

**Summary**

Previously `webpack-dev-server` would allow connections from any host 29578537c1ad38f29a445237c57a52c373183e75 fixed this.

However it introduced a breaking change by enabling this functionality
by default. 

Instead of breaking a current subset of users with this change, we should 
disable it by default until the next major release of `webpack-dev-server`.

See https://github.com/webpack/webpack-dev-server/issues/882#issuecomment-297088982.

**Does this PR introduce a breaking change?**

It introduces a breaking change for users dependent on `disableHostCheck` being false.

However this won't really prevent their servers from running, 
instead it just won't verify the `Host` header.

**What issues does this close?**

resolves #882