### PR TITLE
Allow passing multiple hosts to 'public'

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -414,11 +414,20 @@ Server.prototype.checkHost = function(headers) {
 	// allow hostname of listening adress
 	if(hostname === this.listenHostname) return true;
 
+	const hostIsPublicHost = host => {
+		const idxPublic = host.indexOf(":");
+		const publicHostname = idxPublic >= 0 ? host.substr(0, idxPublic) : host;
+		if(hostname === publicHostname) return true;
+	}
 	// also allow public hostname if provided
 	if(typeof this.publicHost === "string") {
-		const idxPublic = this.publicHost.indexOf(":");
-		const publicHostname = idxPublic >= 0 ? this.publicHost.substr(0, idxPublic) : this.publicHost;
-		if(hostname === publicHostname) return true;
+		if(hostIsPublicHost(this.publicHost)) return true;
+	}
+	// allow multiple public hostnames
+	if(Array.isArray(this.publicHost)) {
+		for(let hostIdx = 0; hostIdx < this.publicHost.length; hostIdx++) {
+			if(hostIsPublicHost(this.publicHost[hostIdx])) return true;
+		}
 	}
 
 	// disallow

--- a/lib/optionsSchema.json
+++ b/lib/optionsSchema.json
@@ -146,6 +146,10 @@
       "description": "The public hostname/ip address of the server.",
       "anyOf": [
         {
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1,
           "type": "array"
         },
         {

--- a/lib/optionsSchema.json
+++ b/lib/optionsSchema.json
@@ -144,7 +144,14 @@
     },
     "public": {
       "description": "The public hostname/ip address of the server.",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "array"
+        },
+        {
+          "type": "string"
+        }
+      ]
     },
     "https": {
       "description": "Enable HTTPS for server.",

--- a/test/Validation.test.js
+++ b/test/Validation.test.js
@@ -20,7 +20,13 @@ describe("Validation", function() {
 		name: "invalid `public` configuration",
 		config: { public: 1 },
 		message: [
-			" - configuration.public should be a string."
+			" - configuration.public should be one of these:",
+			"   [string] | string",
+			"   The public hostname/ip address of the server.",
+			"   Details:",
+			"    * configuration.public should be an array:",
+			"      [string]",
+			"    * configuration.public should be a string."
 		]
 	}, {
 		name: "invalid `contentBase` configuration",


### PR DESCRIPTION
**What kind of change does this PR introduce?**
bugfix

**Did you add or update the `examples/`?**
no

**Summary**
Host checking was added by default in v2.4.3 for security reasons. Users now have to specify the host/URL being used to access the dev-server [more info here](https://medium.com/webpack/webpack-dev-server-middleware-security-issues-1489d950874a) 

This PR allows users to specify multiple hosts that that will pass the check. This will fix [this person's issue](https://github.com/webpack/webpack-dev-server/issues/893#issuecomment-297941966)

**Does this PR introduce a breaking change?**
no
