### PR TITLE
Add 'allowedHosts' option

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -445,7 +445,19 @@ Server.prototype.checkHost = function(headers) {
 	if(hostname === "127.0.0.1" || hostname === "localhost") return true;
 
 	// allow if hostname is in allowedHosts
-	if(this.allowedHosts && this.allowedHosts.indexOf(hostname) >= 0) return true;
+	if(this.allowedHosts && this.allowedHosts.length) {
+		for(let hostIdx = 0; hostIdx < this.allowedHosts.length; hostIdx++) {
+			const allowedHost = this.allowedHosts[hostIdx];
+			if(allowedHost === hostname) return true;
+
+			// support "." as a subdomain wildcard
+			// e.g. ".example.com" will allow "example.com", "www.example.com", "subdomain.example.com", etc
+			if(allowedHost[0] === ".") {
+				if(hostname === allowedHost.substring(1)) return true; // "example.com"
+				if(hostname.endsWith(allowedHost)) return true; // "*.example.com"
+			}
+		}
+	}
 
 	// allow hostname of listening adress
 	if(hostname === this.listenHostname) return true;

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -40,6 +40,7 @@ function Server(compiler, options) {
 	this.clientOverlay = options.overlay;
 	this.disableHostCheck = !!options.disableHostCheck;
 	this.publicHost = options.public;
+	this.allowedHosts = options.allowedHosts;
 	this.sockets = [];
 	this.contentBaseWatchers = [];
 
@@ -442,6 +443,9 @@ Server.prototype.checkHost = function(headers) {
 
 	// always allow localhost host, for convience
 	if(hostname === "127.0.0.1" || hostname === "localhost") return true;
+
+	// allow if hostname is in allowedHosts
+	if(this.allowedHosts && this.allowedHosts.indexOf(hostname) >= 0) return true;
 
 	// allow hostname of listening adress
 	if(hostname === this.listenHostname) return true;

--- a/lib/optionsSchema.json
+++ b/lib/optionsSchema.json
@@ -17,6 +17,13 @@
       "description": "The host the server listens to.",
       "type": "string"
     },
+    "allowedHosts": {
+      "description": "Specifies which hosts are allowed to access the dev server.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
     "filename": {
       "description": "The filename that needs to be requested in order to trigger a recompile (only in lazy mode).",
       "anyOf": [

--- a/test/Validation.test.js
+++ b/test/Validation.test.js
@@ -123,5 +123,43 @@ describe("Validation", function() {
 				throw new Error("Validation didn't fail");
 			}
 		});
+
+		describe("allowedHosts", function() {
+			it("should allow hosts in allowedHosts", function() {
+				const testHosts = [
+					"test.host",
+					"test2.host",
+					"test3.host"
+				];
+				const options = { allowedHosts: testHosts };
+				const server = new Server(compiler, options);
+
+				testHosts.forEach(function(testHost) {
+					const headers = { host: testHost };
+					if(!server.checkHost(headers)) {
+						throw new Error("Validation didn't fail");
+					}
+				});
+			});
+			it("should allow hosts that pass a wildcard in allowedHosts", function() {
+				const options = { allowedHosts: [".example.com"] };
+				const server = new Server(compiler, options);
+				const testHosts = [
+					"www.example.com",
+					"subdomain.example.com",
+					"example.com",
+					"subsubcomain.subdomain.example.com",
+					"example.com:80",
+					"subdomain.example.com:80"
+				];
+
+				testHosts.forEach(function(testHost) {
+					const headers = { host: testHost };
+					if(!server.checkHost(headers)) {
+						throw new Error("Validation didn't fail");
+					}
+				});
+			});
+		});
 	})
 });

--- a/test/Validation.test.js
+++ b/test/Validation.test.js
@@ -23,6 +23,14 @@ describe("Validation", function() {
 			" - configuration.public should be a string."
 		]
 	}, {
+		name: "invalid `allowedHosts` configuration",
+		config: { allowedHosts: 1 },
+		message: [
+			" - configuration.allowedHosts should be an array:",
+			"   [string]",
+			"   Specifies which hosts are allowed to access the dev server."
+		]
+	}, {
 		name: "invalid `contentBase` configuration",
 		config: { contentBase: [0] },
 		message: [
@@ -40,7 +48,7 @@ describe("Validation", function() {
 		config: { asdf: true },
 		message: [
 			" - configuration has an unknown property 'asdf'. These properties are valid:",
-			"   object { hot?, hotOnly?, lazy?, host?, filename?, publicPath?, port?, socket?, " +
+			"   object { hot?, hotOnly?, lazy?, host?, allowedHosts?, filename?, publicPath?, port?, socket?, " +
 			"watchOptions?, headers?, clientLogLevel?, overlay?, key?, cert?, ca?, pfx?, pfxPassphrase?, " +
 			"inline?, disableHostCheck?, public?, https?, contentBase?, watchContentBase?, open?, features?, " +
 			"compress?, proxy?, historyApiFallback?, staticOptions?, setup?, stats?, reporter?, " +


### PR DESCRIPTION
**What kind of change does this PR introduce?**
feature/bugfix

**Did you add or update the `examples/`?**
no

**Summary**
Host checking was added by default in v2.4.3 for security reasons. Users now have to specify the host/URL being used to access the dev-server [more info here](https://medium.com/webpack/webpack-dev-server-middleware-security-issues-1489d950874a) 

This PR allows users to specify multiple hosts that that will pass the check. Recommended by @edmorley here: https://github.com/webpack/webpack-dev-server/issues/882#issuecomment-296799201

**Does this PR introduce a breaking change?**
no

**Example usage in webpack config:**

```js
devServer: {
    allowedHosts: [
        'exampleHost.com',
        'differentExampleHost.com',
        ...
    ]
}
```

**subdomain wildcard:**

mimicking django's `ALLOWED_HOSTS`, a value beginning with "." can be used as a subdomain wildcard. '.example.com' will match example.com, www.example.com, and any other subdomain of example.com.

```js
devServer: {
    allowedHosts: [
        '.example.com'
    ]
}
```
