### PR TITLE
Extracted client logging to its own module.

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -3,6 +3,7 @@ var url = require("url");
 var stripAnsi = require("strip-ansi");
 var socket = require("./socket");
 var overlay = require("./overlay");
+var log = require("./log");
 
 function getCurrentScriptSource() {
 	// `document.currentScript` is the most accurate way to find the current script,
@@ -32,18 +33,8 @@ if(typeof __resourceQuery === "string" && __resourceQuery) {
 var hot = false;
 var initial = true;
 var currentHash = "";
-var logLevel = "info";
 var useWarningOverlay = false;
 var useErrorOverlay = false;
-
-function log(level, msg) {
-	if(logLevel === "info" && level === "info")
-		return console.log(msg);
-	if(["info", "warning"].indexOf(logLevel) >= 0 && level === "warning")
-		return console.warn(msg);
-	if(["info", "warning", "error"].indexOf(logLevel) >= 0 && level === "error")
-		return console.error(msg);
-}
 
 // Send messages to the outside, so plugins can consume it.
 function sendMsg(type, data) {
@@ -73,7 +64,7 @@ var onSocketMsg = {
 		sendMsg("StillOk");
 	},
 	"log-level": function(level) {
-		logLevel = level;
+		log.setLogLevel(level);
 	},
 	"overlay": function(overlay) {
 		if(typeof document !== "undefined") {

--- a/client/log.js
+++ b/client/log.js
@@ -1,0 +1,14 @@
+var logLevel = "info";
+
+module.exports = function(level, msg) {
+	if(logLevel === "info" && level === "info")
+		return console.log(msg);
+	if(["info", "warning"].indexOf(logLevel) >= 0 && level === "warning")
+		return console.warn(msg);
+	if(["info", "warning", "error"].indexOf(logLevel) >= 0 && level === "error")
+		return console.error(msg);
+};
+
+module.exports.setLogLevel = function(level) {
+	logLevel = level;
+};

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "client-live": "webpack ./client/live.js client/live.bundle.js --color --config client/webpack.config.js -p",
     "client-index": "webpack ./client/index.js client/index.bundle.js --color --config client/webpack.config.js -p",
     "client-sockjs": "webpack ./client/sockjs.js client/sockjs.bundle.js --color --config client/webpack.sockjs.config.js -p",
-    "lint": "eslint bin lib test examples client/{index,live,socket,sockjs,overlay,webpack.config}.js",
+    "lint": "eslint bin lib test examples client/{index,live,socket,sockjs,overlay,webpack.config,log}.js",
     "beautify": "npm run lint -- --fix",
     "test": "mocha --full-trace --check-leaks",
     "posttest": "npm run -s lint",


### PR DESCRIPTION
This pull request opens the path to fixing the HMR logging issue described below.

**What kind of change does this PR introduce?**
This is basically refactoring.

**Did you add or update the `examples/`?**
Not needed.

**Summary**
There is a long standing issue with the HMR logging in the browser console, which cannot be turned off. This is because the modules in `webpack/hot` (`dev-server.js`, `only-dev-server.js`, `log-apply-result.js`) use `console.log()` and `console.warn()` directly, without any possibility to turn them off. This is especially annoying while trying to debug using `console.log()`, and getting your debug messages mixed with unrelated HMR messages. There are a few open issues about this, listed below, with some hackish workarounds.

To solve this once and for all, we should have an option to turn off HMR logging based on the desired log level. For this we can use the `clientLogLevel` option added in https://github.com/webpack/webpack-dev-server/pull/579. But because the HMR modules don't have acces to `webpack-dev-server/client/index.js`'s scope, where the `clientLogLevel` is defined, we have two options:
- globally export `clientLogLevel` (or the logging function `log()`) from `webpack-dev-server/client/index.js`, and use it inside the `webpack/hot` modules, or
- extract the logging code into its own module `webpack-dev-server/client/log.js`, and require it inside the `webpack/hot` modules, which I've used here.

As for the `webpack/hot` modules, instead of just having `console.log("[HMR] some message here")`, we will have something like
```
var log;

// is there a more elegant way of checking if a module exists?
var context = require.context("webpack-dev-server/client", false, /\.\/log$/);
if(context.keys().length > 0) {
  log = context("./log");
} else {
  log = function(level, msg) {
    var levels = {
      error: "error",
      info: "log",
      warning: "warn"
    };
    console[levels[level]](msg);
}
...
log("info", "[HMR] some message here");
...
log("warning", "[HMR] some warning here");
...
```
(also see the proof of concept PR here: https://github.com/webpack/webpack/pull/4960)

**Related issues list**:
Option to console.log only important stuff https://github.com/webpack/webpack-dev-server/issues/109
An option to mute console logging for hot module replacement
 https://github.com/webpack/webpack/issues/415
cannot mute webpack/hot/dev-server console.logs https://github.com/webpack/webpack/issues/4115
How to quiet the console.log outputs? https://github.com/gaearon/react-hot-loader/issues/79

**Does this PR introduce a breaking change?**
There's no breaking change, as far as I can see.
