### PR TITLE
Strongly check client isn't running on WebWorker for sendMsg

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -1,4 +1,4 @@
-/* global __resourceQuery */
+/* global __resourceQuery WorkerGlobalScope */
 var url = require("url");
 var stripAnsi = require("strip-ansi");
 var socket = require("./socket");
@@ -47,7 +47,11 @@ function log(level, msg) {
 
 // Send messages to the outside, so plugins can consume it.
 function sendMsg(type, data) {
-	if(typeof self !== "undefined" && self.window) {
+	if(
+		typeof self !== "undefined" &&
+		(typeof WorkerGlobalScope === "undefined" ||
+		!(self instanceof WorkerGlobalScope))
+	) {
 		self.postMessage({
 			type: "webpack" + type,
 			data: data


### PR DESCRIPTION
**What kind of change does this PR introduce?** bugfix

**Summary**

Fix #745 again.

For some reason I've defined `self.window` in WebWorker, so #813 still doesn't fixed for me.