### PR TITLE
ISSUE 947 - plugins defined with webpack 3 _modules Set in a develope…

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Tobias Koppers @sokra",
   "description": "Serves a webpack app. Updates the browser on changes.",
   "peerDependencies": {
-    "webpack": "^2.2.0"
+    "webpack": "^3.0.0"
   },
   "dependencies": {
     "ansi-html": "0.0.7",
@@ -47,7 +47,7 @@
     "style-loader": "~0.13.0",
     "supertest": "^2.0.1",
     "url-loader": "~0.5.6",
-    "webpack": "^2.2.0",
+    "webpack": "^3.0.0",
     "ws": "^1.1.1"
   },
   "license": "MIT",


### PR DESCRIPTION
Plugins defined with webpack 3 `Chunk._modules` Set in a developer's parent project explode when run via webpack-dev-server, as dev-server actually starts and runs a webpack instance via its own dependency, which is currently 2.x . Bumping dependency to 3.x fixes this compatibility issue, and should be backwards compatible as the old `modules` array is deprecated gracefully.

**What kind of change does this PR introduce?**
Bug fix https://github.com/webpack/webpack-dev-server/issues/947
 
**Did you add or update the `examples/`?**
N/A

**Summary**
Fixes https://github.com/webpack/webpack-dev-server/issues/947

An upgrade to webpack 3 in own project broke webpack-dev-server controlled builds, breaking our workflow

```
CommonsChunkPlugin.js:289
for(const module of chunk.modulesIterable) {
^
TypeError: Cannot read property 'Symbol(Symbol.iterator)' of undefined
```

**Does this PR introduce a breaking change?**
Potentially due to peer dependency being bumped to a major version of webpack, may require its own major version altering to suit. Will let maintainers be the judge of that

**Other information**
