### PR TITLE
Make webpack-dev-server npm compatible with webpack@3.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Tobias Koppers @sokra",
   "description": "Serves a webpack app. Updates the browser on changes.",
   "peerDependencies": {
-    "webpack": "^2.2.0"
+    "webpack": ">=2.2.0"
   },
   "dependencies": {
     "ansi-html": "0.0.7",
@@ -47,7 +47,7 @@
     "style-loader": "~0.13.0",
     "supertest": "^2.0.1",
     "url-loader": "~0.5.6",
-    "webpack": "^2.2.0",
+    "webpack": ">=2.2.0",
     "ws": "^1.1.1"
   },
   "license": "MIT",


### PR DESCRIPTION
Currently `webpack-dev-server` requires webpack@^2.2.0 as a dev / peer dependency. This allows anything greater or equal to 2.2.0 instead.

**What kind of change does this PR introduce?**
Version fix for npm compatibility.

**Did you add or update the `examples/`?**
No, seems unnecessary.

**Summary**
Currently, npm throws messages about webpack-dev-server not supporting webpack@3.x.x. This updates the version range to support webpack 2 or beyond.

**Does this PR introduce a breaking change?**
To my knowledge, no it does not.