### PR TITLE
include `subjectAltName` field in self-signed cert

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -386,7 +386,52 @@ function Server(compiler, options) {
         const pems = selfsigned.generate(attrs, {
           algorithm: 'sha256',
           days: 30,
-          keySize: 2048
+          keySize: 2048,
+          extensions: [{
+            name: 'basicConstraints',
+            cA: true
+          }, {
+            name: 'keyUsage',
+            keyCertSign: true,
+            digitalSignature: true,
+            nonRepudiation: true,
+            keyEncipherment: true,
+            dataEncipherment: true
+          }, {
+            name: 'subjectAltName',
+            altNames: [
+              {
+                // type 2 is DNS
+                type: 2,
+                value: 'localhost'
+              },
+              {
+                type: 2,
+                value: 'localhost.localdomain'
+              },
+              {
+                type: 2,
+                value: 'lvh.me'
+              },
+              {
+                type: 2,
+                value: '*.lvh.me'
+              },
+              {
+                type: 2,
+                value: '[::1]'
+              },
+              {
+                // type 7 is IP
+                type: 7,
+                ip: '127.0.0.1'
+              },
+              {
+                type: 7,
+                ip: 'fe80::1'
+              }
+            ]
+          }]
         });
 
         fs.writeFileSync(certPath, pems.private + pems.cert, { encoding: 'utf-8' });


### PR DESCRIPTION
fixes issue with reconnect on Chrome 58+
#941

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
#941 
