### PR TITLE
Fully mute output info if quiet is set to true

### DIFF
--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -440,6 +440,8 @@ function startDevServer(wpOpt, options) {
 
 function reportReadiness(uri, options) {
 	const useColor = argv.color;
+	const contentBase = Array.isArray(options.contentBase) ? options.contentBase.join(", ") : options.contentBase;
+
 	if(!options.quiet) {
 		let startSentence = `Project is running at ${colorInfo(useColor, uri)}`
 		if(options.socket) {
@@ -448,19 +450,21 @@ function reportReadiness(uri, options) {
 		console.log((argv["progress"] ? "\n" : "") + startSentence);
 
 		console.log(`webpack output is served from ${colorInfo(useColor, options.publicPath)}`);
+
+		if(contentBase)
+			console.log(`Content not from webpack is served from ${colorInfo(useColor, contentBase)}`);
+
+		if(options.historyApiFallback)
+			console.log(`404s will fallback to ${colorInfo(useColor, options.historyApiFallback.index || "/index.html")}`);
+
+		if(options.bonjour)
+			console.log("Broadcasting \"http\" with subtype of \"webpack\" via ZeroConf DNS (Bonjour)");
 	}
-	const contentBase = Array.isArray(options.contentBase) ? options.contentBase.join(", ") : options.contentBase;
-	if(contentBase)
-		console.log(`Content not from webpack is served from ${colorInfo(useColor, contentBase)}`);
-	if(options.historyApiFallback)
-		console.log(`404s will fallback to ${colorInfo(useColor, options.historyApiFallback.index || "/index.html")}`);
 	if(options.open) {
 		open(uri + options.openPage).catch(function() {
 			console.log("Unable to open browser. If you are running in a headless environment, please do not use the open flag.");
 		});
 	}
-	if(options.bonjour)
-		console.log("Broadcasting \"http\" with subtype of \"webpack\" via ZeroConf DNS (Bonjour)");
 }
 
 function broadcastZeroconf(options) {


### PR DESCRIPTION
This fully mutes all startup messages if quiet is set.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
This follows #970 and fully mutes all startup messages if quiet is set instead of just half.

**Did you add or update the `examples/`?**
No

**Summary**
Fully mutes all messages following https://github.com/webpack/webpack/issues/1191 and #970.
This fixes issues on our build runners where stdout was outputted from the build even with `quiet` set.

**Does this PR introduce a breaking change?**
No

**Other information**
