### PR TITLE
Always allow requests with IP-address as host in checkHost()

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -7,6 +7,7 @@ const express = require("express");
 const fs = require("fs");
 const http = require("http");
 const httpProxyMiddleware = require("http-proxy-middleware");
+const ip = require("ip");
 const serveIndex = require("serve-index");
 const historyApiFallback = require("connect-history-api-fallback");
 const path = require("path");
@@ -441,11 +442,11 @@ Server.prototype.checkHost = function(headers) {
 	const idx = hostHeader.indexOf(":");
 	const hostname = idx >= 0 ? hostHeader.substr(0, idx) : hostHeader;
 
-	// always allow localhost host, for convience
-	if(hostname === "127.0.0.1" || hostname === "localhost") return true;
-
 	// always allow requests with explicit IP-address
-	if(/^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.|$)){4}$/.test(hostname)) return true;
+	if(ip.isV4Format(hostname)) return true;
+
+	// always allow localhost host, for convience
+	if(hostname === "localhost") return true;
 
 	// allow if hostname is in allowedHosts
 	if(this.allowedHosts && this.allowedHosts.length) {

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -444,6 +444,9 @@ Server.prototype.checkHost = function(headers) {
 	// always allow localhost host, for convience
 	if(hostname === "127.0.0.1" || hostname === "localhost") return true;
 
+	// always allow requests with explicit IP-address
+	if(/^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.|$)){4}$/.test(hostname)) return true;
+
 	// allow if hostname is in allowedHosts
 	if(this.allowedHosts && this.allowedHosts.length) {
 		for(let hostIdx = 0; hostIdx < this.allowedHosts.length; hostIdx++) {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "html-entities": "^1.2.0",
     "http-proxy-middleware": "~0.17.4",
     "internal-ip": "^1.2.0",
+    "ip": "^1.1.5",
     "loglevel": "^1.4.1",
     "opn": "4.0.2",
     "portfinder": "^1.0.9",

--- a/test/Validation.test.js
+++ b/test/Validation.test.js
@@ -111,6 +111,17 @@ describe("Validation", function() {
 			}
 		});
 
+		it("should allow access for every requests using an IP", function() {
+			const options = {};
+			const headers = {
+				host: "192.168.1.123"
+			};
+			const server = new Server(compiler, options);
+			if(!server.checkHost(headers)) {
+				throw new Error("Validation didn't fail");
+			}
+		});
+
 		it("should not allow hostnames that don't match options.public", function() {
 			const options = {
 				public: "test.host:80",


### PR DESCRIPTION
**What kind of change does this PR introduce?**

enhancement

**Did you add or update the `examples/`?**

no.

**Summary**

This patch will allow any requests made using an IP-address to always pass the
checkHost-test.

IP-addresses are not susceptible to a dns-rebind like attack so it would make
sense to not block them to make local-network development possible without
needing to disable the host-checks entirely.


**Does this PR introduce a breaking change?**

no

**Other information**

fixes #931