### PR TITLE
add --allowed-hosts CLI option

### DIFF
--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -204,6 +204,11 @@ yargs.options({
 		default: "localhost",
 		describe: "The hostname/ip address the server will bind to",
 		group: CONNECTION_GROUP
+	},
+	"allowed-hosts": {
+		type: "string",
+		describe: "A comma-delimited string of hosts that are allowed to access the dev server",
+		group: CONNECTION_GROUP
 	}
 });
 
@@ -232,6 +237,9 @@ function processOptions(wpOpt) {
 
 	if(argv.host !== "localhost" || !options.host)
 		options.host = argv.host;
+
+	if(argv["allowed-hosts"])
+		options.allowedHosts = argv["allowed-hosts"].split(",");
 
 	if(argv.public)
 		options.public = argv.public;


### PR DESCRIPTION
**What kind of change does this PR introduce?**
feature

**Did you add or update the `examples/`?**
no

**Summary**
adds the ability to set the [allowedHosts option](https://github.com/webpack/webpack-dev-server/pull/899) via the CLI

**Does this PR introduce a breaking change?**
no

**Usage**
I'm not sure what the best practice is for passing a list as a command line option. I opted for a comma delimited string. E.G.
```
webpack-dev-server --entry /entry/file --output-path /output/path --allowed-hosts host1.com,.host2.com
```

creates the option
```
allowedHosts: [
    'host1.com',
    '.host2.com'
] 
```

Please let me know if there is a better way to do this.