### PR TITLE
Add requestCert support to the server

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -360,7 +360,8 @@ function Server(compiler, options) {
 				cert: options.cert,
 				ca: options.ca,
 				pfx: options.pfx,
-				passphrase: options.pfxPassphrase
+				passphrase: options.pfxPassphrase,
+				requestCert: options.requestCert || false
 			};
 		}
 

--- a/lib/optionsSchema.json
+++ b/lib/optionsSchema.json
@@ -145,6 +145,10 @@
       "description": "The passphrase to a (SSL) PFX file.",
       "type": "string"
     },
+    "requestCert": {
+      "description": "Enables request for client certificate.",
+      "type": "boolean"
+    },
     "inline": {
       "description": "Enable inline mode to include client scripts in bundle (CLI-only).",
       "type": "boolean"

--- a/test/Validation.test.js
+++ b/test/Validation.test.js
@@ -49,7 +49,7 @@ describe("Validation", function() {
 		message: [
 			" - configuration has an unknown property 'asdf'. These properties are valid:",
 			"   object { hot?, hotOnly?, lazy?, bonjour?, host?, allowedHosts?, filename?, publicPath?, port?, socket?, " +
-			"watchOptions?, headers?, clientLogLevel?, overlay?, key?, cert?, ca?, pfx?, pfxPassphrase?, " +
+			"watchOptions?, headers?, clientLogLevel?, overlay?, key?, cert?, ca?, pfx?, pfxPassphrase?, requestCert?, " +
 			"inline?, disableHostCheck?, public?, https?, contentBase?, watchContentBase?, open?, useLocalIp?, openPage?, features?, " +
 			"compress?, proxy?, historyApiFallback?, staticOptions?, setup?, stats?, reporter?, " +
 			"noInfo?, quiet?, serverSideRender?, index?, log?, warn? }"


### PR DESCRIPTION
Add this configuration flag to request a client's certificate for 2-way PKI authentication.
Issue #1011

The motivation for this feature proposal is to allow create-react-app to enable the instance of webpack-dev-server to request the client certificate for 2-way PKI auth.

The issue actually doesn't lie in webpack-dev-server itself (configuration is much easier when using webpack-dev-server by itself), but rather that create-react-app only sends a boolean to webpack-dev-server. Here is the line I am referencing: https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/config/webpackDevServer.config.js#L81

From what I can tell, this means that the configuration options for webpack-dev-server are limited to the key, cert, ca, and passphrase when using create-react-app. Minimizing configuration seems to be create-react-app's goal (which I totally understand) but a feature like this would be nice to have in development.

I simply just added the requestCert field to the configuration if webpack-dev-server receives https as a boolean rather than an object. Defaults to false if it is no specified.
