### PR TITLE
No longer generating ssl cert when one is already specified

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -366,37 +366,40 @@ function Server(compiler, options) {
 			};
 		}
 
-		// Use a self-signed certificate if no certificate was configured.
-		// Cycle certs every 24 hours
-		const certPath = path.join(__dirname, "../ssl/server.pem");
-		let certExists = fs.existsSync(certPath);
+		let fakeCert;
+		if (!options.https.key || !options.https.cert) {
+			// Use a self-signed certificate if no certificate was configured.
+			// Cycle certs every 24 hours
+			const certPath = path.join(__dirname, "../ssl/server.pem");
+			let certExists = fs.existsSync(certPath);
 
-		if(certExists) {
-			const certStat = fs.statSync(certPath);
-			const certTtl = 1000 * 60 * 60 * 24;
-			const now = new Date();
+			if(certExists) {
+				const certStat = fs.statSync(certPath);
+				const certTtl = 1000 * 60 * 60 * 24;
+				const now = new Date();
 
-			// cert is more than 30 days old, kill it with fire
-			if((now - certStat.ctime) / certTtl > 30) {
-				console.log("SSL Certificate is more than 30 days old. Removing.");
-				del.sync([certPath], { force: true });
-				certExists = false;
+				// cert is more than 30 days old, kill it with fire
+				if((now - certStat.ctime) / certTtl > 30) {
+					console.log("SSL Certificate is more than 30 days old. Removing.");
+					del.sync([certPath], { force: true });
+					certExists = false;
+				}
 			}
+
+			if(!certExists) {
+				console.log("Generating SSL Certificate");
+				const attrs = [{ name: "commonName", value: "localhost" }];
+				const pems = selfsigned.generate(attrs, {
+					algorithm: "sha256",
+					days: 30,
+					keySize: 2048
+				});
+
+				fs.writeFileSync(certPath, pems.private + pems.cert, { encoding: "utf-8" });
+			}
+			fakeCert = fs.readFileSync(certPath);
 		}
 
-		if(!certExists) {
-			console.log("Generating SSL Certificate");
-			const attrs = [{ name: "commonName", value: "localhost" }];
-			const pems = selfsigned.generate(attrs, {
-				algorithm: "sha256",
-				days: 30,
-				keySize: 2048
-			});
-
-			fs.writeFileSync(certPath, pems.private + pems.cert, { encoding: "utf-8" });
-		}
-
-		const fakeCert = fs.readFileSync(certPath);
 		options.https.key = options.https.key || fakeCert;
 		options.https.cert = options.https.cert || fakeCert;
 

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -367,7 +367,7 @@ function Server(compiler, options) {
 		}
 
 		let fakeCert;
-		if (!options.https.key || !options.https.cert) {
+		if(!options.https.key || !options.https.cert) {
 			// Use a self-signed certificate if no certificate was configured.
 			// Cycle certs every 24 hours
 			const certPath = path.join(__dirname, "../ssl/server.pem");


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Small startup time optimization

**Did you add or update the `examples/`?**

**Summary**
Skip the generation of a self signed SSL cert if an existing cert is already specified in the https options. The self signed SSL cert never gets used if you specify a cert in the options anyway, so theres not much point generating it in this case

**Does this PR introduce a breaking change?**
No 

**Other information**
