### PR TITLE
explicit hot when hotOnly in options.

### DIFF
--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -261,8 +261,13 @@ function processOptions(wpOpt) {
 	if(!options.hot)
 		options.hot = argv["hot"];
 
-	if(!options.hotOnly)
+	if(!options.hotOnly) {
 		options.hotOnly = argv["hot-only"];
+		// if hotOnly is true, explicitly set `hot` true.
+		if(options.hotOnly) {
+			options.hot = true;
+		}
+	}
 
 	if(!options.clientLogLevel)
 		options.clientLogLevel = argv["client-log-level"];


### PR DESCRIPTION
## PR for issue #877 

### What kind of change does this PR introduce?
bugfix / refactor confusing behaviour

### Did you add or update the examples/?
No.

### Summary

When `hot-only` option is supplied, the `hot` option also needs to be set to true for the `hot-only` option to work as intended which for some users, creates confusion. 

This PR removes the need to turn both `hot` AND `hot-only` on for devServer, when specifying hot-only as it sets hot to true internally for the user.  

### Does this PR introduce a breaking change?
No.

### Other information
cc- @shellscape, were we looking for something like this ?