### PR TITLE
Add subjectAltName to self-signed certificate for https

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -386,7 +386,17 @@ function Server(compiler, options) {
 
 		if(!certExists) {
 			console.log("Generating SSL Certificate");
-			const attrs = [{ name: "commonName", value: "localhost" }];
+			const attrs = [
+				{ name: "commonName", value: "localhost" },
+				{
+					name: "subjectAltName",
+					value: {
+						altNames: [
+							{ type: 6, value: "localhost" }
+						]
+					}
+				}
+			];
 			const pems = selfsigned.generate(attrs, {
 				algorithm: "sha256",
 				days: 30,


### PR DESCRIPTION
This fixes #854 and #906 by adding a subjectAltName matching
the commonName for the self-signed cert.

I've been using `webpack-dev-server` with Rails 5 and it's been quite frustrating to have to manually click "proceed" when using Chrome, even after trusting the self-signed cert.

This PR adds the requisite subjectAltName to the self-signed cert so that Chrome no longer displays the error message described at https://github.com/webpack/webpack-dev-server/issues/854 and https://github.com/webpack/webpack-dev-server/issues/906

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
Simply adds a config option to the self-signed cert.

**Did you add or update the `examples/`?**
No, but tested using the https example.

**Summary**
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
Using webpack-dev-server for Rails 5 development and repeatedly having to visit the server manually in Chrome before I can continue development.

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No.

**Other information**
This PR shouldn't have any side-effects, other than fixing https in Chrome.