### PR TITLE
Include the listening port number in the server object

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -484,6 +484,7 @@ Server.prototype.checkHost = function(headers) {
 
 // delegate listen call and init sockjs
 Server.prototype.listen = function(port, hostname) {
+	this.listenPort = port;
 	this.listenHostname = hostname;
 	const returnValue = this.listeningApp.listen.apply(this.listeningApp, arguments);
 	const sockServer = sockjs.createServer({


### PR DESCRIPTION
**What kind of change does this PR introduce?**
feature

**Did you add or update the `examples/`?**
no

**Summary**
Exposes the listening port number in the server object. 
Implements request in #998.

**Does this PR introduce a breaking change?**
No
