### PR TITLE
Addresses #998 to properly assign a random port and access the port assigned

### DIFF
--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -360,6 +360,7 @@ function processOptions(wpOpt) {
 	// were specified, but since argv.port is 8080, options.port will be
 	// tried first instead.
 	options.port = argv.port === DEFAULT_PORT ? defaultTo(options.port, argv.port) : defaultTo(argv.port, options.port);
+
 	if(options.port != null) {
 		startDevServer(wpOpt, options);
 		return;
@@ -393,7 +394,7 @@ function startDevServer(wpOpt, options) {
 		}));
 	}
 
-	const uri = createDomain(options) + (options.inline !== false || options.lazy === true ? "/" : "/webpack-dev-server/");
+	const suffix = (options.inline !== false || options.lazy === true ? "/" : "/webpack-dev-server/");
 
 	let server;
 	try {
@@ -437,6 +438,8 @@ function startDevServer(wpOpt, options) {
 			const READ_WRITE = 438; // chmod 666 (rw rw rw)
 			fs.chmod(options.socket, READ_WRITE, function(err) {
 				if(err) throw err;
+
+				const uri = createDomain(options, server.listeningApp) + suffix;
 				reportReadiness(uri, options);
 			});
 		});
@@ -444,6 +447,8 @@ function startDevServer(wpOpt, options) {
 		server.listen(options.port, options.host, function(err) {
 			if(err) throw err;
 			if(options.bonjour) broadcastZeroconf(options);
+
+			const uri = createDomain(options, server.listeningApp) + suffix;
 			reportReadiness(uri, options);
 		});
 	}

--- a/lib/util/createDomain.js
+++ b/lib/util/createDomain.js
@@ -2,13 +2,13 @@
 const url = require("url");
 const internalIp = require("internal-ip");
 
-module.exports = function createDomain(options) {
+module.exports = function createDomain(options, listeningApp) {
 	const protocol = options.https ? "https" : "http";
 
 	// the formatted domain (url without path) of the webpack server
 	return options.public ? `${protocol}://${options.public}` : url.format({
 		protocol: protocol,
 		hostname: options.useLocalIp ? internalIp.v4() : options.host,
-		port: options.socket ? 0 : options.port.toString()
+		port: options.socket ? 0 : (listeningApp ? listeningApp.address().port : 0)
 	});
 };


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Feature and Fix

**Did you add or update the `examples/`?**
No need

**Summary**
#998 requested the use of random ports and the ability to access the assigned random port. 

**Does this PR introduce a breaking change?**
It introduces a corrective change. This PR also corrects the port reported by the CLI when a random port is assigned.

**Other information**

To access the port assigned [you may go off of this example](https://github.com/webpack/webpack-dev-server/blob/random-port-access/bin/webpack-dev-server.js#L436), or the following sample code:

```js
const Server = require("webpack-dev-server/lib/Server");
conast server = new Server(compiler, options);

server.listen(0, '127.0.0.1', () => {
  const port = server.listeningApp.address().port;
});
```