### PR TITLE
Fix Broken Socket on Client for Custom/Random Port Numbers

### DIFF
--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -3,6 +3,7 @@
 'use strict';
 
 /* eslint global-require: off, import/order: off, no-console: off */
+require('../lib/polyfills');
 
 const fs = require('fs');
 const net = require('net');

--- a/client/index.js
+++ b/client/index.js
@@ -33,6 +33,10 @@ if (typeof __resourceQuery === 'string' && __resourceQuery) {
   urlParts = url.parse((scriptHost || '/'), false, true);
 }
 
+if (!urlParts.port || urlParts.port === '0') {
+  urlParts.port = self.location.port;
+}
+
 let hot = false;
 let initial = true;
 let currentHash = '';
@@ -176,7 +180,7 @@ const socketUrl = url.format({
   protocol,
   auth: urlParts.auth,
   hostname,
-  port: (urlParts.port === '0') ? self.location.port : urlParts.port,
+  port: urlParts.port,
   pathname: urlParts.path == null || urlParts.path === '/' ? '/sockjs-node' : urlParts.path
 });
 

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -1,6 +1,7 @@
 'use strict';
 
 /* eslint no-console: off, func-names: off */
+require('./polyfills');
 
 const fs = require('fs');
 const http = require('http');
@@ -21,8 +22,6 @@ const webpack = require('webpack');
 const webpackDevMiddleware = require('webpack-dev-middleware');
 const OptionsValidationError = require('./OptionsValidationError');
 const optionsSchema = require('./optionsSchema.json');
-
-require('./polyfills');
 
 const clientStats = { errorDetails: false };
 
@@ -483,49 +482,58 @@ Server.prototype.checkHost = function (headers) {
 };
 
 // delegate listen call and init sockjs
-Server.prototype.listen = function (port, hostname) {
+Server.prototype.listen = function (port, hostname, fn) {
   this.listenHostname = hostname;
   // eslint-disable-next-line
-  const returnValue = this.listeningApp.listen.apply(this.listeningApp, arguments);
-  const sockServer = sockjs.createServer({
-    // Use provided up-to-date sockjs-client
-    sockjs_url: '/__webpack_dev_server__/sockjs.bundle.js',
-    // Limit useless logs
-    log(severity, line) {
-      if (severity === 'error') {
-        console.log(line);
-      }
-    }
-  });
-  sockServer.on('connection', (conn) => {
-    if (!conn) return;
-    if (!this.checkHost(conn.headers)) {
-      this.sockWrite([conn], 'error', 'Invalid Host header');
-      conn.close();
-      return;
-    }
-    this.sockets.push(conn);
 
-    conn.on('close', () => {
-      const connIndex = this.sockets.indexOf(conn);
-      if (connIndex >= 0) {
-        this.sockets.splice(connIndex, 1);
+  const returnValue = this.listeningApp.listen(port, hostname, (err) => {
+    const sockServer = sockjs.createServer({
+      // Use provided up-to-date sockjs-client
+      sockjs_url: '/__webpack_dev_server__/sockjs.bundle.js',
+      // Limit useless logs
+      log(severity, line) {
+        if (severity === 'error') {
+          console.log(line);
+        }
       }
     });
 
-    if (this.clientLogLevel) { this.sockWrite([conn], 'log-level', this.clientLogLevel); }
+    sockServer.on('connection', (conn) => {
+      console.log('connection.remotePort', conn.remotePort);
+      if (!conn) return;
+      if (!this.checkHost(conn.headers)) {
+        this.sockWrite([conn], 'error', 'Invalid Host header');
+        conn.close();
+        return;
+      }
+      this.sockets.push(conn);
 
-    if (this.clientOverlay) { this.sockWrite([conn], 'overlay', this.clientOverlay); }
+      conn.on('close', () => {
+        const connIndex = this.sockets.indexOf(conn);
+        if (connIndex >= 0) {
+          this.sockets.splice(connIndex, 1);
+        }
+      });
 
-    if (this.hot) this.sockWrite([conn], 'hot');
+      if (this.clientLogLevel) { this.sockWrite([conn], 'log-level', this.clientLogLevel); }
 
-    if (!this._stats) return;
-    this._sendStats([conn], this._stats.toJson(clientStats), true);
+      if (this.clientOverlay) { this.sockWrite([conn], 'overlay', this.clientOverlay); }
+
+      if (this.hot) this.sockWrite([conn], 'hot');
+
+      if (!this._stats) return;
+      this._sendStats([conn], this._stats.toJson(clientStats), true);
+    });
+
+    sockServer.installHandlers(this.listeningApp, {
+      prefix: '/sockjs-node'
+    });
+
+    if (fn) {
+      fn.call(this.listeningApp, err);
+    }
   });
 
-  sockServer.installHandlers(this.listeningApp, {
-    prefix: '/sockjs-node'
-  });
   return returnValue;
 };
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bugfix

**Did you add or update the `examples/`?**
No need

**Summary**
#1059 exposed a situation in which the sockjs url for clients with custom/random ports would result in the client using an erroneous url that either omitted the port or used the wrong (default 8080) port. This resulted in socket communication breaking, which was noticed by way of the lack of an overlay being displayed.

This fix does the following:

1. in `Server.js` the socket server won't be initialized nor started until the `listeningApp` triggers the callback on `listen`. That's really the proper time for the socket server to be initialized anyhow. polyfills dep is also moved to the top to match `bin/webpack-dev-server.js`.
2. in `client/index.js` the port parsing is going to look for `null` and `'0'` on `urlParts.port` and that'll be refactored slightly.
3. in `bin/webpack-dev-server.js` the polyfills dep is added to the top of the file preventing `internal-ip` errors on Node 4.x.

**Does this PR introduce a breaking change?**
Negatory

**Other information**
