### PR TITLE
Fixes issue #1064 by switching to a named logger

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -5,7 +5,7 @@
 
 const url = require('url');
 const stripAnsi = require('strip-ansi');
-const log = require('loglevel');
+const log = require('loglevel').getLogger('webpack-dev-server');
 const socket = require('./socket');
 const overlay = require('./overlay');
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
bugfix

**Did you add or update the `examples/`?**
no

**Summary**
This solves issue #1064 
So far, the client JS of webpack-dev-server used the root logger and also changed the configuration of the root logger. This results in webpack overwriting the application's logging configuration.
The PR switches to a named logger, as suggested in the issue description.

**Does this PR introduce a breaking change?**
I don't think it could break an app.

However, if an application uses loglevel and expects webpack-dev-server to configure the root logger, it might have an different log level than expected. 
The solution for the app would be to call [loglevel's `setLevel `or `setDefaultLevel`](https://github.com/pimterry/loglevel#documentation) (which is how you should do it anyway).