### PR TITLE
Get the port from the options object

### DIFF
--- a/lib/util/createDomain.js
+++ b/lib/util/createDomain.js
@@ -6,7 +6,7 @@ const internalIp = require('internal-ip');
 
 module.exports = function createDomain(options, listeningApp) {
   const protocol = options.https ? 'https' : 'http';
-  const appPort = listeningApp ? listeningApp.address().port : 0;
+  const appPort = listeningApp ? listeningApp.address().port : options.port.toString();
   const port = options.socket ? 0 : appPort;
   const hostname = options.useLocalIp ? internalIp.v4() : options.host;
 


### PR DESCRIPTION

**What kind of change does this PR introduce?**
bugfix

**Did you add or update the `examples/`?**
No

**Summary**
When listeningApp is not supplied, use the port from the options object. I think this functionally was broken by PR:  https://github.com/webpack/webpack-dev-server/pull/1054/files#diff-07cfeb70272594b38ac9139434c94502

**Does this PR introduce a breaking change?**
No

**Other information**
