### PR TITLE
Fix Promise version of webpack config

### DIFF
--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -344,7 +344,7 @@ function processOptions(webpackOptions) {
   options.port = argv.port === DEFAULT_PORT ? defaultTo(options.port, argv.port) : defaultTo(argv.port, options.port);
 
   if (options.port != null) {
-    startDevServer(wpOpt, options);
+    startDevServer(webpackOptions, options);
     return;
   }
 
@@ -352,7 +352,7 @@ function processOptions(webpackOptions) {
   portfinder.getPort((err, port) => {
     if (err) throw err;
     options.port = port;
-    startDevServer(wpOpt, options);
+    startDevServer(webpackOptions, options);
   });
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
When using a Promise as the webpack config the dev server version 2.8.1 doesn't startup due to using the Promise inside of StartDevServer instead of the resolved webpack config.

**Did you add or update the `examples/`?**
No

**Summary**
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
Server doesn't work when using a Promise as the webpack config.

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
