### PR TITLE
Fix check for webpack/hot/log when setting HMR log level

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -92,8 +92,7 @@ const onSocketMsg = {
   },
   'log-level': function logLevel(level) {
     const hotCtx = require.context('webpack/hot', false, /^\.\/log$/);
-    const contextKeys = hotCtx.keys();
-    if (contextKeys.length && contextKeys['./log']) {
+    if (hotCtx.keys().indexOf('./log') !== -1) {
       hotCtx('./log').setLogLevel(level);
     }
     switch (level) {


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bugfix.

**Did you add or update the `examples/`?**
Not needed.

**Summary**
Some time ago I authored [PR #926](https://github.com/webpack/webpack-dev-server/pull/926). Which, strangely enough, caused [issue #1049](https://github.com/webpack/webpack-dev-server/issues/1049).

The original code was
```js
  var hotCtx = require.context("webpack/hot", false, /^\.\/log$/);
  if(hotCtx.keys().length > 0) {
    hotCtx("./log").setLogLevel(level);
  }
```
Somehow I was under the impression that `hotCtx.keys()` can only return `[]` or `["./log"]`, and with this assumption, the check `hotCtx.keys().length > 0` is correct. For some strange reason, as per issue #1049, it returned `["../package.json", "./console", "./formatters"]`, which doesn't match the regex at all, so I don't really know what happened there. In this case, of course, the check becomes wrong.

Now, this is the fix for #1049 in [PR #1050](https://github.com/webpack/webpack-dev-server/pull/1050)
```js
  if(hotCtx.keys().length > 0) {
    var contextKeys = hotCtx.keys();
    if(contextKeys.length && contextKeys["./log"]) {
      ...
```
which doesn't work, because `contextKeys` is an array, so `contextKeys["./log"]` will always be `false`.

So the correct check would be `if (hotCtx.keys().indexOf('./log') !== -1) { ...`.

**Does this PR introduce a breaking change?**
No.
