### PR TITLE
Make error overlay translucent

### DIFF
--- a/client/overlay.js
+++ b/client/overlay.js
@@ -50,7 +50,7 @@ function addOverlayDivTo(iframe) {
   div.style.bottom = 0;
   div.style.width = '100vw';
   div.style.height = '100vh';
-  div.style.backgroundColor = 'black';
+  div.style.backgroundColor = 'rgba(0, 0, 0, 0.85)';
   div.style.color = '#E8E8E8';
   div.style.fontFamily = 'Menlo, Consolas, monospace';
   div.style.fontSize = 'large';


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Error overlay translucence.

**Did you add or update the `examples/`?**
Not needed.

**Summary**
Being used to `webpack-hot-middleware`'s error overlay, which has an [alpha of 0.85](https://github.com/glenjamin/webpack-hot-middleware/blob/master/client-overlay.js#L6), it is a bit misleading when getting a completely opaque overlay. This change makes the error overlay's background the same as `webpack-hot-middleware`'s.

**Does this PR introduce a breaking change?**
No.
