### PR TITLE
Fix quotes

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -103,9 +103,8 @@ function Server(compiler, options) {
 
   app.get('/webpack-dev-server', (req, res) => {
     res.setHeader('Content-Type', 'text/html');
-    /* eslint-disable quotes */
     res.write('<!DOCTYPE html><html><head><meta charset="utf-8"/></head><body>');
-    const outputPath = this.middleware.getFilenameFromUrl(options.publicPath || "/");
+    const outputPath = this.middleware.getFilenameFromUrl(options.publicPath || '/');
     const filesystem = this.middleware.fileSystem;
 
     function writeDirectory(baseUrl, basePath) {
@@ -141,7 +140,6 @@ function Server(compiler, options) {
       });
       res.write('</ul>');
     }
-    /* eslint-enable quotes */
     writeDirectory(options.publicPath || '/', outputPath);
     res.end('</body></html>');
   });
@@ -624,13 +622,11 @@ Server.prototype.serveMagicHtml = function (req, res, next) {
   try {
     if (!this.middleware.fileSystem.statSync(this.middleware.getFilenameFromUrl(`${_path}.js`)).isFile()) { return next(); }
     // Serve a page that executes the javascript
-    /* eslint-disable quotes */
     res.write('<!DOCTYPE html><html><head><meta charset="utf-8"/></head><body><script type="text/javascript" charset="utf-8" src="');
     res.write(_path);
     res.write('.js');
-    res.write(req._parsedUrl.search || "");
+    res.write(req._parsedUrl.search || '');
     res.end('"></script></body></html>');
-    /* eslint-enable quotes */
   } catch (e) {
     return next();
   }

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -110,7 +110,7 @@ function Server(compiler, options) {
 
     function writeDirectory(baseUrl, basePath) {
       const content = filesystem.readdirSync(basePath);
-      res.write("<ul>");
+      res.write('<ul>');
       content.forEach((item) => {
         const p = `${basePath}/${item}`;
         if (filesystem.statSync(p).isFile()) {
@@ -139,7 +139,7 @@ function Server(compiler, options) {
           res.write('</li>');
         }
       });
-      res.write("</ul>");
+      res.write('</ul>');
     }
     /* eslint-enable quotes */
     writeDirectory(options.publicPath || '/', outputPath);


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Quotes fix.

**Did you add or update the `examples/`?**
Not needed.

**Summary**
Double quotes in `Server.js` made eslint fail (strangely enough, only in node 4 and 6).

**Does this PR introduce a breaking change?**
No.
