### PR TITLE
Remove header property value validation

### DIFF
--- a/lib/optionsSchema.json
+++ b/lib/optionsSchema.json
@@ -64,9 +64,6 @@
     },
     "headers": {
       "description": "Response headers that are added to each response.",
-      "additionalProperties": {
-        "type": "string"
-      },
       "type": "object"
     },
     "clientLogLevel": {

--- a/test/Routes.test.js
+++ b/test/Routes.test.js
@@ -13,53 +13,81 @@ describe('Routes', () => {
   let server;
   let req;
 
-  before((done) => {
-    server = helper.start(config, {
-      headers: { 'X-Foo': '1' }
-    }, done);
-    req = request(server.app);
+  describe('without headers', () => {
+    before((done) => {
+      server = helper.start(config, {}, done);
+      req = request(server.app);
+    });
+
+    after(helper.close);
+
+    it('GET request to inline bundle', (done) => {
+      req.get('/webpack-dev-server.js')
+        .expect('Content-Type', 'application/javascript')
+        .expect(200, done);
+    });
+
+    it('GET request to live bundle', (done) => {
+      req.get('/__webpack_dev_server__/live.bundle.js')
+        .expect('Content-Type', 'application/javascript')
+        .expect(200, done);
+    });
+
+    it('GET request to sockjs bundle', (done) => {
+      req.get('/__webpack_dev_server__/sockjs.bundle.js')
+        .expect('Content-Type', 'application/javascript')
+        .expect(200, done);
+    });
+
+    it('GET request to live html', (done) => {
+      req.get('/webpack-dev-server/')
+        .expect('Content-Type', 'text/html')
+        .expect(200, /__webpack_dev_server__/, done);
+    });
+
+    it('GET request to directory index', (done) => {
+      req.get('/webpack-dev-server')
+        .expect('Content-Type', 'text/html')
+        .expect(200, directoryIndex.trim(), done);
+    });
+
+    it('GET request to magic html', (done) => {
+      req.get('/bundle')
+        .expect(200, magicHtml.trim(), done);
+    });
   });
 
-  after(helper.close);
+  describe('headers as a string', () => {
+    before((done) => {
+      server = helper.start(config, {
+        headers: { 'X-Foo': '1' }
+      }, done);
+      req = request(server.app);
+    });
 
-  it('GET request to inline bundle', (done) => {
-    req.get('/webpack-dev-server.js')
-      .expect('Content-Type', 'application/javascript')
-      .expect(200, done);
+    after(helper.close);
+
+    it('GET request with headers', (done) => {
+      req.get('/bundle')
+        .expect('X-Foo', '1')
+        .expect(200, done);
+    });
   });
 
-  it('GET request to live bundle', (done) => {
-    req.get('/__webpack_dev_server__/live.bundle.js')
-      .expect('Content-Type', 'application/javascript')
-      .expect(200, done);
-  });
+  describe('headers as an array', () => {
+    before((done) => {
+      server = helper.start(config, {
+        headers: { 'X-Bar': ['key1=value1', 'key2=value2'] }
+      }, done);
+      req = request(server.app);
+    });
 
-  it('GET request to sockjs bundle', (done) => {
-    req.get('/__webpack_dev_server__/sockjs.bundle.js')
-      .expect('Content-Type', 'application/javascript')
-      .expect(200, done);
-  });
+    after(helper.close);
 
-  it('GET request to live html', (done) => {
-    req.get('/webpack-dev-server/')
-      .expect('Content-Type', 'text/html')
-      .expect(200, /__webpack_dev_server__/, done);
-  });
-
-  it('GET request to directory index', (done) => {
-    req.get('/webpack-dev-server')
-      .expect('Content-Type', 'text/html')
-      .expect(200, directoryIndex.trim(), done);
-  });
-
-  it('GET request to magic html', (done) => {
-    req.get('/bundle')
-      .expect(200, magicHtml.trim(), done);
-  });
-
-  it('GET request with headers', (done) => {
-    req.get('/bundle')
-      .expect('X-Foo', '1')
-      .expect(200, done);
+    it('GET request with headers as an array', (done) => {
+      req.get('/bundle')
+        .expect('X-Bar', 'key1=value1, key2=value2')
+        .expect(200, done);
+    });
   });
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
This PR removes property validation for header properties.

**What kind of change does this PR introduce?**
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
bugfix

**Did you add or update the `examples/`?**
No changes were necessary.

**Summary**
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
The validation that was being used before this PR was preventing multiple cookies from being set (Set-Cookie), or multiple domains being used (Access-Control-Allow-Origin). The 'http' server supports strings or arrays, so this validation was preventing this functionality from working.
<!-- Try to link to an open issue for more information. -->
https://github.com/webpack/webpack-dev-server/issues/964

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No

**Other information**
