### PR TITLE
Use built version os `sockjs-client`

### DIFF
--- a/client/socket.js
+++ b/client/socket.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const SockJS = require('sockjs-client');
+const SockJS = require('sockjs-client/dist/sockjs');
 
 let retries = 0;
 let sock = null;

--- a/examples/node-false/README.md
+++ b/examples/node-false/README.md
@@ -1,0 +1,9 @@
+# CLI - node false
+
+```shell
+node ../../bin/webpack-dev-server.js --open
+```
+
+## What should happen
+
+In the app you should see "It's working."

--- a/examples/node-false/app.js
+++ b/examples/node-false/app.js
@@ -1,0 +1,3 @@
+'use strict';
+
+document.write("It's working.");

--- a/examples/node-false/index.html
+++ b/examples/node-false/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<script src="bundle.js" type="text/javascript" charset="utf-8"></script>
+	</head>
+	<body>
+		<h1>Example: CLI - node false</h1>
+	</body>
+</html>

--- a/examples/node-false/webpack.config.js
+++ b/examples/node-false/webpack.config.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = {
+  context: __dirname,
+  entry: './app.js',
+  node: false
+};

--- a/test/fixtures/simple-config/webpack.config.js
+++ b/test/fixtures/simple-config/webpack.config.js
@@ -6,5 +6,6 @@ module.exports = {
   output: {
     filename: 'bundle.js',
     path: '/'
-  }
+  },
+  node: false
 };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
Bugfix

**Did you add or update the `examples/`?**
Yes.

**Summary**
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
`webpack-dev-server` bundles `sockjs-client` from source. `sockjs-client` sources assume a node environment however, and will fail to run if `global` is not available.

By bundling `sockjs-client` from source, the node environment requirement from `sockjs-client` will also be required of the app being served and thus it is not possible to have `node.global = false` in the user app being bundled.

This fix uses the built `sockjs-client` instead of the sources.

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No.

**Other information**
Fix https://github.com/webpack/webpack-dev-server/issues/1147