### PR TITLE
fixes #860: failure to exit on SIGINT race condition

### DIFF
--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -390,8 +390,9 @@ function startDevServer(webpackOptions, options) {
 
   ['SIGINT', 'SIGTERM'].forEach((sig) => {
     process.on(sig, () => {
-      server.close();
-      process.exit(); // eslint-disable-line no-process-exit
+      server.close(() => {
+        process.exit(); // eslint-disable-line no-process-exit
+      });
     });
   });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1997,9 +1997,9 @@
       }
     },
     "execa": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-      "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
+      "integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
       "dev": true,
       "requires": {
         "cross-spawn": "5.1.0",
@@ -8009,6 +8009,23 @@
             "execa": "0.7.0",
             "lcid": "1.0.0",
             "mem": "1.1.0"
+          },
+          "dependencies": {
+            "execa": {
+              "version": "0.7.0",
+              "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+              "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+              "dev": true,
+              "requires": {
+                "cross-spawn": "5.1.0",
+                "get-stream": "3.0.0",
+                "is-stream": "1.1.0",
+                "npm-run-path": "2.0.2",
+                "p-finally": "1.0.0",
+                "signal-exit": "3.0.2",
+                "strip-eof": "1.0.0"
+              }
+            }
           }
         },
         "uglifyjs-webpack-plugin": {

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "eslint": "^4.5.0",
     "eslint-config-webpack": "^1.2.5",
     "eslint-plugin-import": "^2.7.0",
+    "execa": "^0.8.0",
     "file-loader": "^0.11.2",
     "istanbul": "^0.4.5",
     "jquery": "^3.2.1",

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -5,7 +5,7 @@ const path = require('path');
 const execa = require('execa');
 
 describe('SIGINT', () => {
-  it('without filename option it should throw an error', (done) => {
+  it('should exit the process when SIGINT is detected', (done) => {
     const cliPath = path.resolve(__dirname, '../bin/webpack-dev-server.js');
     const examplePath = path.resolve(__dirname, '../examples/cli-public');
     const nodePath = execa.shellSync('which node').stdout;

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const assert = require('assert');
+const path = require('path');
+const execa = require('execa');
+
+describe('SIGINT', () => {
+  it('without filename option it should throw an error', (done) => {
+    const cliPath = path.resolve(__dirname, '../bin/webpack-dev-server.js');
+    const examplePath = path.resolve(__dirname, '../examples/cli-public');
+    const nodePath = execa.shellSync('which node').stdout;
+
+    const proc = execa(nodePath, [cliPath], { cwd: examplePath });
+
+    proc.stdout.on('data', (data) => {
+      const bits = data.toString();
+
+      if (/webpack: Compiled successfully/.test(bits)) {
+        assert(proc.pid !== 0);
+        proc.kill('SIGINT');
+      }
+    });
+
+    proc.on('exit', () => {
+      done();
+    });
+  });
+});

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -24,5 +24,5 @@ describe('SIGINT', () => {
     proc.on('exit', () => {
       done();
     });
-  });
+  }).timeout(4000);
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
Properly calls `process.exit` only after `server.close` has completed. Probable fix for reported edge case whereby the server process doesn't actually exit when SIGINT is sent.

**Did you add or update the `examples/`?**
No need

**Summary**
See above

**Does this PR introduce a breaking change?**
No

**Other information**
Added new test to confirm SIGINT detection works properly.
