### PR TITLE
Fix https in homepage url

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": "webpack/webpack-dev-server",
   "author": "Tobias Koppers @sokra",
-  "homepage": "http://github.com/webpack/webpack-dev-server",
+  "homepage": "https://github.com/webpack/webpack-dev-server",
   "maintainers": [
     {
       "name": "Andrew Powell",


### PR DESCRIPTION
Use `https` instead of `http` URL to Github.