### PR TITLE
fixes #1217: edge case with default watchOptions value

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -50,7 +50,7 @@ function Server(compiler, options) {
   this.allowedHosts = options.allowedHosts;
   this.sockets = [];
   this.contentBaseWatchers = [];
-  this.watchOptions = options.watchOptions;
+  this.watchOptions = options.watchOptions || {};
 
   // Listening for events
   const invalidPlugin = () => {


### PR DESCRIPTION
There is a problem when watchOptions is set to undefined in the options object. this.watchOptions is then set to undefined. We want an empty object so we can check poll property later.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
bugfix
**Did you add or update the `examples/`?**
No.
**Summary**
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
[Edge Case Issue](https://github.com/webpack/webpack-dev-server/issues/1217)

When Server(compiler, options) - options object looks like this:
```
{ 
  ...
  watchOptions: undefined,
  ...
 }
```
this.watchOptions will be set to undefined. 
```
 this.watchOptions = options.watchOptions
```

These lines will give raise to the error specified in the issue request.
```
  const usePolling = this.watchOptions.poll ? true : undefined; // eslint-disable-line no-undefined
  const interval = typeof this.watchOptions.poll === 'number' ? this.watchOptions.poll : undefined; // eslint-disable-line no-undefined
```
**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No.

**Other information**
