### PR TITLE
iOS Safari 10 bug where SockJS couldn't be found

### DIFF
--- a/client/socket.js
+++ b/client/socket.js
@@ -5,7 +5,7 @@ const SockJS = require('sockjs-client/dist/sockjs');
 let retries = 0;
 let sock = null;
 
-const socket = function(url, handlers) {
+const socket = function initSocket(url, handlers) {
   sock = new SockJS(url);
 
   sock.onopen = function onopen() {
@@ -37,6 +37,6 @@ const socket = function(url, handlers) {
     const msg = JSON.parse(e.data);
     if (handlers[msg.type]) { handlers[msg.type](msg.data); }
   };
-}
+};
 
 module.exports = socket;

--- a/client/socket.js
+++ b/client/socket.js
@@ -5,7 +5,7 @@ const SockJS = require('sockjs-client/dist/sockjs');
 let retries = 0;
 let sock = null;
 
-function socket(url, handlers) {
+const socket = function(url, handlers) {
   sock = new SockJS(url);
 
   sock.onopen = function onopen() {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
bug fix on iOS Safari 10 (iOS 10)

**Did you add or update the `examples/`?**
No, not applicable, no API changes

**Summary**
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
Fixes iOS Safari 10 bug. At the root, this works around a bug where Safari's eval's scope was getting confused.  Something to do with [this issue](https://stackoverflow.com/questions/46036960/evaluated-expression-const-variable-scope-in-safari)

[bug reference](https://github.com/webpack/webpack-dev-server/issues/1090#issuecomment-352537184)

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No

**Other information**

No