### PR TITLE
use validateSchema Directly

### DIFF
--- a/lib/DevServer.js
+++ b/lib/DevServer.js
@@ -11,6 +11,7 @@ const WebSocket = require('ws');
 const app = require('./app');
 const features = require('./features');
 const log = require('./log');
+const validateSchema = require('webpack/lib/validateSchema');
 const OptionsValidationError = require('./OptionsValidationError');
 const optionsSchema = require('./schemas/options.json');
 const plugins = require('./plugins');
@@ -31,7 +32,7 @@ module.exports = class DevServer extends EventEmitter {
   constructor(compiler, opts) {
     super();
     const options = Object.assign({}, defaults, opts);
-    const validationErrors = webpack.validateSchema(optionsSchema, options);
+    const validationErrors = validateSchema(optionsSchema, options);
 
     if (validationErrors.length) {
       throw new OptionsValidationError(validationErrors);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
Enhancement / Bugfix
**Did you add or update the `examples/`?**
N/A
**Summary**
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
Trying to run the devServer makes the validationSchema throw. Maybe webpack has changed their implementation, so I used the module directly. This is probably also better? Feel free to repro and investigate, happy to provide more information

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
devServer version is: 2.9.7

![skjermbilde 2017-12-18 kl 21 49 16](https://user-images.githubusercontent.com/16735925/34127451-7f959ea0-e43d-11e7-82e9-d30f88132fa5.png)
