### PR TITLE
enforce ES5 in all client files, fix usage in ES5 only browsers

### DIFF
--- a/client/.eslintrc
+++ b/client/.eslintrc
@@ -1,5 +1,10 @@
 {
+  "parserOptions": {
+    "ecmaVersion": 5
+  },
   "rules": {
+    "no-var": ["off"],
+    "vars-on-top": ["off"],
     "object-shorthand": ["error", "never"],
     "prefer-arrow-callback": ["off"],
     "prefer-template": ["off"]

--- a/client/index.js
+++ b/client/index.js
@@ -3,28 +3,28 @@
 /* global __resourceQuery WorkerGlobalScope self */
 /* eslint prefer-destructuring: off */
 
-const url = require('url');
-const stripAnsi = require('strip-ansi');
-const log = require('loglevel').getLogger('webpack-dev-server');
-const socket = require('./socket');
-const overlay = require('./overlay');
+var url = require('url');
+var stripAnsi = require('strip-ansi');
+var log = require('loglevel').getLogger('webpack-dev-server');
+var socket = require('./socket');
+var overlay = require('./overlay');
 
 function getCurrentScriptSource() {
   // `document.currentScript` is the most accurate way to find the current script,
   // but is not supported in all browsers.
   if (document.currentScript) { return document.currentScript.getAttribute('src'); }
   // Fall back to getting all scripts in the document.
-  const scriptElements = document.scripts || [];
-  const currentScript = scriptElements[scriptElements.length - 1];
+  var scriptElements = document.scripts || [];
+  var currentScript = scriptElements[scriptElements.length - 1];
   if (currentScript) { return currentScript.getAttribute('src'); }
   // Fail as there was no script to use.
   throw new Error('[WDS] Failed to get current script source.');
 }
 
-let urlParts;
-let hotReload = true;
+var urlParts;
+var hotReload = true;
 if (typeof window !== 'undefined') {
-  const qs = window.location.search.toLowerCase();
+  var qs = window.location.search.toLowerCase();
   hotReload = qs.indexOf('hotreload=false') === -1;
 }
 if (typeof __resourceQuery === 'string' && __resourceQuery) {
@@ -32,7 +32,7 @@ if (typeof __resourceQuery === 'string' && __resourceQuery) {
   urlParts = url.parse(__resourceQuery.substr(1));
 } else {
   // Else, get the url from the <script> this file was called with.
-  let scriptHost = getCurrentScriptSource();
+  var scriptHost = getCurrentScriptSource();
   // eslint-disable-next-line no-useless-escape
   scriptHost = scriptHost.replace(/\/[^\/]+$/, '');
   urlParts = url.parse((scriptHost || '/'), false, true);
@@ -42,17 +42,17 @@ if (!urlParts.port || urlParts.port === '0') {
   urlParts.port = self.location.port;
 }
 
-let hot = false;
-let initial = true;
-let currentHash = '';
-let useWarningOverlay = false;
-let useErrorOverlay = false;
-let useProgress = false;
+var hot = false;
+var initial = true;
+var currentHash = '';
+var useWarningOverlay = false;
+var useErrorOverlay = false;
+var useProgress = false;
 
-const INFO = 'info';
-const WARNING = 'warning';
-const ERROR = 'error';
-const NONE = 'none';
+var INFO = 'info';
+var WARNING = 'warning';
+var ERROR = 'error';
+var NONE = 'none';
 
 // Set the default log level
 log.setDefaultLevel(INFO);
@@ -71,7 +71,7 @@ function sendMsg(type, data) {
   }
 }
 
-const onSocketMsg = {
+var onSocketMsg = {
   hot: function msgHot() {
     hot = true;
     log.info('[WDS] Hot Module Replacement enabled.');
@@ -91,7 +91,7 @@ const onSocketMsg = {
     sendMsg('StillOk');
   },
   'log-level': function logLevel(level) {
-    const hotCtx = require.context('webpack/hot', false, /^\.\/log$/);
+    var hotCtx = require.context('webpack/hot', false, /^\.\/log$/);
     if (hotCtx.keys().indexOf('./log') !== -1) {
       hotCtx('./log').setLogLevel(level);
     }
@@ -142,9 +142,9 @@ const onSocketMsg = {
   },
   warnings: function msgWarnings(warnings) {
     log.warn('[WDS] Warnings while compiling.');
-    const strippedWarnings = warnings.map(function map(warning) { return stripAnsi(warning); });
+    var strippedWarnings = warnings.map(function map(warning) { return stripAnsi(warning); });
     sendMsg('Warnings', strippedWarnings);
-    for (let i = 0; i < strippedWarnings.length; i++) { log.warn(strippedWarnings[i]); }
+    for (var i = 0; i < strippedWarnings.length; i++) { log.warn(strippedWarnings[i]); }
     if (useWarningOverlay) overlay.showMessage(warnings);
 
     if (initial) return initial = false; // eslint-disable-line no-return-assign
@@ -152,9 +152,9 @@ const onSocketMsg = {
   },
   errors: function msgErrors(errors) {
     log.error('[WDS] Errors while compiling. Reload prevented.');
-    const strippedErrors = errors.map(function map(error) { return stripAnsi(error); });
+    var strippedErrors = errors.map(function map(error) { return stripAnsi(error); });
     sendMsg('Errors', strippedErrors);
-    for (let i = 0; i < strippedErrors.length; i++) { log.error(strippedErrors[i]); }
+    for (var i = 0; i < strippedErrors.length; i++) { log.error(strippedErrors[i]); }
     if (useErrorOverlay) overlay.showMessage(errors);
   },
   error: function msgError(error) {
@@ -166,8 +166,8 @@ const onSocketMsg = {
   }
 };
 
-let hostname = urlParts.hostname;
-let protocol = urlParts.protocol;
+var hostname = urlParts.hostname;
+var protocol = urlParts.protocol;
 
 
 // check ipv4 and ipv6 `all hostname`
@@ -189,7 +189,7 @@ if (hostname && (self.location.protocol === 'https:' || urlParts.hostname === '0
   protocol = self.location.protocol;
 }
 
-const socketUrl = url.format({
+var socketUrl = url.format({
   protocol: protocol,
   auth: urlParts.auth,
   hostname: hostname,
@@ -199,7 +199,7 @@ const socketUrl = url.format({
 
 socket(socketUrl, onSocketMsg);
 
-let isUnloading = false;
+var isUnloading = false;
 self.addEventListener('beforeunload', function beforeUnload() {
   isUnloading = true;
 });
@@ -211,16 +211,16 @@ function reloadApp() {
   if (hot) {
     log.info('[WDS] App hot update...');
     // eslint-disable-next-line global-require
-    const hotEmitter = require('webpack/hot/emitter');
+    var hotEmitter = require('webpack/hot/emitter');
     hotEmitter.emit('webpackHotUpdate', currentHash);
     if (typeof self !== 'undefined' && self.window) {
       // broadcast update to window
       self.postMessage('webpackHotUpdate' + currentHash, '*');
     }
   } else {
-    let rootWindow = self;
+    var rootWindow = self;
     // use parent window for reload (in case we're in an iframe with no valid src)
-    const intervalId = self.setInterval(function findRootWindow() {
+    var intervalId = self.setInterval(function findRootWindow() {
       if (rootWindow.location.protocol !== 'about:') {
         // reload immediately if protocol is valid
         applyReload(rootWindow, intervalId);
@@ -234,9 +234,9 @@ function reloadApp() {
     });
   }
 
-  function applyReload(rootWindow, intervalId) {
-    clearInterval(intervalId);
+  function applyReload(window, id) {
+    clearInterval(id);
     log.info('[WDS] App updated. Reloading...');
-    rootWindow.location.reload();
+    window.location.reload();
   }
 }

--- a/client/live.js
+++ b/client/live.js
@@ -2,23 +2,23 @@
 
 /* eslint import/no-extraneous-dependencies: off, global-require: off */
 
-const $ = require('jquery');
-const stripAnsi = require('strip-ansi');
-const socket = require('./socket');
+var $ = require('jquery');
+var stripAnsi = require('strip-ansi');
+var socket = require('./socket');
 require('./style.css');
 
-let hot = false;
-let currentHash = '';
+var hot = false;
+var currentHash = '';
 
 $(function ready() {
   $('body').html(require('./page.pug')());
-  const status = $('#status');
-  const okness = $('#okness');
-  const $errors = $('#errors');
-  const iframe = $('#iframe');
-  const header = $('.header');
+  var status = $('#status');
+  var okness = $('#okness');
+  var $errors = $('#errors');
+  var iframe = $('#iframe');
+  var header = $('.header');
 
-  const contentPage = window.location.pathname.substr('/webpack-dev-server'.length) + window.location.search;
+  var contentPage = window.location.pathname.substr('/webpack-dev-server'.length) + window.location.search;
 
   status.text('Connecting to sockjs server...');
   $errors.hide();
@@ -27,7 +27,7 @@ $(function ready() {
     borderColor: '#96b5b4'
   });
 
-  const onSocketMsg = {
+  var onSocketMsg = {
     hot: function msgHot() {
       hot = true;
       iframe.attr('src', contentPage + window.location.hash);
@@ -110,7 +110,7 @@ $(function ready() {
         borderColor: '#96b5b4'
       });
       try {
-        let old = iframe[0].contentWindow.location + '';
+        var old = iframe[0].contentWindow.location + '';
         if (old.indexOf('about') === 0) old = null;
         iframe.attr('src', old || (contentPage + window.location.hash));
         if (old) {

--- a/client/overlay.js
+++ b/client/overlay.js
@@ -3,12 +3,12 @@
 // The error overlay is inspired (and mostly copied) from Create React App (https://github.com/facebookincubator/create-react-app)
 // They, in turn, got inspired by webpack-hot-middleware (https://github.com/glenjamin/webpack-hot-middleware).
 
-const ansiHTML = require('ansi-html');
-const Entities = require('html-entities').AllHtmlEntities;
+var ansiHTML = require('ansi-html');
+var Entities = require('html-entities').AllHtmlEntities;
 
-const entities = new Entities();
+var entities = new Entities();
 
-const colors = {
+var colors = {
   reset: ['transparent', 'transparent'],
   black: '181818',
   red: 'E36049',
@@ -23,7 +23,7 @@ const colors = {
 ansiHTML.setColors(colors);
 
 function createOverlayIframe(onIframeLoad) {
-  const iframe = document.createElement('iframe');
+  var iframe = document.createElement('iframe');
   iframe.id = 'webpack-dev-server-client-overlay';
   iframe.src = 'about:blank';
   iframe.style.position = 'fixed';
@@ -40,7 +40,7 @@ function createOverlayIframe(onIframeLoad) {
 }
 
 function addOverlayDivTo(iframe) {
-  const div = iframe.contentDocument.createElement('div');
+  var div = iframe.contentDocument.createElement('div');
   div.id = 'webpack-dev-server-client-overlay-div';
   div.style.position = 'fixed';
   div.style.boxSizing = 'border-box';
@@ -62,9 +62,9 @@ function addOverlayDivTo(iframe) {
   return div;
 }
 
-let overlayIframe = null;
-let overlayDiv = null;
-let lastOnOverlayDivReady = null;
+var overlayIframe = null;
+var overlayDiv = null;
+var lastOnOverlayDivReady = null;
 
 function ensureOverlayDivExists(onOverlayDivReady) {
   if (overlayDiv) {

--- a/client/socket.js
+++ b/client/socket.js
@@ -1,9 +1,9 @@
 'use strict';
 
-const SockJS = require('sockjs-client/dist/sockjs');
+var SockJS = require('sockjs-client/dist/sockjs');
 
-let retries = 0;
-let sock = null;
+var retries = 0;
+var sock = null;
 
 function socket(url, handlers) {
   sock = new SockJS(url);
@@ -23,7 +23,7 @@ function socket(url, handlers) {
       // Exponentially increase timeout to reconnect.
       // Respectfully copied from the package `got`.
       // eslint-disable-next-line no-mixed-operators, no-restricted-properties
-      const retryInMs = 1000 * Math.pow(2, retries) + Math.random() * 100;
+      var retryInMs = 1000 * Math.pow(2, retries) + Math.random() * 100;
       retries += 1;
 
       setTimeout(function cb() {
@@ -34,7 +34,7 @@ function socket(url, handlers) {
 
   sock.onmessage = function onmessage(e) {
     // This assumes that all data sent via the websocket is JSON.
-    const msg = JSON.parse(e.data);
+    var msg = JSON.parse(e.data);
     if (handlers[msg.type]) { handlers[msg.type](msg.data); }
   };
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "beautify": "npm run lint -- --fix",
     "ci": "npm run cover -- --report lcovonly && npm run test",
     "cover": "istanbul cover node_modules/mocha/bin/_mocha",
-    "lint": "eslint bin lib test examples client/{index,live,socket,sockjs,overlay,webpack.config}.js",
+    "lint": "eslint bin lib test examples client/{index,live,socket,sockjs,overlay}.js",
     "mocha": "mocha --full-trace --check-leaks",
     "prepublish": "(rm ssl/*.pem || true) && npm run -s build:live && npm run -s build:index && npm run -s build:sockjs",
     "test": "npm run lint && npm run mocha",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->
bugfix

**Did you add or update the `examples/`?**
No

**Summary**
There were prior issues regarding the client files, after being upgraded to ES6, not working properly in IE11 (#1084). However, the fix (https://github.com/webpack/webpack-dev-server/commit/c9d32f802278a2285f5a0e316b0e60166a3686ed) left `let` and `const` in the client codebase, which works in IE11, but not in other ES5 compliant browsers (IE<11, UC Browser on Android).

Certain regions of the world, in particular China and developing countries, still has a large percentage of browsers that only support ES5 (UC Browser has over 500 million downloads on Google Play), so developers targeting customers in those countries still need to debug their applications in those browsers.

This PR ensures all client files are ES5 only (also enforces this via ESLint parser version).

**Does this PR introduce a breaking change?**
No.

**Other information**
