### PR TITLE
support for webpack 4.0.0-alpha.*

### DIFF
--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -51,7 +51,11 @@ const defaultTo = (value, def) => value == null ? def : value;
 const yargs = require('yargs')
   .usage(`${versionInfo()}\nUsage: https://webpack.js.org/configuration/dev-server/`);
 
-require('webpack/bin/config-yargs')(yargs);
+try {
+  require('webpack/bin/config-yargs')(yargs);
+} catch (err) {
+  require('webpack-cli/bin/config-yargs')(yargs);
+}
 
 // It is important that this is done after the webpack yargs config,
 // so it overrides webpack's version info.
@@ -219,9 +223,16 @@ yargs.options({
 });
 
 const argv = yargs.argv;
-const wpOpt = require('webpack/bin/convert-argv')(yargs, argv, {
-  outputFilename: '/bundle.js'
-});
+let wpOpt;
+try {
+  wpOpt = require('webpack/bin/convert-argv')(yargs, argv, {
+    outputFilename: '/bundle.js'
+  });
+} catch (err) {
+  wpOpt = require('webpack-cli/bin/convert-argv')(yargs, argv, {
+    outputFilename: '/bundle.js'
+  });
+}
 
 function processOptions(webpackOptions) {
   // process Promise


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Small fallback to test `webpack-dev-server` with `webpack@4.0.0-alpha.*`.

**Did you add or update the `examples/`?**

No.

**Summary**

Now we can use this package with the webpack 4 alphas. See https://github.com/webpack/webpack/issues/6179. Prevents `Cannot find module 'webpack/bin/config-yargs'` errors.

**Does this PR introduce a breaking change?**

No.

**Other information**

🎄❤️