### PR TITLE
Fix 'log' is not a function error

### DIFF
--- a/lib/cli/util.js
+++ b/lib/cli/util.js
@@ -48,7 +48,7 @@ function ready(argv, log, options, uri) {
     }
 
     if (argv.progress) {
-      log();
+      log.info();
     }
 
     log.info(start);


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Enhancement / Bugfix

**Did you add or update the examples/?**
N/A

**Summary**
When starting devServer with `--progress` option on, it fires an error as,  

> node_modules/webpack-dev-server/lib/cli/util.js:56
      log();
      ^
TypeError: log is not a function

This is because, in `argv.progress` check, logs trying to called as `log()` instead of `log.info()`

**Does this PR introduce a breaking change?**
No

**Other information**
devServer version is: 3.0.0-alpha6
reported issue: #1244 

```
/Users/cinarbil/Dev/webpack-demo/node_modules/webpack-dev-server/lib/cli/util.js:56
      log();
      ^

TypeError: log is not a function
    at ready (/Users/cinarbil/Dev/webpack-demo/node_modules/webpack-dev-server/lib/cli/util.js:56:7)
    at Server.devServer.listen (/Users/cinarbil/Dev/webpack-demo/node_modules/webpack-dev-server/lib/cli/start.js:61:7)
    at Server.returnValue.server.listen (/Users/cinarbil/Dev/webpack-demo/node_modules/webpack-dev-server/lib/DevServer.js:179:18)
    at Object.onceWrapper (events.js:254:19)
    at Server.emit (events.js:164:20)
    at Server.emit (/Users/cinarbil/Dev/webpack-demo/node_modules/spdy/lib/spdy/server.js:237:40)
    at emitListeningNT (net.js:1394:10)
    at _combinedTickCallback (internal/process/next_tick.js:135:11)
    at process._tickCallback (internal/process/next_tick.js:180:9)
```

  