### PR TITLE
Support disabling index serving

### DIFF
--- a/lib/optionsSchema.json
+++ b/lib/optionsSchema.json
@@ -320,8 +320,15 @@
       "type": "boolean"
     },
     "index": {
-      "description": "The filename that is considered the index file.",
-      "type": "string"
+      "description": "The filename that is considered the index file, or `false` to proxy the root path",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "boolean"
+        }
+      ]
     },
     "log": {
       "description": "Customize info logs for webpack-dev-middleware.",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

This is a small feature

**Did you add or update the `examples/`?**

no

**Summary**
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

If you are doing server side rendering, by sending all HTML requests to a proxy, and your webpack config generates an `index.html` file, that file will get served instead of your server-side-rendered content for the root of the domain.  Passing an `index` value of `false` to webpack-dev-middleware prevents it from serving the index file, but it violates the current schema for options passed into webpack dev server.

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No, this merely allows an extra value to be passed in for an existing option.

**Other information**

You can work around this issue by passing in `''` which is close enough to `false` to trigger the desired behaviour in webpack-dev-middleware, but also a string so it passes validation.