### PR TITLE
use  webpack-cli for `config-yargs` source

### DIFF
--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -51,7 +51,7 @@ const defaultTo = (value, def) => value == null ? def : value;
 const yargs = require('yargs')
   .usage(`${versionInfo()}\nUsage: https://webpack.js.org/configuration/dev-server/`);
 
-require('webpack/bin/config-yargs')(yargs);
+require('webpack-cli/bin/config-yargs')(yargs);
 
 // It is important that this is done after the webpack yargs config,
 // so it overrides webpack's version info.

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "ssl/"
   ],
   "peerDependencies": {
-    "webpack": "^2.2.0 || ^3.0.0"
+    "webpack": "^4.0.0",
+    "webpack-cli": "^2.0.0"
   },
   "dependencies": {
     "ansi-html": "0.0.7",


### PR DESCRIPTION
webpack (alpha-4) no longer contains config-yargs with `/bin`, but webpack-cli does.

<!--
  Thank you for submitting a pull request!
  Please note that this template is not optional.
  Please fill out _ALL_ fields, or your pull request may be rejected.
  Please do not delete this template. Please do remove this header to acknowledge this message.`

  Please note that we are NOT accepting new FEATURE requests at this time.
  Please place an x, no spaces, in all [ ] that apply
-->

- [x] This is a **bugfix**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **typo fix**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

<!-- Please note that we won't approve your changes if you don't add tests. -->

Would you say that this needs a test?

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for making this change.
  What existing problem does the pull request solve?
  If this Pull Request addresses an issue, please link to the issue.
-->

I am trying out webpack v4 alpha in my own boilerplate project and cam across this today.

As webpack v4 is still in alpha, I guess there is some decisions to be made about how else to handle this i.e. it's probably premature to roll this out now, but perhaps a `webpack-dev-server v3-beta` might be useful with note around people trying webpack v4?

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

I Imagine this is a breaking change, just because people will now have to ensure they have the new cli installed, which was mot necessary before

### Additional Info

see commit : https://github.com/webpack/webpack/commit/4b0332d3909eea8115d84f9a03da2d52478daa70#diff-c1111bd512b29e821b120b86446026b8

see current v4 alpha: https://github.com/webpack/webpack/tree/v4.0.0-alpha.1/bin

  