### PR TITLE
fix: pin strip-ansi to 3.x for ES5 compat

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -129,9 +129,9 @@
       "integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4="
     },
     "ansi-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
     },
     "ansi-styles": {
       "version": "2.2.1",
@@ -9892,11 +9892,11 @@
       "optional": true
     },
     "strip-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
-        "ansi-regex": "3.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "strip-bom": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "sockjs": "0.3.19",
     "sockjs-client": "1.1.4",
     "spdy": "^3.4.1",
-    "strip-ansi": "^4.0.0",
+    "strip-ansi": "^3.0.0",
     "supports-color": "^5.1.0",
     "webpack-dev-middleware": "1.12.2",
     "yargs": "6.6.0"


### PR DESCRIPTION
- [x] This is a **bugfix**

Follow up for https://github.com/webpack/webpack-dev-server/pull/1270#issuecomment-357514454

`strip-ansi` which is required by the clients, uses ES6 syntax. Pinning it to 3.x keeps ES5 compat. ([The only difference between 3.x and 4.0 is the syntax change](https://github.com/chalk/strip-ansi/commits/master))