### PR TITLE
fix(Server): disable page reload when `hot` is not specified (`options.hot`)

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -40,7 +40,8 @@ function Server(compiler, options) {
     throw new Error("'filename' option must be set in lazy mode.");
   }
 
-  this.hot = options.hot || options.hotOnly;
+  this.hot = options.hot;
+  this.hotOnly = options.hotOnly;
   this.headers = options.headers;
   this.clientLogLevel = options.clientLogLevel;
   this.clientOverlay = options.overlay;
@@ -601,7 +602,7 @@ Server.prototype.listen = function (port, hostname, fn) {
 
       if (this.clientOverlay) { this.sockWrite([conn], 'overlay', this.clientOverlay); }
 
-      if (this.hot) this.sockWrite([conn], 'hot');
+      if (this.hot || this.hotOnly) { this.sockWrite([conn], 'hot', this.hotOnly); }
 
       if (!this._stats) return;
       this._sendStats([conn], this._stats.toJson(clientStats), true);


### PR DESCRIPTION
- [x] This is a **bugfix**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **typo fix**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

No

### Motivation / Use-Case

Aimed to fix #1251. As per the issue, the page keeps reloading even if `hot` option is not specified or `false`. This PR contains fix which disables page reload when `hot: false` or not specified or `hotOnly: true`. To enable page refresh along with HMR one has to explicitly set `hot: true`.

### Breaking Changes

No

### Additional Info

I think we can consider adding one more option, something like `livereload` for use-cases when people don't wanna use HMR but instead prefer to go with a regular page refresh. I didn't do it as I feel it's more like a new feature while I tried to keep this PR as simple as possible.
