### PR TITLE
Open browser with command line args

### DIFF
--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -478,7 +478,7 @@ function reportReadiness(uri, options) {
 
     if (typeof options.open === 'string') {
       openOptions = {
-        app: options.openArgs ? [options.open, ...(options.openArgs.split('|'))] : options.open,
+        app: options.openArgs ? [options.open].concat(options.openArgs.split('|')) : options.open,
         wait: false
       };
       openMessage += `: ${options.open}`;

--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -111,6 +111,11 @@ yargs.options({
     describe: 'Open default browser with the specified page',
     requiresArg: true
   },
+  'open-args': {
+    type: 'string',
+    describe: 'Open default browser with the specified command line arguments',
+    requiresArg: true
+  },
   color: {
     type: 'boolean',
     alias: 'colors',
@@ -332,6 +337,11 @@ function processOptions(webpackOptions) {
     options.openPage = argv['open-page'];
   }
 
+  if (argv['open-args']) {
+    options.open = true;
+    options.openArgs = argv['open-args'];
+  }
+
   if (typeof argv.open !== 'undefined') {
     options.open = argv.open !== '' ? argv.open : true;
   }
@@ -467,7 +477,10 @@ function reportReadiness(uri, options) {
     let openMessage = 'Unable to open browser';
 
     if (typeof options.open === 'string') {
-      openOptions = { app: options.open };
+      openOptions = {
+        app: options.openArgs ? [options.open, ...(options.openArgs.split('|'))] : options.open,
+        wait: false
+      };
       openMessage += `: ${options.open}`;
     }
 

--- a/lib/optionsSchema.json
+++ b/lib/optionsSchema.json
@@ -219,6 +219,10 @@
       "description": "Let the CLI open your browser to a specific page on the site.",
       "type": "string"
     },
+    "openArgs": {
+      "description": "Let the CLI open your browser with specific args.",
+      "type": "string"
+    },
     "features": {
       "description": "The order of which the features will be triggered.",
       "items": {

--- a/test/Validation.test.js
+++ b/test/Validation.test.js
@@ -50,7 +50,7 @@ describe('Validation', () => {
       " - configuration has an unknown property 'asdf'. These properties are valid:",
       '   object { hot?, hotOnly?, lazy?, bonjour?, host?, allowedHosts?, filename?, publicPath?, port?, socket?, ' +
       'watchOptions?, headers?, clientLogLevel?, overlay?, progress?, key?, cert?, ca?, pfx?, pfxPassphrase?, requestCert?, ' +
-      'inline?, disableHostCheck?, public?, https?, contentBase?, watchContentBase?, open?, useLocalIp?, openPage?, features?, ' +
+      'inline?, disableHostCheck?, public?, https?, contentBase?, watchContentBase?, open?, useLocalIp?, openPage?, openArgs?, features?, ' +
       'compress?, proxy?, historyApiFallback?, staticOptions?, setup?, before?, after?, stats?, reporter?, reportTime?, ' +
       'noInfo?, quiet?, serverSideRender?, index?, log?, warn? }'
     ]


### PR DESCRIPTION
Open the browser with specific command line arguments.

Arguments are string and being splitted with `'|'` char if there are many for now, because the current version of yargs can not parse arrays successfully (or i could not make that happen).