### PR TITLE
feat: add `sockPath` option (`options.sockPath`)

### DIFF
--- a/client-src/default/index.js
+++ b/client-src/default/index.js
@@ -2,7 +2,7 @@
 
 /* global __resourceQuery WorkerGlobalScope self */
 /* eslint prefer-destructuring: off */
-
+const qs = require('querystring');
 const url = require('url');
 const stripAnsi = require('strip-ansi');
 const log = require('loglevel').getLogger('webpack-dev-server');
@@ -194,7 +194,7 @@ const socketUrl = url.format({
   auth: urlParts.auth,
   hostname,
   port: urlParts.port,
-  pathname: urlParts.path == null || urlParts.path === '/' ? '/sockjs-node' : urlParts.path
+  pathname: urlParts.path == null || urlParts.path === '/' ? '/sockjs-node' : (qs.parse(urlParts.path).sockPath || urlParts.path)
 });
 
 socket(socketUrl, onSocketMsg);

--- a/examples/node-api-sock-path/README.md
+++ b/examples/node-api-sock-path/README.md
@@ -1,0 +1,15 @@
+# Node.js API - Simple
+
+```shell
+node server.js
+```
+
+Starts a simple webpack-dev-server setup via the Node API. Open `http://localhost:8080/` to go the app.
+
+## What should happen
+
+In the app you should see "It's working."
+
+In `app.js`, uncomment the code that results in an error and save. This error should be visible in the CLI and devtools.
+
+Then, in `app.js`, uncomment the code that results in a warning. This warning should be visible in the CLI and devtools.

--- a/examples/node-api-sock-path/app.js
+++ b/examples/node-api-sock-path/app.js
@@ -1,0 +1,7 @@
+document.write('It\'s working under a subapp');
+
+// This results in a warning:
+if (!window) require(`./${window}parseable.js`);
+
+// This results in an error:
+// if(!window) require("test");

--- a/examples/node-api-sock-path/app.js
+++ b/examples/node-api-sock-path/app.js
@@ -1,7 +1,3 @@
+'use strict';
+
 document.write('It\'s working under a subapp');
-
-// This results in a warning:
-if (!window) require(`./${window}parseable.js`);
-
-// This results in an error:
-// if(!window) require("test");

--- a/examples/node-api-sock-path/index.html
+++ b/examples/node-api-sock-path/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<script src="/subapp/bundle.js" type="text/javascript" charset="utf-8"></script>
+	</head>
+	<body>
+		<h1>Example: Node.js API - Simple</h1>
+	</body>
+</html>

--- a/examples/node-api-sock-path/server.js
+++ b/examples/node-api-sock-path/server.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const path = require('path');
+const Webpack = require('webpack');
+const WebpackDevServer = require('../../lib/Server');
+const webpackConfig = require('./webpack.config');
+
+const compiler = Webpack(webpackConfig);
+const server = new WebpackDevServer(compiler, {
+  stats: {
+    colors: true
+  },
+  contentBase: path.resolve(__dirname),
+  watchContentBase: true,
+  sockPath: '/subapp/sockjs-node',
+  publicPath: '/subapp/',
+  historyApiFallback: {
+    disableDotRule: true,
+    index: '/subapp/'
+  }
+});
+
+server.listen(8080, '127.0.0.1', () => {
+  console.log('Starting server on http://localhost:8080');
+});

--- a/examples/node-api-sock-path/webpack.config.js
+++ b/examples/node-api-sock-path/webpack.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  context: __dirname,
+  entry: ['./app.js', '../../client/index.js?http://localhost:8080/&sockPath=subapp/sockjs-node'],
+  output: {
+    filename: 'bundle.js',
+    publicPath: '/subapp/'
+  }
+};

--- a/examples/node-api-sock-path/webpack.config.js
+++ b/examples/node-api-sock-path/webpack.config.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   context: __dirname,
   entry: ['./app.js', '../../client/index.js?http://localhost:8080/&sockPath=subapp/sockjs-node'],

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -51,6 +51,7 @@ function Server(compiler, options) {
   this.sockets = [];
   this.contentBaseWatchers = [];
   this.watchOptions = options.watchOptions || {};
+  this.sockPath = `/${options.sockPath ? options.sockPath.replace(/\/$/, '') : 'sockjs-node'}`;
 
   // Listening for events
   const invalidPlugin = () => {
@@ -608,7 +609,7 @@ Server.prototype.listen = function (port, hostname, fn) {
     });
 
     sockServer.installHandlers(this.listeningApp, {
-      prefix: '/sockjs-node'
+      prefix: this.sockPath
     });
 
     if (fn) {

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -51,7 +51,7 @@ function Server(compiler, options) {
   this.sockets = [];
   this.contentBaseWatchers = [];
   this.watchOptions = options.watchOptions || {};
-  this.sockPath = `/${options.sockPath ? options.sockPath.replace(/\/$/, '') : 'sockjs-node'}`;
+  this.sockPath = `/${options.sockPath ? options.sockPath.replace(/^\/|\/$/, '') : 'sockjs-node'}`;
 
   // Listening for events
   const invalidPlugin = () => {

--- a/lib/optionsSchema.json
+++ b/lib/optionsSchema.json
@@ -58,6 +58,10 @@
       "description": "The Unix socket to listen to (instead of on a host).",
       "type": "string"
     },
+    "sockPath": {
+      "description": "URL path where the sockjs-node is served from (default is sockjs-node).",
+      "type": "string"
+    },
     "watchOptions": {
       "description": "Options for changing the watch behavior.",
       "type": "object"

--- a/lib/util/addDevServerEntrypoints.js
+++ b/lib/util/addDevServerEntrypoints.js
@@ -15,7 +15,8 @@ module.exports = function addDevServerEntrypoints(webpackOptions, devServerOptio
       }
     };
     const domain = createDomain(devServerOptions, app);
-    const devClient = [`${require.resolve('../../client/')}?${domain}`];
+    const sockPath = devServerOptions.sockPath ? `&sockPath=${devServerOptions.sockPath}` : '';
+    const devClient = [`${require.resolve('../../client/')}?${domain}${sockPath}`];
 
     if (devServerOptions.hotOnly) { devClient.push('webpack/hot/only-dev-server'); } else if (devServerOptions.hot) { devClient.push('webpack/hot/dev-server'); }
 

--- a/test/Validation.test.js
+++ b/test/Validation.test.js
@@ -48,7 +48,7 @@ describe('Validation', () => {
     config: { asdf: true },
     message: [
       " - configuration has an unknown property 'asdf'. These properties are valid:",
-      '   object { hot?, hotOnly?, lazy?, bonjour?, host?, allowedHosts?, filename?, publicPath?, port?, socket?, sockPath?' +
+      '   object { hot?, hotOnly?, lazy?, bonjour?, host?, allowedHosts?, filename?, publicPath?, port?, socket?, sockPath?, ' +
       'watchOptions?, headers?, clientLogLevel?, overlay?, progress?, key?, cert?, ca?, pfx?, pfxPassphrase?, requestCert?, ' +
       'inline?, disableHostCheck?, public?, https?, contentBase?, watchContentBase?, open?, useLocalIp?, openPage?, features?, ' +
       'compress?, proxy?, historyApiFallback?, staticOptions?, setup?, before?, after?, stats?, reporter?, reportTime?, ' +

--- a/test/Validation.test.js
+++ b/test/Validation.test.js
@@ -48,7 +48,7 @@ describe('Validation', () => {
     config: { asdf: true },
     message: [
       " - configuration has an unknown property 'asdf'. These properties are valid:",
-      '   object { hot?, hotOnly?, lazy?, bonjour?, host?, allowedHosts?, filename?, publicPath?, port?, socket?, ' +
+      '   object { hot?, hotOnly?, lazy?, bonjour?, host?, allowedHosts?, filename?, publicPath?, port?, socket?, sockPath?' +
       'watchOptions?, headers?, clientLogLevel?, overlay?, progress?, key?, cert?, ca?, pfx?, pfxPassphrase?, requestCert?, ' +
       'inline?, disableHostCheck?, public?, https?, contentBase?, watchContentBase?, open?, useLocalIp?, openPage?, features?, ' +
       'compress?, proxy?, historyApiFallback?, staticOptions?, setup?, before?, after?, stats?, reporter?, reportTime?, ' +

--- a/test/addDevServerEntrypoints.test.js
+++ b/test/addDevServerEntrypoints.test.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const assert = require('assert');
+const addDevServerEntrypoints = require('../lib/util/addDevServerEntrypoints');
+const config = require('./fixtures/simple-config/webpack.config');
+
+describe('addDevServerEntrypoints', () => {
+  it('Entrypoints that are a single file will become an array', () => {
+    addDevServerEntrypoints(Object.assign({}, config), {});
+    assert(config.entry.length);
+  });
+
+  it('Entrypoints that are an array will become a longer array', () => {
+    addDevServerEntrypoints(
+      Object.assign({}, config, { entry: [config.entry] }),
+      {}
+    );
+    assert(config.entry.length > 1);
+  });
+
+  it('Entrypoints that are objects will have more keys', () => {
+    addDevServerEntrypoints(
+      Object.assign({}, config, { entry: { app: config.entry } }),
+      {}
+    );
+    assert(Object.keys(config.entry).length > 1);
+  });
+});


### PR DESCRIPTION
- [x] This is a **bugfix**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **typo fix**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

Added new tests for addDevServerEntrypoints

I've added examples referenced from https://github.com/webpack/webpack-dev-server/pull/911

I've tested this against the [breaking example provided in 2.7.0](https://github.com/webpack/webpack-dev-server/issues/1021#issuecomment-321001601) and it doesn't suffer the same failure.

### Motivation / Use-Case

Similar motivations as https://github.com/webpack/webpack-dev-server/pull/911. 

We also have multiple apps being developed behind a reverse proxy (in our case a docker composed nginx). Each app is served from a top-level sub-directory (can't use root path), e.g. `host/app-part-one`, `host/app-another-piece`

Not sure if v3 fixes this and not sure how long until v3 comes out. This should fix our use case and shouldn't break anything else in the mean time

### Breaking Changes

None

### Additional Info

It doesn't rely on the `publicPath` value, but unfortunately the `sockPath` value has to be passed twice, once in the `devServer` option (this is what Server.js uses to determine what prefix to listen at), and once again in the entry resource url as a query parameter (this is what client/index.js uses to determine where to send requests to)