### PR TITLE
Allow no publicPath or entry point

### DIFF
--- a/lib/util/addDevServerEntrypoints.js
+++ b/lib/util/addDevServerEntrypoints.js
@@ -27,7 +27,7 @@ module.exports = function addDevServerEntrypoints(webpackOptions, devServerOptio
       } else if (typeof wpOpt.entry === 'function') {
         wpOpt.entry = wpOpt.entry(devClient);
       } else {
-        wpOpt.entry = devClient.concat(wpOpt.entry);
+        wpOpt.entry = devClient.concat(wpOpt.entry || './src');
       }
     });
   }

--- a/test/Entry.test.js
+++ b/test/Entry.test.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const assert = require('assert');
+const addDevServerEntrypoints = require('../lib/util/addDevServerEntrypoints');
+
+describe('Entry', () => {
+  it('default to src if no entry point is given', (done) => {
+    const webpackOptions = {};
+    const devServerOptions = {};
+
+    addDevServerEntrypoints(webpackOptions, devServerOptions);
+
+    assert(webpackOptions.entry.length, 2);
+    assert(webpackOptions.entry[1], './src');
+
+    done();
+  });
+});


### PR DESCRIPTION
- [x] This is a **bugfix**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **typo fix**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

Yes

### Motivation / Use-Case

Fixes this issue https://github.com/webpack/webpack-dev-server/issues/1308

Allows for `webpack-dev-server` to run with no config or no configured entry point, keeping the behaviour consistent with the webpack compiler.

### Additional Info

This should eventually be moved out of `webpack-dev-server` as we've currently got two places setting the default entry point (this and `WebpackOptionsDefaulter`).
