### PR TITLE
Fix support for DynamicEntryPlugin

### DIFF
--- a/lib/util/addDevServerEntrypoints.js
+++ b/lib/util/addDevServerEntrypoints.js
@@ -19,16 +19,22 @@ module.exports = function addDevServerEntrypoints(webpackOptions, devServerOptio
 
     if (devServerOptions.hotOnly) { devClient.push('webpack/hot/only-dev-server'); } else if (devServerOptions.hot) { devClient.push('webpack/hot/dev-server'); }
 
-    [].concat(webpackOptions).forEach((wpOpt) => {
-      if (typeof wpOpt.entry === 'object' && !Array.isArray(wpOpt.entry)) {
-        Object.keys(wpOpt.entry).forEach((key) => {
-          wpOpt.entry[key] = devClient.concat(wpOpt.entry[key]);
-        });
-      } else if (typeof wpOpt.entry === 'function') {
-        wpOpt.entry = wpOpt.entry(devClient);
-      } else {
-        wpOpt.entry = devClient.concat(wpOpt.entry || './src');
+    const prependDevClient = (entry) => {
+      if (typeof entry === 'function') {
+        return () => Promise.resolve(entry()).then(prependDevClient);
       }
+      if (typeof entry === 'object' && !Array.isArray(entry)) {
+        const entryClone = {};
+        Object.keys(entry).forEach((key) => {
+          entryClone[key] = devClient.concat(entry[key]);
+        });
+        return entryClone;
+      }
+      return devClient.concat(entry);
+    };
+
+    [].concat(webpackOptions).forEach((wpOpt) => {
+      wpOpt.entry = prependDevClient(wpOpt.entry || './src');
     });
   }
 };

--- a/test/Entry.test.js
+++ b/test/Entry.test.js
@@ -2,8 +2,51 @@
 
 const assert = require('assert');
 const addDevServerEntrypoints = require('../lib/util/addDevServerEntrypoints');
+const config = require('./fixtures/simple-config/webpack.config');
 
 describe('Entry', () => {
+  it('adds devServer entry points to a single entry point', () => {
+    const webpackOptions = Object.assign({}, config);
+    const devServerOptions = {};
+
+    addDevServerEntrypoints(webpackOptions, devServerOptions);
+
+    assert.equal(webpackOptions.entry.length, 2);
+    assert(webpackOptions.entry[0].indexOf('client/index.js?') !== -1);
+    assert.equal(webpackOptions.entry[1], './foo.js');
+  });
+
+  it('adds devServer entry points to a multi-module entry point', () => {
+    const webpackOptions = Object.assign({}, config, {
+      entry: ['./foo.js', './bar.js']
+    });
+    const devServerOptions = {};
+
+    addDevServerEntrypoints(webpackOptions, devServerOptions);
+
+    assert.equal(webpackOptions.entry.length, 3);
+    assert(webpackOptions.entry[0].indexOf('client/index.js?') !== -1);
+    assert.equal(webpackOptions.entry[1], './foo.js');
+    assert.equal(webpackOptions.entry[2], './bar.js');
+  });
+
+  it('adds devServer entry points to a multi entry point object', () => {
+    const webpackOptions = Object.assign({}, config, {
+      entry: {
+        foo: './foo.js',
+        bar: './bar.js'
+      }
+    });
+    const devServerOptions = {};
+
+    addDevServerEntrypoints(webpackOptions, devServerOptions);
+
+    assert.equal(webpackOptions.entry.foo.length, 2);
+    assert(webpackOptions.entry.foo[0].indexOf('client/index.js?') !== -1);
+    assert.equal(webpackOptions.entry.foo[1], './foo.js');
+    assert.equal(webpackOptions.entry.bar[1], './bar.js');
+  });
+
   it('defaults to src if no entry point is given', () => {
     const webpackOptions = {};
     const devServerOptions = {};

--- a/test/Entry.test.js
+++ b/test/Entry.test.js
@@ -4,15 +4,13 @@ const assert = require('assert');
 const addDevServerEntrypoints = require('../lib/util/addDevServerEntrypoints');
 
 describe('Entry', () => {
-  it('default to src if no entry point is given', (done) => {
+  it('defaults to src if no entry point is given', () => {
     const webpackOptions = {};
     const devServerOptions = {};
 
     addDevServerEntrypoints(webpackOptions, devServerOptions);
 
-    assert(webpackOptions.entry.length, 2);
-    assert(webpackOptions.entry[1], './src');
-
-    done();
+    assert.equal(webpackOptions.entry.length, 2);
+    assert.equal(webpackOptions.entry[1], './src');
   });
 });


### PR DESCRIPTION
- [x] This is a **bugfix**
- [ ] This is a **code refactor**
- [x] This is a **test update**
- [ ] This is a **typo fix**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

Yes.  I have added tests for this change and I have added new tests for prior behavior to prove that this doesn't break anything.

### Motivation / Use-Case

The support for DynamicEntryPlugin added in #802 was incorrect.  This fixes `addDevServerEntrypoints.js` as it applies to dynamic endpoints (functions which return an entry object and functions which return a Promise)

### Breaking Changes

none.

### Additional Info

This pull request targets the `webpack-4` v3.x branch, but I would like to port this back to `2.x` as well if you plan to make any more releases under that major version.  The only conflict would be the default entry point added in #1310.  I could simply exclude that behavior from this change and open up a separate PR targeting the master branch.

Closes: #1318 