### PR TITLE
refactor(webpack-dev-server): use default `publicPath`

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ execute the file or command.
 Either method will start a server instance and begin listening for connections
 from `localhost` on port `8080`.
 
+By default the entry file will be `src/index.js` and it will be served at
+`/dist/main.js` when the `--mode` flag is used. These can be customized in
+`webpack.config.js` if needed.
+
 webpack-dev-server is configured by default to support live-reload of files as
 you edit your assets while the server is running.
 

--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -264,7 +264,12 @@ function processOptions(webpackOptions) {
     // eslint-disable-next-line
     options.publicPath = firstWpOpt.output && firstWpOpt.output.publicPath || '';
     if (!/^(https?:)?\/\//.test(options.publicPath) && options.publicPath[0] !== '/') {
-      options.publicPath = `/${options.publicPath}`;
+      if (webpackOptions.mode) {
+        // Enable Webpack 4 like default path when the --mode flag is set
+        options.publicPath = `/dist/${options.publicPath}`;
+      } else {
+        options.publicPath = `/${options.publicPath}`;
+      }
     }
   }
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!
  Please note that this template is not optional.
  Please fill out _ALL_ fields, or your pull request may be rejected.
  Please do not delete this template. Please do remove this header to acknowledge this message.`

  Please note that we are NOT accepting new FEATURE requests at this time.
  Please place an x, no spaces, in all [ ] that apply
-->

- [ ] This is a **bugfix**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **typo fix**
- [ ] This is a **metadata update**

PR for #1311

### For Bugs and Features; did you add new tests?

No... There doesn't seem to be any existing direct tests for the `bin/webpack-dev-server.js` script.

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for making this change.
  What existing problem does the pull request solve?
  If this Pull Request addresses an issue, please link to the issue.
-->

Simple zero configuration projects. 

Example <https://github.com/epeli/0cjs-webpack-dev-server>

It hilights how it should work after this PR.

I'm going to do a small presentation about Webpack and this would make it easier to sell Webpack to my audience. People seem to be quite intimidated by Webpack configurations. This would make the beginning very smooth.

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

This is a breaking change. Currently the bundle is served from `/main.js` after this it will be `/dist/main.js` which aligns with the default Webpack 4 ouput.
