### PR TITLE
Live bundle not loading, typo during migration

### DIFF
--- a/client-src/live/index.js
+++ b/client-src/live/index.js
@@ -11,7 +11,7 @@ let hot = false;
 let currentHash = '';
 
 $(() => {
-  $('body').html(require('./page.html')());
+  $('body').html(require('./page.html'));
   const status = $('#status');
   const okness = $('#okness');
   const $errors = $('#errors');


### PR DESCRIPTION
- [ ] This is a **bugfix**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [X] This is a **typo fix**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

Nope, is typo.

### Motivation / Use-Case

The live client was [refactored](https://github.com/webpack/webpack-dev-server/commit/a02c0839fb50b59fee089f19d3e18e3c6e603695#diff-6b9850aa6ec84dd7b01865bf903ec26b) and migrated from the [pug-loader](https://github.com/pugjs/pug-loader) to the [html-loader](https://github.com/webpack-contrib/html-loader).  The `pug-loader`, I assume, returns a function, whereas the `html-loader` returns a string.  

You get this abstract error and the page completely fails to load:
```
jQuery.Deferred exception: n(...) is not a function TypeError: n(...) is not a function
    at HTMLDocument.<anonymous> (http://0.0.0.0:3000/__webpack_dev_server__/live.bundle.js:1:163209)
    at c (http://0.0.0.0:3000/__webpack_dev_server__/live.bundle.js:1:105849)
    at l (http://0.0.0.0:3000/__webpack_dev_server__/live.bundle.js:1:106151) undefined
```