### PR TITLE
Remove Tapable#apply calls

### DIFF
--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -386,9 +386,9 @@ function startDevServer(webpackOptions, options) {
   }
 
   if (options.progress) {
-    compiler.apply(new webpack.ProgressPlugin({
+    new webpack.ProgressPlugin({
       profile: argv.profile
-    }));
+    }).apply(compiler);
   }
 
   const suffix = (options.inline !== false || options.lazy === true ? '/' : '/webpack-dev-server/');

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -64,7 +64,7 @@ function Server(compiler, options, _log) {
       if (addInfo) msg = `${msg} (${addInfo})`;
       this.sockWrite(this.sockets, 'progress-update', { percent, msg });
     });
-    compiler.apply(progressPlugin);
+    progressPlugin.apply(compiler);
   }
 
   const addCompilerHooks = (comp) => {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!
  Please note that this template is not optional.
  Please fill out _ALL_ fields, or your pull request may be rejected.
  Please do not delete this template. Please do remove this header to acknowledge this message.`

  Please note that we are NOT accepting new FEATURE requests at this time.
  Please place an x, no spaces, in all [ ] that apply
-->

- [x] This is a **bugfix**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **typo fix**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

no

### Motivation / Use-Case

`Tapable#apply` is deprecated so I removed the calls.

### Breaking Changes

no

### Additional Info

No more deprecation notice about `Tapable#apply`