### PR TITLE
feat(Server): add `sockJsUrl` option (`options.sockJsUrl`)

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -52,6 +52,7 @@ function Server(compiler, options, _log) {
   this.sockets = [];
   this.contentBaseWatchers = [];
   this.watchOptions = options.watchOptions || {};
+  this.sockjsUrl = options.sockjsUrl || '/sockjs-node';
 
   // Listening for events
   const invalidPlugin = () => {
@@ -611,7 +612,7 @@ Server.prototype.listen = function (port, hostname, fn) {
     });
 
     sockServer.installHandlers(this.listeningApp, {
-      prefix: '/sockjs-node'
+      prefix: this.sockjsUrl
     });
 
     if (fn) {

--- a/lib/optionsSchema.json
+++ b/lib/optionsSchema.json
@@ -341,6 +341,10 @@
     "warn": {
       "description": "Customize warn logs for webpack-dev-middleware.",
       "instanceof": "Function"
+    },
+    "sockjsUrl": {
+      "description": "Customize url at which the sockjs server listens, defaults to /sockjs-node",
+      "type": "string"
     }
   },
   "type": "object"


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!
  Please note that this template is not optional.
  Please fill out _ALL_ fields, or your pull request may be rejected.
  Please do not delete this template. Please do remove this header to acknowledge this message.`

  Please note that we are NOT accepting new FEATURE requests at this time.
  Please place an x, no spaces, in all [ ] that apply
-->

- [ ] This is a **bugfix**
- [x] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **typo fix**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

<!-- Please note that we won't approve your changes if you don't add tests. -->

### Motivation / Use-Case

Currently, sockjs-node is the hardcoded sockjs path. However, in some environments it's desirable to be able to set what the sockjs path is, if it already exists (and is difficult to change). Allow users to specify the url as an arg.

### Breaking Changes

N/A

### Additional Info
