### PR TITLE
Allow user to define openOptions in config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 /ssl/*.pem
 .idea/
 .DS_Store
+yarn.lock

--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -473,11 +473,23 @@ function reportReadiness(uri, options, log) {
 
   if (options.open) {
     let openOptions = {};
-    let openMessage = 'Unable to open browser';
+    let openMessage = 'Unable to open ';
 
     if (typeof options.open === 'string') {
-      openOptions = { app: options.open };
-      openMessage += `: ${options.open}`;
+      openMessage += `${options.open}`;
+
+      if (options.openOptions) {
+        openOptions = { app: [options.open, ...options.openOptions] };
+        openMessage += ` with options: ${options.openOptions}`;
+      } else {
+        openOptions = { app: options.open };
+      }
+    } else {
+      openMessage += 'default browser';
+
+      if (options.openOptions) {
+        log.warn('To use openOptions you must specify browser name first. Options will be ignored.');
+      }
     }
 
     open(uri + (options.openPage || ''), openOptions).catch(() => {

--- a/lib/optionsSchema.json
+++ b/lib/optionsSchema.json
@@ -222,6 +222,13 @@
         }
       ]
     },
+    "openOptions": {
+      "description": "Optional options or flags for your browser open command.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
     "useLocalIp": {
       "description": "Let the browser open with your local IP.",
       "type": "boolean"

--- a/test/Validation.test.js
+++ b/test/Validation.test.js
@@ -50,7 +50,7 @@ describe('Validation', () => {
       " - configuration has an unknown property 'asdf'. These properties are valid:",
       '   object { hot?, hotOnly?, lazy?, bonjour?, host?, allowedHosts?, filename?, publicPath?, port?, socket?, ' +
       'watchOptions?, headers?, logLevel?, clientLogLevel?, overlay?, progress?, key?, cert?, ca?, pfx?, pfxPassphrase?, requestCert?, ' +
-      'inline?, disableHostCheck?, public?, https?, contentBase?, watchContentBase?, open?, useLocalIp?, openPage?, features?, ' +
+      'inline?, disableHostCheck?, public?, https?, contentBase?, watchContentBase?, open?, openOptions?, useLocalIp?, openPage?, features?, ' +
       'compress?, proxy?, historyApiFallback?, staticOptions?, setup?, before?, after?, stats?, reporter?, logTime?, ' +
       'noInfo?, quiet?, serverSideRender?, index?, log?, warn? }'
     ]


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!
  Please note that this template is not optional.
  Please fill out _ALL_ fields, or your pull request may be rejected.
  Please do not delete this template. Please do remove this header to acknowledge this message.`

  Please note that we are NOT accepting new FEATURE requests at this time.
  Please place an x, no spaces, in all [ ] that apply
-->

- [X] Unfortunately **FEATURE**
- [ ] This is a **bugfix**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **typo fix**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

There are no tests for `open` option so unfortunately due to lack of test examples no particular tests has been added with `openOptions`. However I have tested few cases/combination on my local build and with few different sets of options and projects.

### Motivation / Use-Case

Remove [webpack-browser-plugin](https://github.com/1337programming/webpack-browser-plugin) from my project.

### Breaking Changes

None?

### Additional Info

No CLI support ATM due to yargs parsing issues with open options formatted as flags i.e.: `--disable-web-security`.

I can prepare documentation updates for `webpack.js.org` when PR will be accepted.

Additionaly `yarn.lock` has been added to `.gitignore`.