### PR TITLE
speed up incremental builds by not doing excessive stats.toJSON work

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -25,7 +25,7 @@ const createLog = require('./createLog');
 const OptionsValidationError = require('./OptionsValidationError');
 const optionsSchema = require('./optionsSchema.json');
 
-const clientStats = { errorDetails: false };
+const clientStats = { errorDetails: false, chunkSortMode: 'none', chunks: false };
 
 function Server(compiler, options, _log) {
   // Default options

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -25,7 +25,7 @@ const createLog = require('./createLog');
 const OptionsValidationError = require('./OptionsValidationError');
 const optionsSchema = require('./optionsSchema.json');
 
-const clientStats = { errorDetails: false, chunkSortMode: 'none', chunks: false };
+const clientStats = { all: false, assets: true, warnings: true, errors: true, errorDetails: false };
 
 function Server(compiler, options, _log) {
   // Default options


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!
  Please note that this template is not optional.
  Please fill out _ALL_ fields, or your pull request may be rejected.
  Please do not delete this template. Please do remove this header to acknowledge this message.`

  Please note that we are NOT accepting new FEATURE requests at this time.
  Please place an x, no spaces, in all [ ] that apply
-->

- [x] This is a **bugfix**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **typo fix**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

There's no need to add tests, as it is just a configuration change to toJSON

### Motivation / Use-Case

The stats.toJSON call is done every time an incremental build finishes. Given a sufficiently large codebase, this is very SLOW (my repo went from ~30s to ~10s just by getting rid of this)

### Breaking Changes

None

### Additional Info
