### PR TITLE
[2.x backport] perf(Server): don't enable all `stats` by default

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -24,7 +24,7 @@ const webpackDevMiddleware = require('webpack-dev-middleware');
 const OptionsValidationError = require('./OptionsValidationError');
 const optionsSchema = require('./optionsSchema.json');
 
-const clientStats = { errorDetails: false };
+const clientStats = { all: false, assets: true, warnings: true, errors: true, errorDetails: false };
 const log = console.log; // eslint-disable-line no-console
 
 function Server(compiler, options) {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!
  Please note that this template is not optional.
  Please fill out _ALL_ fields, or your pull request may be rejected.
  Please do not delete this template. Please do remove this header to acknowledge this message.`

  Please note that we are NOT accepting new FEATURE requests at this time.
  Please place an x, no spaces, in all [ ] that apply
-->

- [x] This is a **bugfix**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **typo fix**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

No - tests currently covered the scenario

### Motivation / Use-Case

Merging the same speedy change from v3.x code to v2.x (we still use it since v2 is slightly faster for inc builds still for us)

### Breaking Changes

No breaking changes

### Additional Info
