### PR TITLE
Fix options schema inconsistency for `logLevel`

### DIFF
--- a/lib/optionsSchema.json
+++ b/lib/optionsSchema.json
@@ -67,14 +67,14 @@
       "type": "object"
     },
     "logLevel": {
-      "description": "Log level in the terminal/console (trace, debug, info, warn, error or none)",
+      "description": "Log level in the terminal/console (trace, debug, info, warn, error or silent)",
       "enum": [
         "trace",
         "debug",
         "info",
         "warn",
         "error",
-        "none"
+        "silent"
       ]
     },
     "clientLogLevel": {


### PR DESCRIPTION


<!--
  Thank you for submitting a pull request!
  Please note that this template is not optional.
  Please fill out _ALL_ fields, or your pull request may be rejected.
  Please do not delete this template. Please do remove this header to acknowledge this message.`

  Please note that we are NOT accepting new FEATURE requests at this time.
  Please place an x, no spaces, in all [ ] that apply
-->

- [x] This is a **bugfix**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **typo fix**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

No

### Motivation / Use-Case

I tried to use webpack-dev-server with {logLevel: 'silent'} option, but it fails with the following error
```
WebpackDevServerOptionsValidationError: Invalid configuration object. webpack-dev-server has been initialised using a configuration object that does not match the API schema.
 - configuration.logLevel should be one of these:
   "trace" | "debug" | "info" | "warn" | "error" | "none"
```
That happens because the options schema defines an incorrect 'none' value, while webpack-log expects the 'silent' value.

### Breaking Changes

### Additional Info