### PR TITLE
Use webpack-dev-middleware ^3.1.3.

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "spdy": "^3.4.1",
     "strip-ansi": "^3.0.0",
     "supports-color": "^5.1.0",
-    "webpack-dev-middleware": "3.1.2",
+    "webpack-dev-middleware": "^3.1.3",
     "webpack-log": "^1.1.2",
     "yargs": "11.0.0"
   },


### PR DESCRIPTION
Unclear why a caret is not already in use here (or even a tilde).