### PR TITLE
update webpack-dev-middleware dependency to v3.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12140,13 +12140,13 @@
       }
     },
     "webpack-dev-middleware": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.1.2.tgz",
-      "integrity": "sha512-Z11Zp3GTvCe6mGbbtma+lMB9xRfJcNtupXfmvFBujyXqLNms6onDnSi9f/Cb2rw6KkD5kgibOfxhN7npZwTiGA==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.1.3.tgz",
+      "integrity": "sha512-I6Mmy/QjWU/kXwCSFGaiOoL5YEQIVmbb0o45xMoCyQAg/mClqZVTcsX327sPfekDyJWpCxb+04whNyLOIxpJdQ==",
       "requires": {
         "loud-rejection": "1.6.0",
         "memory-fs": "0.4.1",
-        "mime": "2.2.2",
+        "mime": "2.3.1",
         "path-is-absolute": "1.0.1",
         "range-parser": "1.2.0",
         "url-join": "4.0.0",
@@ -12154,9 +12154,9 @@
       },
       "dependencies": {
         "mime": {
-          "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-2.2.2.tgz",
-          "integrity": "sha512-A7PDg4s48MkqFEcYg2b069m3DXOEq7hx+9q9rIFrSSYfzsh35GX+LOVMQ8Au0ko7d8bSQCIAuzkjp0vCtwENlQ=="
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.3.1.tgz",
+          "integrity": "sha512-OEUllcVoydBHGN1z84yfQDimn58pZNNNXgZlHXSboxMlFvgI6MXSWpWKpFRra7H1HxpVhHTkrghfRW49k6yjeg=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "spdy": "^3.4.1",
     "strip-ansi": "^3.0.0",
     "supports-color": "^5.1.0",
-    "webpack-dev-middleware": "3.1.2",
+    "webpack-dev-middleware": "^3.1.3",
     "webpack-log": "^1.1.2",
     "yargs": "11.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "spdy": "^3.4.1",
     "strip-ansi": "^3.0.0",
     "supports-color": "^5.1.0",
-    "webpack-dev-middleware": "^3.1.3",
+    "webpack-dev-middleware": "3.1.3",
     "webpack-log": "^1.1.2",
     "yargs": "11.0.0"
   },


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!
  Please note that this template is not optional.
  Please fill out _ALL_ fields, or your pull request may be rejected.
  Please do not delete this template. Please do remove this header to acknowledge this message.`

  Please note that we are NOT accepting new FEATURE requests at this time.
  Please place an x, no spaces, in all [ ] that apply
-->

- [x] This is a **bugfix**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **typo fix**
- [ ] This is a **metadata update**

### Motivation / Use-Case
Spaces in the `outputPath` are not being handled correctly on Windows.
This change addresses the regression which introduced the bug and is being tracked in https://github.com/webpack/webpack-dev-server/issues/1375

The only change made is that the `package.json` has been updated to reference v3.1.3 of webpack-dev-middleware. 

The issue was corrected here:
https://github.com/webpack/webpack-dev-middleware/issues/297