### PR TITLE
don't use argv outside of processOptions function.

### DIFF
--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -351,6 +351,10 @@ function processOptions(webpackOptions) {
 
   if (argv.useLocalIp) { options.useLocalIp = true; }
 
+  if (argv.profile) { options.profile = true; }
+
+  if (argv.color) { options.color = true; }
+
   // Kind of weird, but ensures prior behavior isn't broken in cases
   // that wouldn't throw errors. E.g. both argv.port and options.port
   // were specified, but since argv.port is 8080, options.port will be
@@ -387,7 +391,7 @@ function startDevServer(webpackOptions, options) {
 
   if (options.progress) {
     new webpack.ProgressPlugin({
-      profile: argv.profile
+      profile: options.profile
     }).apply(compiler);
   }
 
@@ -454,7 +458,7 @@ function startDevServer(webpackOptions, options) {
 }
 
 function reportReadiness(uri, options, log) {
-  const useColor = argv.color;
+  const useColor = options.color;
   const contentBase = Array.isArray(options.contentBase) ? options.contentBase.join(', ') : options.contentBase;
 
   if (options.socket) {

--- a/lib/optionsSchema.json
+++ b/lib/optionsSchema.json
@@ -341,6 +341,14 @@
     "warn": {
       "description": "Customize warn logs for webpack-dev-middleware.",
       "instanceof": "Function"
+    },
+    "profile": {
+      "description": "Profile the compilation and include information in stats.",
+      "type": "boolean"
+    },
+    "color": {
+      "description": "Enables/Disables colors on the console.",
+      "type": "boolean"
     }
   },
   "type": "object"

--- a/test/Validation.test.js
+++ b/test/Validation.test.js
@@ -52,7 +52,7 @@ describe('Validation', () => {
       'watchOptions?, headers?, logLevel?, clientLogLevel?, overlay?, progress?, key?, cert?, ca?, pfx?, pfxPassphrase?, requestCert?, ' +
       'inline?, disableHostCheck?, public?, https?, contentBase?, watchContentBase?, open?, useLocalIp?, openPage?, features?, ' +
       'compress?, proxy?, historyApiFallback?, staticOptions?, setup?, before?, after?, stats?, reporter?, logTime?, ' +
-      'noInfo?, quiet?, serverSideRender?, index?, log?, warn? }'
+      'noInfo?, quiet?, serverSideRender?, index?, log?, warn?, profile?, color? }'
     ]
   }];
   testCases.forEach((testCase) => {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!
  Please note that this template is not optional.
  Please fill out _ALL_ fields, or your pull request may be rejected.
  Please do not delete this template. Please do remove this header to acknowledge this message.`

  Please note that we are NOT accepting new FEATURE requests at this time.
  Please place an x, no spaces, in all [ ] that apply
-->

- [ ] This is a **bugfix**
- [x] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **typo fix**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

<!-- Please note that we won't approve your changes if you don't add tests. -->

### Motivation / Use-Case
I want to use the webpack-dev-server from my js code (not command line). To do that I will need to separate command line arguments passing. Mostly it is easy to do, but in those 2 places global argv is unfortunately referenced.
<!--
  Please explain the motivation or use-case for making this change.
  What existing problem does the pull request solve?
  If this Pull Request addresses an issue, please link to the issue.
-->

### Breaking Changes
None
<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info
