### PR TITLE
fix(examples/cli): correct template path in `open-page` example

### DIFF
--- a/examples/cli/open-page/webpack.config.js
+++ b/examples/cli/open-page/webpack.config.js
@@ -11,7 +11,7 @@ module.exports = setup({
   plugins: [
     new HtmlWebpackPlugin({
       filename: 'example.html',
-      template: '../../assets/layout.html',
+      template: '../../.assets/layout.html',
       title: 'Open Page / Example'
     })
   ]


### PR DESCRIPTION
Otherwise is returning  an _Html Webpack Plugin_ error:

```
Error: Child compilation failed:
Entry module not found: Error: Can't resolve '/(...)/webpack/webpack-dev-server/examples/assets/layout.html
```

<!--
  Thank you for submitting a pull request!
  Please note that this template is not optional.
  Please fill out _ALL_ fields, or your pull request may be rejected.
  Please do not delete this template. Please do remove this header to acknowledge this message.`

  Please note that we are NOT accepting new FEATURE requests at this time.
  Please place an x, no spaces, in all [ ] that apply
-->

- [ ] This is a **bugfix**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [x] This is a **typo fix**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

<!-- Please note that we won't approve your changes if you don't add tests. -->

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for making this change.
  What existing problem does the pull request solve?
  If this Pull Request addresses an issue, please link to the issue.
-->

Trying to test the `--open` behaviour, first approach is to check the _example_
and seems broken finding a wrong `path`.

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info
