### PR TITLE
patch: Bumps chokidar to 2.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1991,9 +1991,9 @@
       "dev": true
     },
     "chokidar": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.2.tgz",
-      "integrity": "sha512-l32Hw3wqB0L2kGVmSbK/a+xXLDrUEsc84pSgMkmwygHvD7ubRsP/vxxHa5BtB6oix1XLLVCHyYMsckRXxThmZw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.3.tgz",
+      "integrity": "sha512-zW8iXYZtXMx4kux/nuZVXjkLP+CyIK5Al5FHnj1OgTKGZfp4Oy6/ymtMSKFv3GD8DviEmUPmJg9eFdJ/JzudMg==",
       "requires": {
         "anymatch": "2.0.0",
         "async-each": "1.0.1",
@@ -2006,7 +2006,7 @@
         "normalize-path": "2.1.1",
         "path-is-absolute": "1.0.1",
         "readdirp": "2.1.0",
-        "upath": "1.0.4"
+        "upath": "1.0.5"
       }
     },
     "chownr": {
@@ -11592,9 +11592,9 @@
       "dev": true
     },
     "upath": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/upath/-/upath-1.0.4.tgz",
-      "integrity": "sha512-d4SJySNBXDaQp+DPrziv3xGS6w3d2Xt69FijJr86zMPBy23JEloMCEOUBBzuN7xCtjLCnmB9tI/z7SBCahHBOw=="
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/upath/-/upath-1.0.5.tgz",
+      "integrity": "sha512-qbKn90aDQ0YEwvXoLqj0oiuUYroLX2lVHZ+b+xwjozFasAOC4GneDq5+OaIG5Zj+jFmbz/uO+f7a9qxjktJQww=="
     },
     "upper-case": {
       "version": "1.1.3",
@@ -11929,7 +11929,7 @@
       "integrity": "sha512-RSlipNQB1u48cq0wH/BNfCu1tD/cJ8ydFIkNYhp9o+3d+8unClkIovpW5qpFPgmL9OE48wfAnlZydXByWP82AA==",
       "dev": true,
       "requires": {
-        "chokidar": "2.0.2",
+        "chokidar": "2.0.3",
         "graceful-fs": "4.1.11",
         "neo-async": "2.5.0"
       }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "ansi-html": "0.0.7",
     "array-includes": "^3.0.3",
     "bonjour": "^3.5.0",
-    "chokidar": "^2.0.0",
+    "chokidar": "^2.0.3",
     "compression": "^1.5.2",
     "connect-history-api-fallback": "^1.3.0",
     "debug": "^3.1.0",


### PR DESCRIPTION
- [ ] This is a **bugfix**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **typo fix**
- [ ] This is a **metadata update**

### Motivation / Use-Case

While updating a project leveraging webpack-dev-server to Node v10 we've encountered an issue with the `engine` compatibility definition for [upath](https://www.npmjs.com/package/upath). They have fixed that in their own repo (see https://github.com/anodynos/upath/issues/14).

webpack-dev-server uses upath through [chokidar](https://www.npmjs.com/package/chokidar). They have also fixed this engine requirement (as in locking upath to a certain version before the fix) in a recent patch (see https://github.com/paulmillr/chokidar/issues/710).

### Breaking Changes

None