### PR TITLE
Fix path to webpack client hot reload scripts to be resolved relatively

### DIFF
--- a/lib/util/addDevServerEntrypoints.js
+++ b/lib/util/addDevServerEntrypoints.js
@@ -17,7 +17,11 @@ module.exports = function addDevServerEntrypoints(webpackOptions, devServerOptio
     const domain = createDomain(devServerOptions, app);
     const devClient = [`${require.resolve('../../client/')}?${domain}`];
 
-    if (devServerOptions.hotOnly) { devClient.push('webpack/hot/only-dev-server'); } else if (devServerOptions.hot) { devClient.push('webpack/hot/dev-server'); }
+    if (devServerOptions.hotOnly) {
+      devClient.push(require.resolve('webpack/hot/only-dev-server'));
+    } else if (devServerOptions.hot) {
+      devClient.push(require.resolve('webpack/hot/dev-server'));
+    }
 
     const prependDevClient = (entry) => {
       if (typeof entry === 'function') {

--- a/test/Entry.test.js
+++ b/test/Entry.test.js
@@ -110,4 +110,38 @@ describe('Entry', () => {
       })
     )).catch(done);
   });
+
+  it('prepends webpack\'s hot reload client script', () => {
+    const webpackOptions = Object.assign({}, config, {
+      entry: {
+        app: './app.js'
+      }
+    });
+    const devServerOptions = {
+      hot: true
+    };
+
+    addDevServerEntrypoints(webpackOptions, devServerOptions);
+
+    const hotClientScript = webpackOptions.entry.app[1];
+    assert.equal(hotClientScript.includes('webpack/hot/dev-server'), true);
+    assert.equal(hotClientScript, require.resolve(hotClientScript));
+  });
+
+  it('prepends webpack\'s hot-only client script', () => {
+    const webpackOptions = Object.assign({}, config, {
+      entry: {
+        app: './app.js'
+      }
+    });
+    const devServerOptions = {
+      hotOnly: true
+    };
+
+    addDevServerEntrypoints(webpackOptions, devServerOptions);
+
+    const hotClientScript = webpackOptions.entry.app[1];
+    assert.equal(hotClientScript.includes('webpack/hot/only-dev-server'), true);
+    assert.equal(hotClientScript, require.resolve(hotClientScript));
+  });
 });


### PR DESCRIPTION
- [x] This is a **bugfix**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **typo fix**
- [ ] This is a **metadata update**

### Motivation / Use-Case

This PR solves an issue in projects that use yarn workspaces, in which there are two different versions of `webpack` get installed:
```
yarn list webpack
├─ webpack@3.11.0
└─ package-A@1.0.0
   └─ webpack@4.1.1
```
In that case when package-A starts a webpack-dev-server the webpack client scripts appended to the entry scripts are resolved against project root that gets resolved to webpack@3.11.0, which is a different version of webpack that is required by package-A