### PR TITLE
Explanation for generating certificates in Win7

### DIFF
--- a/examples/cli/https/README.md
+++ b/examples/cli/https/README.md
@@ -8,8 +8,20 @@ certificate is only good for 30 days, at which point it'll be regenerated.
 We highly recommend creating and managing your own certificates. Please see the
 following resources for doing so:
 
-* (MacOS) https://certsimple.com/blog/localhost-ssl-fix
-* (Windows) https://technet.microsoft.com/itpro/powershell/windows/pkiclient/new-selfsignedcertificate
+### MacOS
+https://certsimple.com/blog/localhost-ssl-fix
+
+### Windows 10
+https://technet.microsoft.com/itpro/powershell/windows/pkiclient/new-selfsignedcertificate
+
+### Windows 7
+https://msdn.microsoft.com/en-us/library/aa386968.aspx
+
+Example (the .pfx file generated the following way can be used without `--pfx-passphrase`):
+```
+makecert -r -pe -sky exchange -sv makecert.pvk makecert.cer
+pvk2pfx -pvk makecert.pvk -spc makecert.cer -pfx makecert.pfx
+```
 
 ## Getting Started
 


### PR DESCRIPTION
- [ ] This is a **bugfix**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **typo fix**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

Not a code change.

### Motivation / Use-Case

Since Windows 7 still has a market share of 40% among Windows versions, I think a workflow supported by it is worth mentioning.
And also an example, since using makecert [is tricky for newcomers](https://stackoverflow.com/questions/9506671/why-do-i-keep-getting-a-failed-when-trying-to-make-a-cer-for-testing/35316218) and I for one was not sure whether supplying a PFX without a passphrase would even work.

### Breaking Changes

None.

### Additional Info

None.