### PR TITLE
sendMsg('Progress', data)

### DIFF
--- a/client-src/default/index.js
+++ b/client-src/default/index.js
@@ -129,6 +129,7 @@ const onSocketMsg = {
   },
   'progress-update': function progressUpdate(data) {
     if (useProgress) log.info(`[WDS] ${data.percent}% - ${data.msg}.`);
+    sendMsg('Progress', data);
   },
   ok() {
     sendMsg('Ok');


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!
  Please note that this template is not optional.
  Please fill out _ALL_ fields, or your pull request may be rejected.
  Please do not delete this template. Please do remove this header to acknowledge this message.`

  Please note that we are NOT accepting new FEATURE requests at this time.
  Please place an x, no spaces, in all [ ] that apply
-->

- [x] This is a **bugfix**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **typo fix**
- [ ] This is a **metadata update**

### Motivation / Use-Case
One line change.

Context: we maintain a module that shows a webpack status bar on the browser page. It handles ok, error, status e.t.c messages but since progress isn't sent out we can't respond to that.

https://github.com/mixpanel/webpack-dev-server-status-bar

The goal is to make the bar respond to progress by showing a fixed bar on top that increases in width as progress increases. For this to happen webpack-dev-server needs to send the event via `postMessage`

### Breaking Changes

No breaking changes.