### PR TITLE
fix(bin): handle `process` signals correctly when the server isn't ready yet

### DIFF
--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -15,6 +15,20 @@ const addDevServerEntrypoints = require('../lib/util/addDevServerEntrypoints');
 const createDomain = require('../lib/util/createDomain'); // eslint-disable-line
 const createLog = require('../lib/createLog');
 
+let server;
+
+['SIGINT', 'SIGTERM'].forEach((sig) => {
+  process.on(sig, () => {
+    if (server) {
+      server.close(() => {
+        process.exit(); // eslint-disable-line no-process-exit
+      });
+    } else {
+      process.exit(); // eslint-disable-line no-process-exit
+    }
+  });
+});
+
 // Prefer the local installation of webpack-dev-server
 if (importLocal(__filename)) {
   debug('Using local install of webpack-dev-server');
@@ -392,7 +406,6 @@ function startDevServer(webpackOptions, options) {
 
   const suffix = (options.inline !== false || options.lazy === true ? '/' : '/webpack-dev-server/');
 
-  let server;
   try {
     server = new Server(compiler, options, log);
   } catch (e) {
@@ -403,14 +416,6 @@ function startDevServer(webpackOptions, options) {
     }
     throw e;
   }
-
-  ['SIGINT', 'SIGTERM'].forEach((sig) => {
-    process.on(sig, () => {
-      server.close(() => {
-        process.exit(); // eslint-disable-line no-process-exit
-      });
-    });
-  });
 
   if (options.socket) {
     server.listeningApp.on('error', (e) => {

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -46,4 +46,25 @@ describe('CLI', () => {
       done();
     });
   }).timeout(18000);
+
+  it('should exit the process when SIGINT is detected, even before the compilation is done', (done) => {
+    const cliPath = path.resolve(__dirname, '../bin/webpack-dev-server.js');
+    const examplePath = path.resolve(__dirname, '../examples/cli/public');
+    const nodePath = execa.shellSync('which node').stdout;
+
+    const proc = execa(nodePath, [cliPath], { cwd: examplePath });
+
+    let killed = false;
+    proc.stdout.on('data', () => {
+      if (!killed) {
+        assert(proc.pid !== 0);
+        proc.kill('SIGINT');
+      }
+      killed = true;
+    });
+
+    proc.on('exit', () => {
+      done();
+    });
+  }).timeout(18000);
 });


### PR DESCRIPTION
### Type

- [x] Fix
 
### Issues

- Fixes #1360

### SemVer

- [x] Patch