### PR TITLE
feat(Server): exclude client scripts for `node` targets

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -68,6 +68,7 @@ function Server(compiler, options, _log) {
   }
 
   const addCompilerHooks = (comp) => {
+    if (!['async-node', 'node'].includes(comp.options.target)) return;
     comp.hooks.compile.tap('webpack-dev-server', invalidPlugin);
     comp.hooks.invalid.tap('webpack-dev-server', invalidPlugin);
     comp.hooks.done.tap('webpack-dev-server', (stats) => {

--- a/lib/util/addDevServerEntrypoints.js
+++ b/lib/util/addDevServerEntrypoints.js
@@ -38,6 +38,7 @@ module.exports = function addDevServerEntrypoints(webpackOptions, devServerOptio
     };
 
     [].concat(webpackOptions).forEach((wpOpt) => {
+      if (['async-node', 'node'].includes(wpOpt.target)) return;
       wpOpt.entry = prependDevClient(wpOpt.entry || './src');
     });
   }


### PR DESCRIPTION
```bash
git clone git@github.com:EloB/ssr.git
cd ssr/node_modules/webpack-dev-server # <- This is using my branch
npm install # Install all dependencies
npm run prepublish # To build all client scripts
cd ../../
npm run dev
```

### Type 

- [x] Feature

### Issues

- Fixes #1256 
- Fixes #1338

### SemVer

- [x] Minor