### PR TITLE
Upgrade chokidar dependency to support Node 10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5221,7 +5221,8 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "combined-stream": {
           "version": "1.0.5",
@@ -5526,6 +5527,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5714,7 +5716,8 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "oauth-sign": {
           "version": "0.8.2",
@@ -5942,6 +5945,7 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "ansi-html": "0.0.7",
     "array-includes": "^3.0.3",
     "bonjour": "^3.5.0",
-    "chokidar": "^2.0.0",
+    "chokidar": "^2.0.4",
     "compression": "^1.5.2",
     "connect-history-api-fallback": "^1.3.0",
     "debug": "^3.1.0",


### PR DESCRIPTION
- [ ] This is a **bugfix**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **typo fix**
- [x] This is a **metadata update**

### Motivation / Use-Case

Chokidar depends on a package called `upath` and upath had a max node version of 9. This has now been removed in upath (see: https://github.com/anodynos/upath/commit/8c5f4e10376ed1cd4553d9432297d39a34410c69#diff-b9cfc7f2cdf78a7f4b91a753d10865a2) and chokidar updated upath to v 1.0.5. 

I'm trying to use node 10 now and am unable to install webpack-dev-server because of the old upath node version 
