### PR TITLE
fix CONTRIBUTING.md PR test dependency

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ Pull requests often need some real-world testing.
 1. In your `package.json`, change the line with `webpack-dev-server` to:
 
   ```json
-  "webpack-dev-server": "webpack/webpack-dev-server#<ID>/head"
+  "webpack-dev-server": "github:webpack/webpack-dev-server#pull/<ID>/head"
   ```
 
   `<ID>` is the ID of the pull request.


### PR DESCRIPTION
- [x] This is a **bugfix**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **typo fix**
- [ ] This is a **metadata update**

### Motivation / Use-Case

Fixes incorrect dependency line for testing PRs in CONTRIBUTING.md.

### Additional Info

Also be aware that this doesn't work on npm@5.x.x, but works on other versions of npm (tested 4 and 6) (current version in CONTRIBUTING.md doesn't work at all)