### PR TITLE
fix(utils/createLogger): ensure `quiet` always takes precedence (`options.quiet`)

### DIFF
--- a/lib/utils/createLogger.js
+++ b/lib/utils/createLogger.js
@@ -8,12 +8,12 @@ const log = require('webpack-log');
 function createLogger (options) {
   let level = options.logLevel || 'info';
 
-  if (options.quiet === true) {
-    level = 'silent';
-  }
-
   if (options.noInfo === true) {
     level = 'warn';
+  }
+
+  if (options.quiet === true) {
+    level = 'silent';
   }
 
   return log({


### PR DESCRIPTION

<!--
  Thank you for submitting a pull request!
  Please note that this template is not optional.
  Please fill out _ALL_ fields, or your pull request may be rejected.
  Please do not delete this template. Please do remove this header to acknowledge this message.`

  Please note that we are NOT accepting new FEATURE requests at this time.
  Please place an x, no spaces, in all [ ] that apply
-->

- [x] This is a **bugfix**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **typo fix**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

Doesn't look like `logLevel` is currently tested, aside from validation. Also not sure how to test this~

### Motivation / Use-Case

Setting `noInfo` and `quiet` to `true` still reported errors (and warnings), despite the fact that `quiet` should silence everything.

### Breaking Changes

N/A

### Additional Info

Screenshot includes `wdm` error message. Also displaying the full `devServer` config above it. 

<img width="673" alt="screen shot 2018-09-02 at 12 43 38 pm" src="https://user-images.githubusercontent.com/5855893/44960292-bee62b80-aeb1-11e8-8086-9f72c880bc33.png">
