### PR TITLE
chore(package): add `webpack-cli` as peer dependency (`peerDependencies`)

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,8 @@
     "ws": "^6.0.0"
   },
   "peerDependencies": {
-    "webpack": "^4.0.0"
+    "webpack": "^4.0.0",
+    "webpack-cli": "^3.1.0"
   },
   "author": "Tobias Koppers @sokra",
   "bugs": "https://github.com/webpack/webpack-dev-server/issues",


### PR DESCRIPTION
As `webpack-dev-server` requires `webpack-cli` indeed:

https://github.com/webpack/webpack-dev-server/blob/3d37cc5a4a4fc06f0649db8d382ef8484ff73131/bin/webpack-dev-server.js#L84

I couldn't determine which semver of `webpack-cli` is required, and I just copy `^3.1.0` from `devDependencies` for now.

### Type

- [x] Chore

### Issues

- None

### SemVer

- [x] Patch