### PR TITLE
fix(webpack-dev-server): patch the output of webpack with devServer options

### DIFF
--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -331,6 +331,8 @@ function startDevServer(config, options) {
 
   let compiler;
 
+  config.output = Object.assign({}, config.output, { publicPath: createDomain(options) + options.publicPath });
+
   try {
     compiler = webpack(config);
   } catch (err) {

--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -38,6 +38,7 @@ const {
 const Server = require('../lib/Server');
 
 const addEntries = require('../lib/utils/addEntries');
+const patchPublicPath = require('../lib/utils/patchPublicPath');
 const createDomain = require('../lib/utils/createDomain');
 const createLogger = require('../lib/utils/createLogger');
 
@@ -328,11 +329,9 @@ function startDevServer(config, options) {
   const log = createLogger(options);
 
   addEntries(config, options);
+  patchPublicPath(config, options);
 
   let compiler;
-
-  const publicPath = options.publicPath || config.output.PublicPath
-  config.output = Object.assign({}, config.output, { publicPath: createDomain(options) + publicPath });
 
   try {
     compiler = webpack(config);

--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -331,7 +331,8 @@ function startDevServer(config, options) {
 
   let compiler;
 
-  config.output = Object.assign({}, config.output, { publicPath: createDomain(options) + options.publicPath });
+  const publicPath = options.publicPath || config.output.PublicPath
+  config.output = Object.assign({}, config.output, { publicPath: createDomain(options) + publicPath });
 
   try {
     compiler = webpack(config);

--- a/lib/utils/patchPublicPath.js
+++ b/lib/utils/patchPublicPath.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const createDomain = require('./createDomain');
+
+function patchPublicPath(config, options) {
+  if (options.public) {
+    const publicPath = options.publicPath || config.output.publicPath;
+
+    config.output = Object.assign({}, config.output, { publicPath: createDomain(options) + publicPath });
+  }
+}
+
+module.exports = patchPublicPath;

--- a/test/patchPublicPath.test.js
+++ b/test/patchPublicPath.test.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const assert = require('assert');
+const patchPublicPath = require('../lib/utils/patchPublicPath');
+
+describe('PublicPath', () => {
+  it('uses config output by default', () => {
+    const config = {
+      output: { publicPath: '/abc/' }
+    };
+    const devServerOptions = {};
+
+    patchPublicPath(config, devServerOptions);
+
+    assert.equal('/abc/', config.output.publicPath);
+  });
+
+  it('overrides the domain', () => {
+    const config = {
+      output: { public: 'example.com', publicPath: '/abc/' }
+    };
+    const devServerOptions = {
+      public: 'somewhereelse.com:9999'
+    };
+
+    patchPublicPath(config, devServerOptions);
+
+    assert.equal('http://somewhereelse.com:9999/abc/', config.output.publicPath);
+  });
+
+  it('overrides the publicPath', () => {
+    const config = {
+      output: { public: 'example.com', publicPath: '/original/' }
+    };
+    const devServerOptions = {
+      public: 'somewhereelse.com:9999',
+      publicPath: '/patched/'
+    };
+
+    patchPublicPath(config, devServerOptions);
+
+    assert.equal('http://somewhereelse.com:9999/patched/', config.output.publicPath);
+  });
+});


### PR DESCRIPTION
- [x] This is a **bugfix**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **typo fix**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

I am fairly new to webpack's codebase, and not sure how to test this. With a few pointers, I will be happy to add them.
I am not sure how to test that a file change would trigger a change to the `hot-update.json` manifest and that this one is requested at the right url.

### Motivation / Use-Case

When serving an app from a different domain and/or port, the `hot-update.json` request result in a 404.

This has been discussed here:
https://github.com/webpack/webpack-dev-server/issues/1385
https://github.com/webpack/webpack/pull/8112

Here is a minimal reproduction repository for the issue https://github.com/krzystof/webpack-issue-repro

In addition to this change, the `webpack.config.js` devServer options must include `public: 'domain:port'` to allow the dev server to fetch the manifest at the correct location.

### Breaking Changes

When using the dev server, I believe that the original output config is ignored. If that's right, there is no breaking change.

### Additional Info
