### PR TITLE
fix(options): add `writeToDisk` option to schema

### DIFF
--- a/lib/options.json
+++ b/lib/options.json
@@ -54,6 +54,16 @@
     "watchOptions": {
       "type": "object"
     },
+    "writeToDisk": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "instanceof": "Function"
+        }
+      ]
+    },
     "headers": {
       "type": "object"
     },
@@ -312,6 +322,7 @@
       "port": "should be {String|Number} (https://webpack.js.org/configuration/dev-server/#devserver-port)",
       "socket": "should be {String} (https://webpack.js.org/configuration/dev-server/#devserver-socket)",
       "watchOptions": "should be {Object} (https://webpack.js.org/configuration/dev-server/#devserver-watchoptions)",
+      "writeToDisk": "should be {Boolean|Function} (https://github.com/webpack/webpack-dev-middleware#writetodisk)",
       "headers": "should be {Object} (https://webpack.js.org/configuration/dev-server/#devserver-headers-)",
       "clientLogLevel": "should be {String} and equal to one of the allowed values\n\n [ 'trace', 'debug', 'info', 'warn', 'error', 'silent' ]\n\n(https://webpack.js.org/configuration/dev-server/#devserver-clientloglevel)",
       "overlay": "should be {Object|Boolean} (https://webpack.js.org/configuration/dev-server/#devserver-overlay)",

--- a/test/Validation.test.js
+++ b/test/Validation.test.js
@@ -27,6 +27,11 @@ describe('Validation', () => {
       message: 'options.logLevel should be {String} and equal to one of the allowed values'
     },
     {
+      name: 'invalid `writeToDisk` configuration',
+      config: { writeToDisk: 1 },
+      message: 'options.writeToDisk should be {Boolean|Function} (https://github.com/webpack/webpack-dev-middleware#writetodisk)\n'
+    },
+    {
       name: 'invalid `overlay` configuration',
       config: { overlay: { errors: 1 } },
       message: 'options.overlay should be {Object|Boolean} (https://webpack.js.org/configuration/dev-server/#devserver-overlay)\n'


### PR DESCRIPTION
According to https://github.com/webpack/webpack-dev-middleware#watchoptions
- [x] This is a **feature**
- [ ] This is a **bugfix**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **typo fix**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

Yes

### Motivation / Use-Case

Closes https://github.com/webpack/webpack-dev-server/issues/1357

### Breaking Changes

None
