### PR TITLE
fix(Server): set `tls.DEFAULT_ECDH_CURVE` to `'auto'`

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -13,6 +13,7 @@ const fs = require('fs');
 const path = require('path');
 
 const ip = require('ip');
+const tls = require('tls');
 const url = require('url');
 const http = require('http');
 const https = require('https');
@@ -39,6 +40,16 @@ const createCertificate = require('./utils/createCertificate');
 
 const validateOptions = require('schema-utils');
 const schema = require('./options.json');
+
+// Workaround for node ^8.6.0, ^9.0.0
+// DEFAULT_ECDH_CURVE is default to prime256v1 in these version
+// breaking connection when certificate is not signed with prime256v1
+// change it to auto allows OpenSSL to select the curve automatically
+// See https://github.com/nodejs/node/issues/16196 for more infomation
+const version = parseFloat(process.version.slice(1));
+if (version >= 8.6 && version < 10) {
+  tls.DEFAULT_ECDH_CURVE = 'auto';
+}
 
 const STATS = {
   all: false,
@@ -581,7 +592,7 @@ function Server (compiler, options = {}, _log) {
     // - https://github.com/nodejs/node/issues/21665
     // - https://github.com/webpack/webpack-dev-server/issues/1449
     // - https://github.com/expressjs/express/issues/3388
-    if (+process.version.match(/^v(\d+)/)[1] >= 10) {
+    if (version >= 10) {
       this.listeningApp = https.createServer(options.https, app);
     } else {
       this.listeningApp = spdy.createServer(options.https, app);


### PR DESCRIPTION
- [x] This is a **bugfix**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **typo fix**
- [ ] This is a **metadata update**

The default value of tls.DEFAULT_ECDH_CURVE is 'prime256v1',
it breaks the connection when certificate is not compatible
with the default curve since node^8.6.0.

To fix this issue, we need set it to 'auto', makes OpenSSL
select the curve automatically.
