### PR TITLE
feat(webpack-dev-server): add `WEBPACK_DEV_SERVER` environment variable

### DIFF
--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -92,6 +92,8 @@ yargs.options(options);
 
 const argv = yargs.argv;
 
+process.env.WEBPACK_DEV_SERVER = true;
+
 // webpack-cli@3.3 path : 'webpack-cli/bin/utils/convert-argv'
 let convertArgvPath;
 try {

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -90,6 +90,8 @@ class Server {
       throw new Error("'filename' option must be set in lazy mode.");
     }
 
+    process.env.WEBPACK_DEV_SERVER = true;
+
     // if the user enables http2, we can safely enable https
     if (options.http2 && !options.https) {
       options.https = true;

--- a/test/Server.test.js
+++ b/test/Server.test.js
@@ -8,6 +8,13 @@ const config = require('./fixtures/simple-config/webpack.config');
 const helper = require('./helper');
 
 describe('Server', () => {
+  it('process.env.WEBPACK_DEV_SERVER', () => {
+    const compiler = webpack(config);
+    // eslint-disable-next-line no-new
+    new Server(compiler);
+    expect(process.env.WEBPACK_DEV_SERVER).toBeTruthy();
+  });
+
   describe('addEntries', () => {
     it('add hot option', () => {
       return new Promise((res) => {

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -17,6 +17,15 @@ const keyPath = path.join(httpsCertificateDirectory, 'server.key');
 const certPath = path.join(httpsCertificateDirectory, 'server.crt');
 
 describe('CLI', () => {
+  it('process.env.WEBPACK_DEV_SERVER', (done) => {
+    runDevServer()
+      .then(() => {
+        expect(process.env.WEBPACK_DEV_SERVER).toBeTruthy();
+        done();
+      })
+      .catch(done);
+  });
+
   it('--progress', (done) => {
     runDevServer('--progress')
       .then((output) => {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!
  Please note that this template is not optional.
  Please fill out _ALL_ fields, or your pull request may be rejected.
  Please do not delete this template. Please do remove this header to acknowledge this message.`

  Please note that we are NOT accepting new FEATURE requests at this time.
  Please place an x, no spaces, in all [ ] that apply
-->

- [ ] This is a **bugfix**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **typo fix**
- [ ] This is a **metadata update**
- [x] This is a **feature** ← It looks like this is missing in the template? ⚠️

### For Bugs and Features; did you add new tests?

No. I just added it in the same way `webpack-serve` did it and they had no test for this either 🤔As this was an official package before I assume it's okay for this one as well? 

<!-- Please note that we won't approve your changes if you don't add tests. -->

### Motivation / Use-Case

As described here: https://github.com/webpack/webpack-dev-server/issues/1532.

<!--
  Please explain the motivation or use-case for making this change.
  What existing problem does the pull request solve?
  If this Pull Request addresses an issue, please link to the issue.
-->

### Breaking Changes

No.

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info

I placed this just before `require('webpack-cli/bin/convert-argv')` which will require my config and this env variable should be visible for the config file.

👋