### PR TITLE
fix(Server): correct `node` version checks

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -20,6 +20,8 @@ const https = require('https');
 const spdy = require('spdy');
 const sockjs = require('sockjs');
 
+const semver = require('semver');
+
 const killable = require('killable');
 
 const del = require('del');
@@ -46,8 +48,7 @@ const schema = require('./options.json');
 // breaking connection when certificate is not signed with prime256v1
 // change it to auto allows OpenSSL to select the curve automatically
 // See https://github.com/nodejs/node/issues/16196 for more infomation
-const version = parseFloat(process.version.slice(1));
-if (version >= 8.6 && version < 10) {
+if (semver.satisfies(process.version, '8.6.0 - 9')) {
   tls.DEFAULT_ECDH_CURVE = 'auto';
 }
 
@@ -592,7 +593,7 @@ function Server (compiler, options = {}, _log) {
     // - https://github.com/nodejs/node/issues/21665
     // - https://github.com/webpack/webpack-dev-server/issues/1449
     // - https://github.com/expressjs/express/issues/3388
-    if (version >= 10) {
+    if (semver.gte(process.version, '10.0.0')) {
       this.listeningApp = https.createServer(options.https, app);
     } else {
       this.listeningApp = spdy.createServer(options.https, app);

--- a/package-lock.json
+++ b/package-lock.json
@@ -10393,9 +10393,9 @@
       }
     },
     "semver": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
-      "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw=="
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
     },
     "send": {
       "version": "0.16.2",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "portfinder": "^1.0.9",
     "schema-utils": "^1.0.0",
     "selfsigned": "^1.9.1",
+    "semver": "^5.6.0",
     "serve-index": "^1.7.2",
     "sockjs": "0.3.19",
     "sockjs-client": "1.3.0",


### PR DESCRIPTION
- [x] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

In pull request https://github.com/webpack/webpack-dev-server/pull/1531 we add a workaround for ECDH curve choice from node@^8.6.0 to node@10. We use parsed number to compare the version but it won't work as expected when compare like 8.12 to 8.6.

To fix this use version compare library is the best choice, since `semver` has been introduced into dependency tree by `chokidar`, choose it will not add package size.