### PR TITLE
feat(Server): add `/invalidate` endpoint

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -299,6 +299,11 @@ class Server {
       res.end('</body></html>');
     });
 
+    app.get('/invalidate', (_req, res) => {
+      this.invalidate();
+      res.end();
+    });
+
     let contentBase;
 
     if (options.contentBase !== undefined) {

--- a/test/Routes.test.js
+++ b/test/Routes.test.js
@@ -33,6 +33,10 @@ describe('Routes', () => {
       .expect(200, done);
   });
 
+  it('GET request to invalidate endpoint', (done) => {
+    req.get('/invalidate').expect(200, done);
+  });
+
   it('GET request to live bundle', (done) => {
     req
       .get('/__webpack_dev_server__/live.bundle.js')


### PR DESCRIPTION
- [ ] This is a **bugfix**
- [x] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

Sadly no. How should I go about testing this? Happy to work something up given some direction.

### Motivation / Use-Case

We're trying to use docker-compose for local development of a giant monolithic rails app that uses webpack for several pages written with react. For performance reasons, we're mounting a volume inside the rails container using NFS, which doesn't support file system events. Consequently, making changes to our react components doesn't trigger an automatic webpack refresh. This PR is an attempt to expose and endpoint that, when hit, will trigger a recompile. The idea is to run a separate container with a regular 'ol non-NFS volume that will listen for file system events and ping the /invalidate endpoint. Actually, while I have you here, I've been trying to figure out an easy way to get the list of files webpack-dev-server is watching, but that appears to be pretty well concealed. Any tips?

### Additional Info

I added this change by creating a branch from master, but, if this change is accepted, I would love it if it could be released as both a 2.x and a 3.x version bump, since we are still stuck on 2.x at the moment.