### PR TITLE
refactor(options): remove `serverSideRender` option (`options.serverSideRender`)

### DIFF
--- a/lib/options.json
+++ b/lib/options.json
@@ -295,9 +295,6 @@
     "quiet": {
       "type": "boolean"
     },
-    "serverSideRender": {
-      "type": "boolean"
-    },
     "index": {
       "type": "string"
     },
@@ -355,7 +352,6 @@
       "logTime": "should be {Boolean} (https://webpack.js.org/configuration/dev-server/#devserver-logtime)",
       "noInfo": "should be {Boolean} (https://webpack.js.org/configuration/dev-server/#devserver-noinfo-)",
       "quiet": "should be {Boolean} (https://webpack.js.org/configuration/dev-server/#devserver-quiet-)",
-      "serverSideRender": "should be {Boolean} (https://webpack.js.org/configuration/dev-server/#devserver-serversiderender)",
       "index": "should be {String} (https://webpack.js.org/configuration/dev-server/#devserver-index)",
       "log": "should be {Function} (https://webpack.js.org/configuration/dev-server/#devserver-log)",
       "warn": "should be {Function} (https://webpack.js.org/configuration/dev-server/#devserver-warn)"


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [ ] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [x] This is a **metadata update**

### For Bugs and Features; did you add new tests?

<!-- Please note that we won't approve your changes if you don't add tests. -->

### Motivation / Use-Case

<!--
  What existing problem does the pull request solve?

  Please explain the motivation or use-case for making this change.
  If this Pull Request addresses an issue, please link to the issue.
-->
This PR removes the options.serverSideRender as per the road map in webpack-dev-middleware
### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  potential migration path for existing applications.
-->

### Additional Info
