### PR TITLE
fix(bin/options): correct check for color support (`options.color`)

### DIFF
--- a/bin/options.js
+++ b/bin/options.js
@@ -57,7 +57,7 @@ const options = {
     type: 'boolean',
     alias: 'colors',
     default: function supportsColor() {
-      return require('supports-color');
+      return require('supports-color').stdout;
     },
     group: DISPLAY_GROUP,
     describe: 'Enables/Disables colors on the console'

--- a/bin/options.js
+++ b/bin/options.js
@@ -57,6 +57,8 @@ const options = {
     type: 'boolean',
     alias: 'colors',
     default: function supportsColor() {
+      // Use `require('supports-color').stdout` for supports-color >= 5.0.0.
+      // See https://github.com/webpack/webpack-dev-server/pull/1555.
       return require('supports-color').stdout;
     },
     group: DISPLAY_GROUP,


### PR DESCRIPTION
- [x] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

No, tests would require _not_ setting the option (allow default) and running in different environments (TTY vs. non-TTY). Moreover, supports-color has special behaviour for CIs.

### Motivation / Use-Case

Since [supports-color](https://github.com/chalk/supports-color) 5.0.0 (chalk/supports-color#64),
```javascript
return require("supports-color").supportsColor
```
returns a function instead of the test result. Because a function is truthy, colours are enabled by default irrespective of TTY or `FORCE_COLOR` settings.

```javascript
return require("supports-color").stdout
```
is the correct way to use supports-color.

### Breaking Changes

None.

### Additional Info