### PR TITLE
set default mode to development

### DIFF
--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -113,6 +113,9 @@ function processOptions (config) {
     ? config[0]
     : config;
 
+  // This updates both config and firstWpOpt
+  firstWpOpt.mode = defaultTo(firstWpOpt.mode, 'development');
+
   const options = config.devServer || firstWpOpt.devServer || {};
 
   if (argv.bonjour) {


### PR DESCRIPTION
- [x] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?
If this needs any tests I would appreciate some help what type of test, and where to add it

### Motivation / Use-Case
Set default `mode` to `development`. webpack config and CLI option will override the default if provided. 
See #1560 and #1327 

### Breaking Changes

### Additional Info
As far as I could tell the devServer options (just below the line changed in this PR) are only picked up from the first array item if the webpack config is an array(?). So I used the same principle for detecting `mode` in the config. 