### PR TITLE
ci(travis): Node 11 (on OS X) crashes, use 10 for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,9 @@ jobs:
       stage: Test (MacOS)
       os: 'osx'
       env: SCRIPT=test
-      node_js: 'stable'
+      # Node 10 instead of 'stable' since Node 11 segfaults
+      # https://github.com/webpack/webpack-dev-server/pull/1588
+      node_js: 10
     - <<: *osx
       node_js: 'lts/*'
     - <<: *osx


### PR DESCRIPTION
- [ ] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [x] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?
No, this is about the tests.

### Motivation / Use-Case

Mac OS X (on Travis) has a unknown segfault running the tests. About a month ago the `node/stable` went from Node 10 to Node 11, and then the project started getting these segfaults on Proxy tests as far as I can see.

### Additional Info

This is just a workaround, but the tests failing like now isn't very useful. I've added a bug with Node:
https://github.com/nodejs/node/issues/24835

This change should be reverted once it is fixed.