### PR TITLE
add params for invalidate function

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -884,7 +884,6 @@ Server.prototype._watch = function (watchPath) {
 };
 
 Server.prototype.invalidate = function (callback) {
-  callback = callback || () => {};
   if (this.middleware) {
     this.middleware.invalidate(callback);
   }

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -883,9 +883,10 @@ Server.prototype._watch = function (watchPath) {
   this.contentBaseWatchers.push(watcher);
 };
 
-Server.prototype.invalidate = function () {
+Server.prototype.invalidate = function (callback) {
+  callback = callback || () => {};
   if (this.middleware) {
-    this.middleware.invalidate();
+    this.middleware.invalidate(callback);
   }
 };
 


### PR DESCRIPTION

- [x ] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

<!-- Please note that we won't approve your changes if you don't add tests. -->

### Motivation / Use-Case
It uses the function invalidate of webpack-dev-middleware which can accept a callback. But when I used invalidate function export from webpack-dev-server, I can't pass parameters.

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  potential migration path for existing applications.
-->

### Additional Info
