### PR TITLE
add callback function as parameter of invalidate

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -883,9 +883,9 @@ Server.prototype._watch = function (watchPath) {
   this.contentBaseWatchers.push(watcher);
 };
 
-Server.prototype.invalidate = function () {
+Server.prototype.invalidate = function (callback) {
   if (this.middleware) {
-    this.middleware.invalidate();
+    this.middleware.invalidate(callback);
   }
 };
 


### PR DESCRIPTION

- [x] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

<!-- Please note that we won't approve your changes if you don't add tests. -->

### Motivation / Use-Case
The invalidate function exported from webpack-dev-middleware can accept a paremeter. But this function in webpack-dev-server do not pass the paremeter to webpack-dev-middleware.

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  potential migration path for existing applications.
-->

### Additional Info
