### PR TITLE
Fix checkHost for checking Origin header

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -646,7 +646,12 @@ Server.prototype.checkHost = function (headers, headerToCheck) {
   }
 
   // use the node url-parser to retrieve the hostname from the host-header.
-  const hostname = url.parse(`//${hostHeader}`, false, true).hostname;
+  const hostname = url.parse(
+    // if hostHeader doesn't have scheme, add // for parsing.
+    /^(.+:)?\/\//.test(hostHeader) ? hostHeader : `//${hostHeader}`,
+    false,
+    true,
+  ).hostname;
   // always allow requests with explicit IPv4 or IPv6-address.
   // A note on IPv6 addresses:
   // hostHeader will always contain the brackets denoting

--- a/test/Validation.test.js
+++ b/test/Validation.test.js
@@ -171,6 +171,19 @@ describe('Validation', () => {
       }
     });
 
+    it('should allow urls with scheme for checking origin', () => {
+      const options = {
+        public: 'test.host:80'
+      };
+      const headers = {
+        origin: 'https://test.host'
+      };
+      const server = new Server(compiler, options);
+      if (!server.checkHost(headers, 'origin')) {
+        throw new Error("Validation didn't fail");
+      }
+    });
+
     describe('allowedHosts', () => {
       it('should allow hosts in allowedHosts', () => {
         const tests = [


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [x] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [x] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

Yes
<!-- Please note that we won't approve your changes if you don't add tests. -->

### Motivation / Use-Case

Fixed #1604 

`checkHost` add `//` to header value for parsing.

#1603 use `checkHost` to check `Origin` header.

However, `Origin` must start with scheme ([MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin)), so paring result will be incorrect.

(e.g. `http://localhost:8080` -> `//http://localhost:8080`)

<!--
  What existing problem does the pull request solve?

  Please explain the motivation or use-case for making this change.
  If this Pull Request addresses an issue, please link to the issue.
-->

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  potential migration path for existing applications.
-->

### Additional Info
