### PR TITLE
Add workaround for sockjs@~0.3.19

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -47,13 +47,14 @@ const schema = require('./options.json');
 // sockjs will remove Origin header, however Origin header is required for checking host.
 // See https://github.com/webpack/webpack-dev-server/issues/1604 for more information
 {
+  // eslint-disable-next-line global-require
   const SockjsSession = require('sockjs/lib/transport').Session;
   const decorateConnection = SockjsSession.prototype.decorateConnection;
   SockjsSession.prototype.decorateConnection = function(req) {
     decorateConnection.call(this, req);
     const connection = this.connection;
     if (connection.headers && !('origin' in connection.headers) && 'origin' in req.headers) {
-      connection.headers['origin'] = req.headers['origin'];
+      connection.headers.origin = req.headers.origin;
     }
   };
 }

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -43,6 +43,21 @@ const createCertificate = require('./utils/createCertificate');
 const validateOptions = require('schema-utils');
 const schema = require('./options.json');
 
+// Workaround for sockjs@~0.3.19
+// sockjs will remove Origin header, however Origin header is required for checking host.
+// See https://github.com/webpack/webpack-dev-server/issues/1604 for more information
+{
+  const SockjsSession = require('sockjs/lib/transport').Session;
+  const decorateConnection = SockjsSession.prototype.decorateConnection;
+  SockjsSession.prototype.decorateConnection = function(req) {
+    decorateConnection.call(this, req);
+    const connection = this.connection;
+    if (connection.headers && !('origin' in connection.headers) && 'origin' in req.headers) {
+      connection.headers['origin'] = req.headers['origin'];
+    }
+  };
+}
+
 // Workaround for node ^8.6.0, ^9.0.0
 // DEFAULT_ECDH_CURVE is default to prime256v1 in these version
 // breaking connection when certificate is not signed with prime256v1


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [x] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

No
<!-- Please note that we won't approve your changes if you don't add tests. -->

### Motivation / Use-Case

sockjs will remove `Origin` header, however Origin header is required for checking host (#1603).
See https://github.com/webpack/webpack-dev-server/issues/1604#issuecomment-449582097

This workaround overwrote `Session.prototype.decorateConnection`.
(See https://github.com/sockjs/sockjs-node/blob/v0.3.19/src/transport.coffee#L112-L140)

<!--
  What existing problem does the pull request solve?

  Please explain the motivation or use-case for making this change.
  If this Pull Request addresses an issue, please link to the issue.
-->

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  potential migration path for existing applications.
-->

### Additional Info

This workaround maybe broken at `sockjs@^0.4.x` because sockjs are refactoring now.
When sockjs/sockjs-node#247 is merged, this workaround is not necessary.