### PR TITLE
fix: remove onbeforeunload workaround

### DIFF
--- a/client-src/default/index.js
+++ b/client-src/default/index.js
@@ -201,13 +201,8 @@ const socketUrl = url.format({
 
 socket(socketUrl, onSocketMsg);
 
-let isUnloading = false;
-self.addEventListener('beforeunload', () => {
-  isUnloading = true;
-});
-
 function reloadApp() {
-  if (isUnloading || !hotReload) {
+  if (!hotReload) {
     return;
   }
   if (hot) {


### PR DESCRIPTION
- [ ] This is a **bugfix**
- [ ] This is a **feature**
- [x] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

<!-- Please note that we won't approve your changes if you don't add tests. -->

N/A

### Motivation / Use-Case

<!--
  What existing problem does the pull request solve?

  Please explain the motivation or use-case for making this change.
  If this Pull Request addresses an issue, please link to the issue.
-->

The code that is removed here added a `beforeunload` event check in order to prevent the reload from happening if the page is already refreshing.

However, it is not always the case that after `beforeunload` page will continue reloading, for two reasons at least:
- `beforeunload` is cancelable, by spec
- custom protocol use case

In my case, there is an API that writes to `window.location` using a custom protocol.  `window.location` changes but the JS context is preserved, leaving `webpack-dev-server` incapacitated.

This PR fixes that (and should also apply cleanly to the v2 branch).

Ref: https://github.com/webpack/webpack-dev-server/pull/841
Ref: https://github.com/webpack/webpack-dev-server/issues/544

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  potential migration path for existing applications.
-->

N/A

### Additional Info

N/A