### PR TITLE
Automatically add the HMR plugin when hot or hotOnly is enabled

### DIFF
--- a/lib/utils/addEntries.js
+++ b/lib/utils/addEntries.js
@@ -6,6 +6,7 @@
   array-bracket-spacing,
   space-before-function-paren
 */
+const webpack = require('webpack');
 const createDomain = require('./createDomain');
 
 function addEntries (config, options, server) {
@@ -48,6 +49,13 @@ function addEntries (config, options, server) {
 
     [].concat(config).forEach((config) => {
       config.entry = prependEntry(config.entry || './src');
+
+      if (options.hot || options.hotOnly) {
+        config.plugins = config.plugins || [];
+        if (!config.plugins.find(plugin => plugin.constructor === webpack.HotModuleReplacementPlugin)) {
+          config.plugins.push(new webpack.HotModuleReplacementPlugin());
+        }
+      }
     });
   }
 }


### PR DESCRIPTION
- [ ] This is a **bugfix**
- [x] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

Yep, tests added.

### Motivation / Use-Case

When setting the `hot` or `hotOnly` option, the entries are added automatically, but the HMR plugin needs to be added into config by the user.

This PR extends the existing `addEntries` module to also amend the plugins config. This does make the name a bit of a misnomer, but for now i've just done the minimal changes.

### Breaking Changes

This is arguably a breaking change, as it's modifying config that it wasn't before. **But** if you were passing `hot` or `hotOnly` and missing the plugin, you were doing something wrong - and I've put in some logic to prevent duplicates of the HMR plugin.

I think it could be argued that this is safe to put into a point release.

### Additional Info
This overlaps somewhat with functionality implemented in `webpack-cli/bin/convert-argv`, that adds the webpack HMR plugin if you specifiy `--hot`, but not if you specify `--hot-only`.