### PR TITLE
fixes Origin validation for IP address. gives meaning to public and allowedHosts

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -12,7 +12,6 @@
 const fs = require('fs');
 const path = require('path');
 
-const ip = require('ip');
 const tls = require('tls');
 const url = require('url');
 const http = require('http');

--- a/test/Validation.test.js
+++ b/test/Validation.test.js
@@ -159,11 +159,14 @@ describe('Validation', () => {
         const isPublicHostname = test === options.public;
         const isInAllowedHosts = options.allowedHosts.includes(test);
         if (server.checkHost(headers)) {
-          if (!isPublicHostname && !isInAllowedHosts)
+          if (!isPublicHostname && !isInAllowedHosts) {
             throw new Error("Validation didn't fail. It should");
+          }
         } else {
-          if (isPublicHostname || isInAllowedHosts)
+          // eslint-disable-next-line no-lonely-if
+          if (isPublicHostname || isInAllowedHosts) {
             throw new Error("Validation failed and it shouldn't");
+          }
         }
       });
     });


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [x] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

Yes, I have adapted and improved the tests.

### Motivation / Use-Case

<!--
  What existing problem does the pull request solve?

  Please explain the motivation or use-case for making this change.
  If this Pull Request addresses an issue, please link to the issue.
-->

#1618 

### Breaking Changes

None.

BUT it is breaking if people are using webpack-dev-server in a way it is not intended to be used. For example, without specifying `public` or `allowedHosts` to serve publicly.

### Additional Info

This fixes #1618 which are two things basically:

1. More security regarding the websocket server (it was accepting all connections with an IP address as Origin). https://www.npmjs.com/advisories/725
2. Not letting everyone in the network connect to the development server unless specified if `public`, `allowedHosts`, etc
