### PR TITLE
fix: allow single object proxy config

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -307,27 +307,31 @@ class Server {
            * }
            */
           if (!Array.isArray(options.proxy)) {
-            options.proxy = Object.keys(options.proxy).map((context) => {
-              let proxyOptions;
-              // For backwards compatibility reasons.
-              const correctedContext = context
-                .replace(/^\*$/, '**')
-                .replace(/\/\*$/, '');
+            if (Object.prototype.hasOwnProperty.call(options.proxy, 'target')) {
+              options.proxy = [options.proxy];
+            } else {
+              options.proxy = Object.keys(options.proxy).map((context) => {
+                let proxyOptions;
+                // For backwards compatibility reasons.
+                const correctedContext = context
+                  .replace(/^\*$/, '**')
+                  .replace(/\/\*$/, '');
 
-              if (typeof options.proxy[context] === 'string') {
-                proxyOptions = {
-                  context: correctedContext,
-                  target: options.proxy[context],
-                };
-              } else {
-                proxyOptions = Object.assign({}, options.proxy[context]);
-                proxyOptions.context = correctedContext;
-              }
+                if (typeof options.proxy[context] === 'string') {
+                  proxyOptions = {
+                    context: correctedContext,
+                    target: options.proxy[context],
+                  };
+                } else {
+                  proxyOptions = Object.assign({}, options.proxy[context]);
+                  proxyOptions.context = correctedContext;
+                }
 
-              proxyOptions.logLevel = proxyOptions.logLevel || 'warn';
+                proxyOptions.logLevel = proxyOptions.logLevel || 'warn';
 
-              return proxyOptions;
-            });
+                return proxyOptions;
+              });
+            }
           }
 
           const getProxyMiddleware = (proxyConfig) => {

--- a/test/Proxy.test.js
+++ b/test/Proxy.test.js
@@ -11,7 +11,7 @@ const shouldSkipTestSuite = require('./shouldSkipTestSuite');
 const WebSocketServer = WebSocket.Server;
 const contentBase = path.join(__dirname, 'fixtures/proxy-config');
 
-const proxyOption = {
+const proxyOptionPathsAsProperties = {
   '/proxy1': {
     target: 'http://localhost:9000',
   },
@@ -28,8 +28,13 @@ const proxyOption = {
   },
 };
 
+const proxyOption = {
+  context: () => true,
+  target: 'http://localhost:9000'
+};
+
 const proxyOptionOfArray = [
-  { context: '/proxy1', target: proxyOption['/proxy1'].target },
+  { context: '/proxy1', target: proxyOption.target },
   function proxy() {
     return {
       context: '/api/proxy2',
@@ -68,21 +73,17 @@ describe('Proxy', () => {
     return;
   }
 
-  describe('proxy options is a object', () => {
+  describe('proxy options is an object of paths as properties', () => {
     let server;
     let req;
     let closeProxyServers;
 
     beforeAll((done) => {
       closeProxyServers = startProxyServers();
-      server = helper.start(
-        config,
-        {
-          contentBase,
-          proxy: proxyOption,
-        },
-        done
-      );
+      server = helper.start(config, {
+        contentBase,
+        proxy: proxyOptionPathsAsProperties
+      }, done);
       req = request(server.app);
     });
 
@@ -120,7 +121,34 @@ describe('Proxy', () => {
     });
   });
 
-  describe('proxy option is an array', () => {
+  context('proxy option is an object', () => {
+    let server;
+    let req;
+    let closeProxyServers;
+
+    before((done) => {
+      closeProxyServers = startProxyServers();
+      server = helper.start(config, {
+        contentBase,
+        proxy: proxyOption
+      }, done);
+      req = request(server.app);
+    });
+
+    after((done) => {
+      helper.close(() => {
+        closeProxyServers();
+        done();
+      });
+    });
+
+    it('respects a proxy option', (done) => {
+      req.get('/proxy1')
+        .expect(200, 'from proxy1', done);
+    });
+  });
+
+  context('proxy option is an array', () => {
     let server;
     let req;
     let closeProxyServers;

--- a/test/Proxy.test.js
+++ b/test/Proxy.test.js
@@ -30,7 +30,7 @@ const proxyOptionPathsAsProperties = {
 
 const proxyOption = {
   context: () => true,
-  target: 'http://localhost:9000'
+  target: 'http://localhost:9000',
 };
 
 const proxyOptionOfArray = [
@@ -80,10 +80,14 @@ describe('Proxy', () => {
 
     beforeAll((done) => {
       closeProxyServers = startProxyServers();
-      server = helper.start(config, {
-        contentBase,
-        proxy: proxyOptionPathsAsProperties
-      }, done);
+      server = helper.start(
+        config,
+        {
+          contentBase,
+          proxy: proxyOptionPathsAsProperties,
+        },
+        done
+      );
       req = request(server.app);
     });
 
@@ -121,21 +125,25 @@ describe('Proxy', () => {
     });
   });
 
-  context('proxy option is an object', () => {
+  describe('proxy option is an object', () => {
     let server;
     let req;
     let closeProxyServers;
 
-    before((done) => {
+    beforeAll((done) => {
       closeProxyServers = startProxyServers();
-      server = helper.start(config, {
-        contentBase,
-        proxy: proxyOption
-      }, done);
+      server = helper.start(
+        config,
+        {
+          contentBase,
+          proxy: proxyOption,
+        },
+        done
+      );
       req = request(server.app);
     });
 
-    after((done) => {
+    afterAll((done) => {
       helper.close(() => {
         closeProxyServers();
         done();
@@ -143,12 +151,11 @@ describe('Proxy', () => {
     });
 
     it('respects a proxy option', (done) => {
-      req.get('/proxy1')
-        .expect(200, 'from proxy1', done);
+      req.get('/proxy1').expect(200, 'from proxy1', done);
     });
   });
 
-  context('proxy option is an array', () => {
+  describe('proxy option is an array', () => {
     let server;
     let req;
     let closeProxyServers;


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [x] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

Yes. 

* I added a new test to test the proxy config.
* I renamed a previous test since the name of the test was too generic after adding a new one.

<!-- Please note that we won't approve your changes if you don't add tests. -->

### Motivation / Use-Case

Fix #1438.  Allow for a simple object proxy config as described in the [options schema](https://github.com/webpack/webpack-dev-server/blob/349e7332a18f46250554ccc5fb5272a3550aad53/lib/options.json#L224) and demonstrated in the [docs](https://webpack.js.org/configuration/dev-server/#devserver-proxy).

```js
module.exports = {
  //...
  devServer: {
    index: '', // specify to enable root proxying
    host: '...',
    contentBase: '...',
    proxy: {
      context: () => true,
      target: 'http://localhost:1234'
    }
  }
};
```

<!--
  What existing problem does the pull request solve?

  Please explain the motivation or use-case for making this change.
  If this Pull Request addresses an issue, please link to the issue.
-->

### Breaking Changes

N/A
<!--
  If this PR introduces a breaking change, please describe the impact and a
  potential migration path for existing applications.
-->

### Additional Info

I'm not sure if just checking for a `target` prop is too naive on the proxy config.

