### PR TITLE
fix:add webpack-cli as peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,8 @@
     "ws": "^6.0.0"
   },
   "peerDependencies": {
-    "webpack": "^4.0.0"
+    "webpack": "^4.0.0",
+    "webpack-cli": "^3.2.1"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
- [x] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

This does not require any extra tests

### Motivation / Use-Case

Lack of `webpack-cli` in peerDependencies was causing late discovery of missing dependencies only after trying to start the dev server. Having it here will show unmet peer dependency warning when installing the package.

### Breaking Changes

none

### Additional Info
