### PR TITLE
Fix SPDY fails in node >= 11.1.0

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -17,7 +17,6 @@ const tls = require('tls');
 const url = require('url');
 const http = require('http');
 const https = require('https');
-const spdy = require('spdy');
 const sockjs = require('sockjs');
 
 const semver = require('semver');
@@ -630,6 +629,7 @@ function Server(compiler, options = {}, _log) {
     if (semver.gte(process.version, '10.0.0')) {
       this.listeningApp = https.createServer(options.https, app);
     } else {
+      const spdy = require('spdy');
       this.listeningApp = spdy.createServer(options.https, app);
     }
   } else {

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -629,8 +629,9 @@ function Server(compiler, options = {}, _log) {
     if (semver.gte(process.version, '10.0.0')) {
       this.listeningApp = https.createServer(options.https, app);
     } else {
-      const spdy = require('spdy');
-      this.listeningApp = spdy.createServer(options.https, app);
+      /* eslint-disable global-require */
+      this.listeningApp = require('spdy').createServer(options.https, app);
+      /* eslint-enable global-require */
     }
   } else {
     this.listeningApp = http.createServer(app);

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -635,6 +635,9 @@ class Server {
         this.listeningApp = https.createServer(options.https, app);
       } else {
         /* eslint-disable global-require */
+        // The relevant issues are:
+        // https://github.com/spdy-http2/node-spdy/issues/350
+        // https://github.com/webpack/webpack-dev-server/issues/1592
         this.listeningApp = require('spdy').createServer(options.https, app);
         /* eslint-enable global-require */
       }


### PR DESCRIPTION
In node v11+:
```
util.js:305
    throw new ERR_INVALID_ARG_TYPE('superCtor.prototype',
    ^

TypeError [ERR_INVALID_ARG_TYPE]: The "superCtor.prototype" property must be of type Object. Received type undefined
```

- [x] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

