### PR TITLE
test(Proxy): skip Proxy.test.js

### DIFF
--- a/test/Proxy.test.js
+++ b/test/Proxy.test.js
@@ -6,6 +6,7 @@ const express = require('express');
 const WebSocket = require('ws');
 const helper = require('./helper');
 const config = require('./fixtures/proxy-config/webpack.config');
+const shouldSkipTestSuite = require('./shouldSkipTestSuite');
 
 const WebSocketServer = WebSocket.Server;
 const contentBase = path.join(__dirname, 'fixtures/proxy-config');
@@ -62,6 +63,11 @@ function startProxyServers() {
 }
 
 describe('Proxy', () => {
+  // issue: https://github.com/webpack/webpack-dev-server/pull/1633#issuecomment-463938675
+  if (shouldSkipTestSuite()) {
+    return;
+  }
+
   describe('proxy options is a object', () => {
     let server;
     let req;

--- a/test/shouldSkipTestSuite.js
+++ b/test/shouldSkipTestSuite.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const semver = require('semver');
+
+// issue: https://github.com/nodejs/node/issues/24835
+function shouldSkipTestSuite() {
+  if (
+    semver.satisfies(process.version, '11') &&
+    process.platform === 'darwin'
+  ) {
+    it('skip', () => {
+      expect(true).toBeTruthy();
+    });
+
+    return true;
+  }
+  return false;
+}
+
+module.exports = shouldSkipTestSuite;


### PR DESCRIPTION
This test is unstable when running on Node v11 on MacOS.

<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [ ] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [x] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

<!-- Please note that we won't approve your changes if you don't add tests. -->

N/A

### Motivation / Use-Case

see https://github.com/webpack/webpack-dev-server/pull/1633#issuecomment-463982581
<!--
  What existing problem does the pull request solve?

  Please explain the motivation or use-case for making this change.
  If this Pull Request addresses an issue, please link to the issue.
-->

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  potential migration path for existing applications.
-->

no 

### Additional Info

`HistoryApiFallback.test.js` seems to be good when we add skipping code to `Proxy.test.js`.