### PR TITLE
fix: allow `ca`, `key` and `cert` will be string (regression)

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -570,8 +570,21 @@ class Server {
         const value = options.https[property];
         const isBuffer = value instanceof Buffer;
 
-        if (value && !isBuffer && fs.lstatSync(value).isFile()) {
-          options.https[property] = fs.readFileSync(path.resolve(value));
+        if (value && !isBuffer) {
+          let stats = null;
+
+          try {
+            stats = fs.lstatSync(value).isFile();
+          } catch (error) {
+            // ignore error
+          }
+
+          if (stats) {
+            // It is file
+            options.https[property] = fs.readFileSync(path.resolve(value));
+          } else {
+            options.https[property] = value;
+          }
         }
       }
 
@@ -610,7 +623,7 @@ class Server {
           const pems = createCertificate(attrs);
 
           fs.writeFileSync(certPath, pems.private + pems.cert, {
-            encoding: 'utf-8',
+            encoding: 'utf8',
           });
         }
 

--- a/test/Https.test.js
+++ b/test/Https.test.js
@@ -18,9 +18,8 @@ const contentBasePublic = path.join(
 describe('HTTPS', () => {
   let server;
   let req;
-  afterEach(helper.close);
 
-  describe('to directory', () => {
+  describe('is boolean', () => {
     beforeAll((done) => {
       server = helper.start(
         config,
@@ -35,6 +34,10 @@ describe('HTTPS', () => {
 
     it('Request to index', (done) => {
       req.get('/').expect(200, /Heyo/, done);
+    });
+
+    afterAll(() => {
+      helper.close();
     });
   });
 
@@ -68,7 +71,7 @@ describe('HTTPS', () => {
     });
   });
 
-  describe('ca, pfx, key and cert are string', () => {
+  describe('ca, pfx, key and cert are paths', () => {
     beforeAll((done) => {
       server = helper.start(
         config,
@@ -91,4 +94,39 @@ describe('HTTPS', () => {
       req.get('/').expect(200, /Heyo/, done);
     });
   });
+
+  describe('ca, pfx, key and cert are raw strings', () => {
+    beforeAll((done) => {
+      server = helper.start(
+        config,
+        {
+          contentBase: contentBasePublic,
+          https: {
+            ca: fs
+              .readFileSync(path.join(httpsCertificateDirectory, 'ca.pem'))
+              .toString(),
+            // pfx can't be string because it is binary format
+            pfx: fs.readFileSync(
+              path.join(httpsCertificateDirectory, 'server.pfx')
+            ),
+            key: fs
+              .readFileSync(path.join(httpsCertificateDirectory, 'server.key'))
+              .toString(),
+            cert: fs
+              .readFileSync(path.join(httpsCertificateDirectory, 'server.crt'))
+              .toString(),
+            passphrase: 'webpack-dev-server',
+          },
+        },
+        done
+      );
+      req = request(server.app);
+    });
+
+    it('Request to index', (done) => {
+      req.get('/').expect(200, /Heyo/, done);
+    });
+  });
+
+  afterEach(helper.close);
 });


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [x] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [x] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

Yes

### Motivation / Use-Case

fixes #1674

### Breaking Changes

No

### Additional Info

It is regression, just not `pfx` can't be string due it is binary format