### PR TITLE
fix: deprecation message about `setup` now warning about `v4`

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -505,7 +505,7 @@ class Server {
       setup: () => {
         if (typeof options.setup === 'function') {
           this.log.warn(
-            'The `setup` option is deprecated and will be removed in v3. Please update your config to use `before`'
+            'The `setup` option is deprecated and will be removed in v4. Please update your config to use `before`'
           );
 
           options.setup(app, this);


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [x] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

No need

### Motivation / Use-Case

We don't remove `setup` in `v3`, we should do this for `v4`

### Breaking Changes

No

### Additional Info

No