### PR TITLE
Fixed issue when certificates are not imported on runtime

### DIFF
--- a/lib/utils/createConfig.js
+++ b/lib/utils/createConfig.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const fs = require('fs');
 const path = require('path');
 const { defaultTo } = require('../../bin/utils');
 
@@ -134,6 +135,22 @@ function createConfig(config, argv, { port }) {
 
   if (argv.https) {
     options.https = true;
+  }
+
+  if (argv.cert) {
+    options.cert = fs.readFileSync(path.resolve(argv.cert));
+  }
+
+  if (argv.key) {
+    options.key = fs.readFileSync(path.resolve(argv.key));
+  }
+
+  if (argv.cacert) {
+    options.ca = fs.readFileSync(path.resolve(argv.cacert));
+  }
+
+  if (argv.pfx) {
+    options.pfx = fs.readFileSync(path.resolve(argv.pfx));
   }
 
   if (argv.pfxPassphrase) {


### PR DESCRIPTION
Added back argument parser for certificates which resolves issue with custom domain. 

Fixes https://github.com/webpack/webpack-dev-server/issues/1675