### PR TITLE
Fix proxy bypass return false

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ state, the project only officially supports the _last two versions of major
 browsers_. We simply don't have the resources to support every whacky
 browser out there.
 
-If you find an bug with an obscure / old browser, we would actively welcome a
+If you find a bug with an obscure / old browser, we would actively welcome a
 Pull Request to resolve the bug.
 
 ## Support
@@ -127,25 +127,6 @@ out completely._
 ## Contributing
 
 We welcome your contributions! Please have a read of [CONTRIBUTING.md](CONTRIBUTING.md) for more information on how to get involved.
-
-## Maintainers
-
-<table>
-  <tbody>
-    <tr>
-      <td align="center">
-        <img src="https://avatars.githubusercontent.com/SpaceK33z?v=4&s=150">
-        <br />
-        <a href="https://github.com/SpaceK33z">Kees Kluskens</a>
-      </td>
-      <td align="center">
-        <img src="https://i.imgur.com/4v6pgxh.png">
-        <br />
-        <a href="https://github.com/shellscape">Andrew Powell</a>
-      </td>
-    </tr>
-  </tbody>
-</table>
 
 ## Attribution
 

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -381,21 +381,22 @@ class Server {
                 }
               }
 
-              // const bypass = typeof proxyConfig.bypass === 'function';
-              // const bypassRawValue = bypass ? proxyConfig.bypass(req, res, proxyConfig) : null;
-              // const bypassUrl = typeof bypassRawValue === 'string'
-              //   ? bypassRawValue
-              //   : (typeof bypassRawValue === 'boolean' && bypassRawValue === false);
-
               const bypass = typeof proxyConfig.bypass === 'function';
+              const bypassRawValue = bypass
+                ? proxyConfig.bypass(req, res, proxyConfig)
+                : null;
               const bypassUrl =
-                (bypass && proxyConfig.bypass(req, res, proxyConfig)) || false;
+                typeof bypassRawValue === 'string'
+                  ? bypassRawValue
+                  : typeof bypassRawValue === 'boolean' &&
+                    bypassRawValue === false;
 
               if (bypassUrl) {
-                // In case bypassURL is a boolean with a true value
-                // (as result from setting a bypassRawValue boolean
-                // with false value) the request will be ignored
-                req.url = bypassUrl;
+                // Only in case bypassURL is a string
+                // the request will be set
+                if (typeof bypassUrl === 'string') {
+                  req.url = bypassUrl;
+                }
                 next();
               } else if (proxyMiddleware) {
                 return proxyMiddleware(req, res, next);

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -381,14 +381,21 @@ class Server {
                 }
               }
 
-              const bypass = typeof proxyConfig.bypass === 'function';
+              // const bypass = typeof proxyConfig.bypass === 'function';
+              // const bypassRawValue = bypass ? proxyConfig.bypass(req, res, proxyConfig) : null;
+              // const bypassUrl = typeof bypassRawValue === 'string'
+              //   ? bypassRawValue
+              //   : (typeof bypassRawValue === 'boolean' && bypassRawValue === false);
 
+              const bypass = typeof proxyConfig.bypass === 'function';
               const bypassUrl =
                 (bypass && proxyConfig.bypass(req, res, proxyConfig)) || false;
 
               if (bypassUrl) {
+                // In case bypassURL is a boolean with a true value
+                // (as result from setting a bypassRawValue boolean
+                // with false value) the request will be ignored
                 req.url = bypassUrl;
-
                 next();
               } else if (proxyMiddleware) {
                 return proxyMiddleware(req, res, next);

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -392,11 +392,14 @@ class Server {
                     bypassRawValue === false;
 
               if (bypassUrl) {
-                // Only in case bypassURL is a string
-                // the request will be set
+                if (typeof bypassUrl === 'boolean') {
+                  req.url = null;
+                }
+
                 if (typeof bypassUrl === 'string') {
                   req.url = bypassUrl;
                 }
+
                 next();
               } else if (proxyMiddleware) {
                 return proxyMiddleware(req, res, next);

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -381,25 +381,22 @@ class Server {
                 }
               }
 
-              const bypass = typeof proxyConfig.bypass === 'function';
-              const bypassRawValue = bypass
+              // - Check if we have a bypass function defined
+              // - In case the bypass function is defined we'll retrieve the
+              // bypassUrl from it otherwise byPassUrl would be null
+              const isByPassFuncDefined =
+                typeof proxyConfig.bypass === 'function';
+              const bypassUrl = isByPassFuncDefined
                 ? proxyConfig.bypass(req, res, proxyConfig)
                 : null;
-              const bypassUrl =
-                typeof bypassRawValue === 'string'
-                  ? bypassRawValue
-                  : typeof bypassRawValue === 'boolean' &&
-                    bypassRawValue === false;
 
-              if (bypassUrl) {
-                if (typeof bypassUrl === 'boolean') {
-                  req.url = null;
-                }
-
-                if (typeof bypassUrl === 'string') {
-                  req.url = bypassUrl;
-                }
-
+              if (typeof bypassUrl === 'boolean') {
+                // skip the proxy
+                req.url = null;
+                next();
+              } else if (typeof bypassUrl === 'string') {
+                // byPass to that url
+                req.url = bypassUrl;
                 next();
               } else if (proxyMiddleware) {
                 return proxyMiddleware(req, res, next);

--- a/test/Proxy.test.js
+++ b/test/Proxy.test.js
@@ -23,11 +23,15 @@ const proxyOptionPathsAsProperties = {
       if (/\.html$/.test(req.path)) {
         return '/index.html';
       }
+
+      return null;
     },
   },
   '/proxyfalse': {
-    bypass() {
-      return false;
+    bypass(req) {
+      if (/\/proxyfalse$/.test(req.path)) {
+        return false;
+      }
     },
   },
 };

--- a/test/Proxy.test.js
+++ b/test/Proxy.test.js
@@ -21,7 +21,7 @@ const proxyOptionPathsAsProperties = {
   '/foo': {
     bypass(req) {
       if (/\.html$/.test(req.path)) {
-        return 'index.html';
+        return '/index.html';
       }
     },
   },

--- a/test/Proxy.test.js
+++ b/test/Proxy.test.js
@@ -21,8 +21,13 @@ const proxyOptionPathsAsProperties = {
   '/foo': {
     bypass(req) {
       if (/\.html$/.test(req.path)) {
-        return '/index.html';
+        return 'index.html';
       }
+    },
+  },
+  '/proxyfalse': {
+    bypass() {
+      return false;
     },
   },
 };
@@ -115,6 +120,10 @@ describe('Proxy', () => {
 
       it('should pass through a proxy when a bypass function returns null', (done) => {
         req.get('/foo.js').expect(200, /Hey/, done);
+      });
+
+      it('should not pass through a proxy when a bypass function returns false', (done) => {
+        req.get('/proxyfalse').expect(404, done);
       });
     });
   });


### PR DESCRIPTION
- [x] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

Yes

### Motivation / Use-Case

Based on the [explanation in the docs](https://webpack.js.org/configuration/dev-server/#devserverproxy)

> It must return either `false` or a path that will be served instead of continuing to proxy the request.

It was expected that `return false` skip the proxy with a 404

### Breaking Changes

None

### Additional Info

Closes https://github.com/webpack/webpack-dev-server/issues/1677

/CC @evilebottnawi 

@jsmith-sapient @jshado1 @evilebottnawi could you please test this manually and confirm that this have the intended behaviour? 
