### PR TITLE
chore(deps): update jest to v24.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -751,6 +751,24 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@cnakazawa/watch": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.3.tgz",
+      "integrity": "sha512-r5160ogAvGyHsal38Kux7YYtodEKOj89RGb28ht1jh3SJb08VwRwAKKJL0bGb04Zd/3r9FL3BFIc3bBidYffCA==",
+      "dev": true,
+      "requires": {
+        "exec-sh": "^0.3.2",
+        "minimist": "^1.2.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
     "@iamstarkov/listr-update-renderer": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@iamstarkov/listr-update-renderer/-/listr-update-renderer-0.4.1.tgz",
@@ -813,6 +831,202 @@
         }
       }
     },
+    "@jest/console": {
+      "version": "24.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-24.3.0.tgz",
+      "integrity": "sha512-NaCty/OOei6rSDcbPdMiCbYCI0KGFGPgGO6B09lwWt5QTxnkuhKYET9El5u5z1GAcSxkQmSMtM63e24YabCWqA==",
+      "dev": true,
+      "requires": {
+        "@jest/source-map": "^24.3.0",
+        "@types/node": "*",
+        "chalk": "^2.0.1",
+        "slash": "^2.0.0"
+      }
+    },
+    "@jest/core": {
+      "version": "24.3.1",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-24.3.1.tgz",
+      "integrity": "sha512-orucOIBKfXgm1IJirtPT0ToprqDVGYKUNJKNc9a6v1Lww6qLPq+xj5OfxyhpJb2rWOgzEkATW1bfZzg3oqV70w==",
+      "dev": true,
+      "requires": {
+        "@jest/console": "^24.3.0",
+        "@jest/reporters": "^24.3.1",
+        "@jest/test-result": "^24.3.0",
+        "@jest/transform": "^24.3.1",
+        "@jest/types": "^24.3.0",
+        "ansi-escapes": "^3.0.0",
+        "chalk": "^2.0.1",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.1.15",
+        "jest-changed-files": "^24.3.0",
+        "jest-config": "^24.3.1",
+        "jest-haste-map": "^24.3.1",
+        "jest-message-util": "^24.3.0",
+        "jest-regex-util": "^24.3.0",
+        "jest-resolve-dependencies": "^24.3.1",
+        "jest-runner": "^24.3.1",
+        "jest-runtime": "^24.3.1",
+        "jest-snapshot": "^24.3.1",
+        "jest-util": "^24.3.0",
+        "jest-validate": "^24.3.1",
+        "jest-watcher": "^24.3.0",
+        "micromatch": "^3.1.10",
+        "p-each-series": "^1.0.0",
+        "pirates": "^4.0.1",
+        "realpath-native": "^1.1.0",
+        "rimraf": "^2.5.4",
+        "strip-ansi": "^5.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
+          "integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
+          "integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@jest/environment": {
+      "version": "24.3.1",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-24.3.1.tgz",
+      "integrity": "sha512-M8bqEkQqPwZVhMMFMqqCnzqIZtuM5vDMfFQ9ZvnEfRT+2T1zTA4UAOH/V4HagEi6S3BCd/mdxFdYmPgXf7GKCA==",
+      "dev": true,
+      "requires": {
+        "@jest/fake-timers": "^24.3.0",
+        "@jest/transform": "^24.3.1",
+        "@jest/types": "^24.3.0",
+        "@types/node": "*",
+        "jest-mock": "^24.3.0"
+      }
+    },
+    "@jest/fake-timers": {
+      "version": "24.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-24.3.0.tgz",
+      "integrity": "sha512-rHwVI17dGMHxHzfAhnZ04+wFznjFfZ246QugeBnbiYr7/bDosPD2P1qeNjWnJUUcfl0HpS6kkr+OB/mqSJxQFg==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^24.3.0",
+        "@types/node": "*",
+        "jest-message-util": "^24.3.0",
+        "jest-mock": "^24.3.0"
+      }
+    },
+    "@jest/reporters": {
+      "version": "24.3.1",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-24.3.1.tgz",
+      "integrity": "sha512-jEIDJcvk20ReUW1Iqb+prlAcFV+kfFhQ/01poCq8X9As7/l/2y1GqVwJ3+6SaPTZuCXh0d0LVDy86zDAa8zlVA==",
+      "dev": true,
+      "requires": {
+        "@jest/environment": "^24.3.1",
+        "@jest/test-result": "^24.3.0",
+        "@jest/transform": "^24.3.1",
+        "@jest/types": "^24.3.0",
+        "chalk": "^2.0.1",
+        "exit": "^0.1.2",
+        "glob": "^7.1.2",
+        "istanbul-api": "^2.1.1",
+        "istanbul-lib-coverage": "^2.0.2",
+        "istanbul-lib-instrument": "^3.0.1",
+        "istanbul-lib-source-maps": "^3.0.1",
+        "jest-haste-map": "^24.3.1",
+        "jest-resolve": "^24.3.1",
+        "jest-runtime": "^24.3.1",
+        "jest-util": "^24.3.0",
+        "jest-worker": "^24.3.1",
+        "node-notifier": "^5.2.1",
+        "slash": "^2.0.0",
+        "source-map": "^0.6.0",
+        "string-length": "^2.0.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
+    "@jest/source-map": {
+      "version": "24.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-24.3.0.tgz",
+      "integrity": "sha512-zALZt1t2ou8le/crCeeiRYzvdnTzaIlpOWaet45lNSqNJUnXbppUUFR4ZUAlzgDmKee4Q5P/tKXypI1RiHwgag==",
+      "dev": true,
+      "requires": {
+        "callsites": "^3.0.0",
+        "graceful-fs": "^4.1.15",
+        "source-map": "^0.6.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
+    "@jest/test-result": {
+      "version": "24.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-24.3.0.tgz",
+      "integrity": "sha512-j7UZ49T8C4CVipEY99nLttnczVTtLyVzFfN20OiBVn7awOs0U3endXSTq7ouPrLR5y4YjI5GDcbcvDUjgeamzg==",
+      "dev": true,
+      "requires": {
+        "@jest/console": "^24.3.0",
+        "@jest/types": "^24.3.0",
+        "@types/istanbul-lib-coverage": "^1.1.0"
+      }
+    },
+    "@jest/transform": {
+      "version": "24.3.1",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-24.3.1.tgz",
+      "integrity": "sha512-PpjylI5goT4Si69+qUjEeHuKjex0LjjrqJzrMYzlOZn/+SCumGKuGC0UQFeEPThyGsFvWH1Q4gj0R66eOHnIpw==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.1.0",
+        "@jest/types": "^24.3.0",
+        "babel-plugin-istanbul": "^5.1.0",
+        "chalk": "^2.0.1",
+        "convert-source-map": "^1.4.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "graceful-fs": "^4.1.15",
+        "jest-haste-map": "^24.3.1",
+        "jest-regex-util": "^24.3.0",
+        "jest-util": "^24.3.0",
+        "micromatch": "^3.1.10",
+        "realpath-native": "^1.1.0",
+        "slash": "^2.0.0",
+        "source-map": "^0.6.1",
+        "write-file-atomic": "2.4.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
+    "@jest/types": {
+      "version": "24.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-24.3.0.tgz",
+      "integrity": "sha512-VoO1F5tU2n/93QN/zaZ7Q8SeV/Rj+9JJOgbvKbBwy4lenvmdj1iDaQEPXGTKrO6OSvDeb2drTFipZJYxgo6kIQ==",
+      "dev": true,
+      "requires": {
+        "@types/istanbul-lib-coverage": "^1.1.0",
+        "@types/yargs": "^12.0.9"
+      }
+    },
     "@samverschueren/stream-to-observable": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz",
@@ -821,6 +1035,71 @@
       "requires": {
         "any-observable": "^0.3.0"
       }
+    },
+    "@types/babel__core": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.0.tgz",
+      "integrity": "sha512-wJTeJRt7BToFx3USrCDs2BhEi4ijBInTQjOIukj6a/5tEkwpFMVZ+1ppgmE+Q/FQyc5P/VWUbx7I9NELrKruHA==",
+      "dev": true,
+      "requires": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "@types/babel__generator": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.0.2.tgz",
+      "integrity": "sha512-NHcOfab3Zw4q5sEE2COkpfXjoE7o+PmqD9DQW4koUT3roNxwziUdXGnRndMat/LJNUtePwn1TlP4do3uoe3KZQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@types/babel__template": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.0.2.tgz",
+      "integrity": "sha512-/K6zCpeW7Imzgab2bLkLEbz0+1JlFSrUMdw7KoIIu+IUdu51GWaBZpd3y1VXGVXzynvGa4DaIaxNZHiON3GXUg==",
+      "dev": true,
+      "requires": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@types/babel__traverse": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.6.tgz",
+      "integrity": "sha512-XYVgHF2sQ0YblLRMLNPB3CkFMewzFmlDsH/TneZFHUXDlABQgh88uOxuez7ZcXxayLFrqLwtDH1t+FmlFwNZxw==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.3.0"
+      }
+    },
+    "@types/istanbul-lib-coverage": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.0.tgz",
+      "integrity": "sha512-ohkhb9LehJy+PA40rDtGAji61NCgdtKLAlFoYp4cnuuQEswwdK3vz9SOIkkyc3wrk8dzjphQApNs56yyXLStaQ==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "11.10.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.10.5.tgz",
+      "integrity": "sha512-DuIRlQbX4K+d5I+GMnv+UfnGh+ist0RdlvOp+JZ7ePJ6KQONCFQv/gKYSU1ZzbVdFSUCKZOltjmpFAGGv5MdYA==",
+      "dev": true
+    },
+    "@types/stack-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
+      "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
+      "dev": true
+    },
+    "@types/yargs": {
+      "version": "12.0.9",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-12.0.9.tgz",
+      "integrity": "sha512-sCZy4SxP9rN2w30Hlmg5dtdRwgYQfYRiLo9usw8X9cxlf+H4FqM1xX7+sNH7NNKVdbXMJWqva7iyy+fxh/V7fA==",
+      "dev": true
     },
     "@webassemblyjs/ast": {
       "version": "1.8.3",
@@ -1356,13 +1635,16 @@
       "dev": true
     },
     "babel-jest": {
-      "version": "24.1.0",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-24.1.0.tgz",
-      "integrity": "sha512-MLcagnVrO9ybQGLEfZUqnOzv36iQzU7Bj4elm39vCukumLVSfoX+tRy3/jW7lUKc7XdpRmB/jech6L/UCsSZjw==",
+      "version": "24.3.1",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-24.3.1.tgz",
+      "integrity": "sha512-6KaXyUevY0KAxD5Ba+EBhyfwvc+R2f7JV7BpBZ5T8yJGgj0M1hYDfRhDq35oD5MzprMf/ggT81nEuLtMyxfDIg==",
       "dev": true,
       "requires": {
+        "@jest/transform": "^24.3.1",
+        "@jest/types": "^24.3.0",
+        "@types/babel__core": "^7.1.0",
         "babel-plugin-istanbul": "^5.1.0",
-        "babel-preset-jest": "^24.1.0",
+        "babel-preset-jest": "^24.3.0",
         "chalk": "^2.4.2",
         "slash": "^2.0.0"
       }
@@ -1391,19 +1673,22 @@
       }
     },
     "babel-plugin-jest-hoist": {
-      "version": "24.1.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.1.0.tgz",
-      "integrity": "sha512-gljYrZz8w1b6fJzKcsfKsipSru2DU2DmQ39aB6nV3xQ0DDv3zpIzKGortA5gknrhNnPN8DweaEgrnZdmbGmhnw==",
-      "dev": true
+      "version": "24.3.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.3.0.tgz",
+      "integrity": "sha512-nWh4N1mVH55Tzhx2isvUN5ebM5CDUvIpXPZYMRazQughie/EqGnbR+czzoQlhUmJG9pPJmYDRhvocotb2THl1w==",
+      "dev": true,
+      "requires": {
+        "@types/babel__traverse": "^7.0.6"
+      }
     },
     "babel-preset-jest": {
-      "version": "24.1.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-24.1.0.tgz",
-      "integrity": "sha512-FfNLDxFWsNX9lUmtwY7NheGlANnagvxq8LZdl5PKnVG3umP+S/g0XbVBfwtA4Ai3Ri/IMkWabBz3Tyk9wdspcw==",
+      "version": "24.3.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-24.3.0.tgz",
+      "integrity": "sha512-VGTV2QYBa/Kn3WCOKdfS31j9qomaXSgJqi65B6o05/1GsJyj9LVhSljM9ro4S+IBGj/ENhNBuH9bpqzztKAQSw==",
       "dev": true,
       "requires": {
         "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
-        "babel-plugin-jest-hoist": "^24.1.0"
+        "babel-plugin-jest-hoist": "^24.3.0"
       }
     },
     "balanced-match": {
@@ -3055,9 +3340,9 @@
       "integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw=="
     },
     "diff-sequences": {
-      "version": "24.0.0",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.0.0.tgz",
-      "integrity": "sha512-46OkIuVGBBnrC0soO/4LHu5LHGHx0uhP65OVz8XOrAJpqiCB2aVIuESvjI1F9oqebuvY8lekS1pt6TN7vt7qsw==",
+      "version": "24.3.0",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.3.0.tgz",
+      "integrity": "sha512-xLqpez+Zj9GKSnPWS0WZw1igGocZ+uua8+y+5dDNTT934N3QuY1sp2LkHzwiaYQGz60hMq0pjAshdeXm5VUOEw==",
       "dev": true
     },
     "diffie-hellman": {
@@ -3764,13 +4049,10 @@
       }
     },
     "exec-sh": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.2.tgz",
-      "integrity": "sha512-FIUCJz1RbuS0FKTdaAafAByGS0CPvU3R0MeHxgtl+djzCc//F8HakL8GzmVNZanasTbTAY/3DRFA0KpVqj/eAw==",
-      "dev": true,
-      "requires": {
-        "merge": "^1.2.0"
-      }
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.3.2.tgz",
+      "integrity": "sha512-9sLAvzhI5nc8TpuQUh4ahMdCrWT00wPWz7j47/emR5+2qEfoZP5zzUXvx+vdx+H6ohhnsYC31iX04QLYJK8zTg==",
+      "dev": true
     },
     "execa": {
       "version": "1.0.0",
@@ -3842,16 +4124,17 @@
       }
     },
     "expect": {
-      "version": "24.1.0",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-24.1.0.tgz",
-      "integrity": "sha512-lVcAPhaYkQcIyMS+F8RVwzbm1jro20IG8OkvxQ6f1JfqhVZyyudCwYogQ7wnktlf14iF3ii7ArIUO/mqvrW9Gw==",
+      "version": "24.3.1",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-24.3.1.tgz",
+      "integrity": "sha512-xnmobSlaqhg4FKqjb5REk4AobQzFMJoctDdREKfSGqrtzRfCWYbfqt3WmikAvQz/J8mCNQhORgYdEjPMJbMQPQ==",
       "dev": true,
       "requires": {
+        "@jest/types": "^24.3.0",
         "ansi-styles": "^3.2.0",
-        "jest-get-type": "^24.0.0",
-        "jest-matcher-utils": "^24.0.0",
-        "jest-message-util": "^24.0.0",
-        "jest-regex-util": "^24.0.0"
+        "jest-get-type": "^24.3.0",
+        "jest-matcher-utils": "^24.3.1",
+        "jest-message-util": "^24.3.0",
+        "jest-regex-util": "^24.3.0"
       }
     },
     "express": {
@@ -4393,7 +4676,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4411,11 +4695,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4428,15 +4714,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4539,7 +4828,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4549,6 +4839,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4561,17 +4852,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4588,6 +4882,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4660,7 +4955,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4670,6 +4966,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4745,7 +5042,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4775,6 +5073,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4792,6 +5091,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4830,11 +5130,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -6248,235 +6550,212 @@
       }
     },
     "jest": {
-      "version": "24.1.0",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-24.1.0.tgz",
-      "integrity": "sha512-+q91L65kypqklvlRFfXfdzUKyngQLOcwGhXQaLmVHv+d09LkNXuBuGxlofTFW42XMzu3giIcChchTsCNUjQ78A==",
+      "version": "24.3.1",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-24.3.1.tgz",
+      "integrity": "sha512-SqZguEbYNcZ3r0KUUBN+IkKfyPS1VBbIUiK4Wrc0AiGUR52gJa0fmlWSOCL3x25908QrfoQwkVDu5jCsfXb2ig==",
       "dev": true,
       "requires": {
         "import-local": "^2.0.0",
-        "jest-cli": "^24.1.0"
+        "jest-cli": "^24.3.1"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
-          "integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==",
-          "dev": true
-        },
         "jest-cli": {
-          "version": "24.1.0",
-          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-24.1.0.tgz",
-          "integrity": "sha512-U/iyWPwOI0T1CIxVLtk/2uviOTJ/OiSWJSe8qt6X1VkbbgP+nrtLJlmT9lPBe4lK78VNFJtrJ7pttcNv/s7yCw==",
+          "version": "24.3.1",
+          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-24.3.1.tgz",
+          "integrity": "sha512-HdwMgigvDQdlWX7gwM2QMkJJRqSk7tTYKq7kVplblK28RarqquJMWV/lOCN8CukuG9u3DZTeXpCDXR7kpGfB3w==",
           "dev": true,
           "requires": {
-            "ansi-escapes": "^3.0.0",
+            "@jest/core": "^24.3.1",
+            "@jest/test-result": "^24.3.0",
+            "@jest/types": "^24.3.0",
             "chalk": "^2.0.1",
             "exit": "^0.1.2",
-            "glob": "^7.1.2",
-            "graceful-fs": "^4.1.15",
             "import-local": "^2.0.0",
             "is-ci": "^2.0.0",
-            "istanbul-api": "^2.0.8",
-            "istanbul-lib-coverage": "^2.0.2",
-            "istanbul-lib-instrument": "^3.0.1",
-            "istanbul-lib-source-maps": "^3.0.1",
-            "jest-changed-files": "^24.0.0",
-            "jest-config": "^24.1.0",
-            "jest-environment-jsdom": "^24.0.0",
-            "jest-get-type": "^24.0.0",
-            "jest-haste-map": "^24.0.0",
-            "jest-message-util": "^24.0.0",
-            "jest-regex-util": "^24.0.0",
-            "jest-resolve-dependencies": "^24.1.0",
-            "jest-runner": "^24.1.0",
-            "jest-runtime": "^24.1.0",
-            "jest-snapshot": "^24.1.0",
-            "jest-util": "^24.0.0",
-            "jest-validate": "^24.0.0",
-            "jest-watcher": "^24.0.0",
-            "jest-worker": "^24.0.0",
-            "micromatch": "^3.1.10",
-            "node-notifier": "^5.2.1",
-            "p-each-series": "^1.0.0",
-            "pirates": "^4.0.0",
+            "jest-config": "^24.3.1",
+            "jest-util": "^24.3.0",
+            "jest-validate": "^24.3.1",
             "prompts": "^2.0.1",
-            "realpath-native": "^1.0.0",
-            "rimraf": "^2.5.4",
-            "slash": "^2.0.0",
-            "string-length": "^2.0.0",
-            "strip-ansi": "^5.0.0",
-            "which": "^1.2.12",
+            "realpath-native": "^1.1.0",
             "yargs": "^12.0.2"
-          }
-        },
-        "strip-ansi": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
-          "integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^4.0.0"
           }
         }
       }
     },
     "jest-changed-files": {
-      "version": "24.0.0",
-      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-24.0.0.tgz",
-      "integrity": "sha512-nnuU510R9U+UX0WNb5XFEcsrMqriSiRLeO9KWDFgPrpToaQm60prfQYpxsXigdClpvNot5bekDY440x9dNGnsQ==",
+      "version": "24.3.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-24.3.0.tgz",
+      "integrity": "sha512-fTq0YAUR6644fgsqLC7Zi2gXA/bAplMRvfXQdutmkwgrCKK6upkj+sgXqsUfUZRm15CVr3YSojr/GRNn71IMvg==",
       "dev": true,
       "requires": {
+        "@jest/types": "^24.3.0",
         "execa": "^1.0.0",
         "throat": "^4.0.0"
       }
     },
     "jest-config": {
-      "version": "24.1.0",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-24.1.0.tgz",
-      "integrity": "sha512-FbbRzRqtFC6eGjG5VwsbW4E5dW3zqJKLWYiZWhB0/4E5fgsMw8GODLbGSrY5t17kKOtCWb/Z7nsIThRoDpuVyg==",
+      "version": "24.3.1",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-24.3.1.tgz",
+      "integrity": "sha512-ujHQywsM//vKFvJwEC02KNZgKAGOzGz1bFPezmTQtuj8XdfsAVq8p6N/dw4yodXV11gSf6TJ075i4ehM+mKatA==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.1.0",
-        "babel-jest": "^24.1.0",
+        "@jest/types": "^24.3.0",
+        "babel-jest": "^24.3.1",
         "chalk": "^2.0.1",
         "glob": "^7.1.1",
-        "jest-environment-jsdom": "^24.0.0",
-        "jest-environment-node": "^24.0.0",
-        "jest-get-type": "^24.0.0",
-        "jest-jasmine2": "^24.1.0",
-        "jest-regex-util": "^24.0.0",
-        "jest-resolve": "^24.1.0",
-        "jest-util": "^24.0.0",
-        "jest-validate": "^24.0.0",
+        "jest-environment-jsdom": "^24.3.1",
+        "jest-environment-node": "^24.3.1",
+        "jest-get-type": "^24.3.0",
+        "jest-jasmine2": "^24.3.1",
+        "jest-regex-util": "^24.3.0",
+        "jest-resolve": "^24.3.1",
+        "jest-util": "^24.3.0",
+        "jest-validate": "^24.3.1",
         "micromatch": "^3.1.10",
-        "pretty-format": "^24.0.0",
-        "realpath-native": "^1.0.2"
+        "pretty-format": "^24.3.1",
+        "realpath-native": "^1.1.0"
       }
     },
     "jest-diff": {
-      "version": "24.0.0",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.0.0.tgz",
-      "integrity": "sha512-XY5wMpRaTsuMoU+1/B2zQSKQ9RdE9gsLkGydx3nvApeyPijLA8GtEvIcPwISRCer+VDf9W1mStTYYq6fPt8ryA==",
+      "version": "24.3.1",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.3.1.tgz",
+      "integrity": "sha512-YRVzDguyzShP3Pb9wP/ykBkV7Z+O4wltrMZ2P4LBtNxrHNpxwI2DECrpD9XevxWubRy5jcE8sSkxyX3bS7W+rA==",
       "dev": true,
       "requires": {
         "chalk": "^2.0.1",
-        "diff-sequences": "^24.0.0",
-        "jest-get-type": "^24.0.0",
-        "pretty-format": "^24.0.0"
+        "diff-sequences": "^24.3.0",
+        "jest-get-type": "^24.3.0",
+        "pretty-format": "^24.3.1"
       }
     },
     "jest-docblock": {
-      "version": "24.0.0",
-      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-24.0.0.tgz",
-      "integrity": "sha512-KfAKZ4SN7CFOZpWg4i7g7MSlY0M+mq7K0aMqENaG2vHuhC9fc3vkpU/iNN9sOus7v3h3Y48uEjqz3+Gdn2iptA==",
+      "version": "24.3.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-24.3.0.tgz",
+      "integrity": "sha512-nlANmF9Yq1dufhFlKG9rasfQlrY7wINJbo3q01tu56Jv5eBU5jirylhF2O5ZBnLxzOVBGRDz/9NAwNyBtG4Nyg==",
       "dev": true,
       "requires": {
         "detect-newline": "^2.1.0"
       }
     },
     "jest-each": {
-      "version": "24.0.0",
-      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-24.0.0.tgz",
-      "integrity": "sha512-gFcbY4Cu55yxExXMkjrnLXov3bWO3dbPAW7HXb31h/DNWdNc/6X8MtxGff8nh3/MjkF9DpVqnj0KsPKuPK0cpA==",
+      "version": "24.3.1",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-24.3.1.tgz",
+      "integrity": "sha512-GTi+nxDaWwSgOPLiiqb/p4LURy0mv3usoqsA2eoTYSmRsLgjgZ6VUyRpUBH5JY9EMBx33suNFXk0iyUm29WRpw==",
       "dev": true,
       "requires": {
+        "@jest/types": "^24.3.0",
         "chalk": "^2.0.1",
-        "jest-get-type": "^24.0.0",
-        "jest-util": "^24.0.0",
-        "pretty-format": "^24.0.0"
+        "jest-get-type": "^24.3.0",
+        "jest-util": "^24.3.0",
+        "pretty-format": "^24.3.1"
       }
     },
     "jest-environment-jsdom": {
-      "version": "24.0.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-24.0.0.tgz",
-      "integrity": "sha512-1YNp7xtxajTRaxbylDc2pWvFnfDTH5BJJGyVzyGAKNt/lEULohwEV9zFqTgG4bXRcq7xzdd+sGFws+LxThXXOw==",
+      "version": "24.3.1",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-24.3.1.tgz",
+      "integrity": "sha512-rz2OSYJiQerDqWDwjisqRwhVNpwkqFXdtyMzEuJ47Ip9NRpRQ+qy7/+zFujPUy/Z+zjWRO5seHLB/dOD4VpEVg==",
       "dev": true,
       "requires": {
-        "jest-mock": "^24.0.0",
-        "jest-util": "^24.0.0",
+        "@jest/environment": "^24.3.1",
+        "@jest/fake-timers": "^24.3.0",
+        "@jest/types": "^24.3.0",
+        "jest-mock": "^24.3.0",
+        "jest-util": "^24.3.0",
         "jsdom": "^11.5.1"
       }
     },
     "jest-environment-node": {
-      "version": "24.0.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-24.0.0.tgz",
-      "integrity": "sha512-62fOFcaEdU0VLaq8JL90TqwI7hLn0cOKOl8vY2n477vRkCJRojiRRtJVRzzCcgFvs6gqU97DNqX5R0BrBP6Rxg==",
+      "version": "24.3.1",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-24.3.1.tgz",
+      "integrity": "sha512-Xy+/yFem/yUs9OkzbcawQT237vwDjBhAVLjac1KYAMYVjGb0Vb/Ovw4g61PunVdrEIpfcXNtRUltM4+9c7lARQ==",
       "dev": true,
       "requires": {
-        "jest-mock": "^24.0.0",
-        "jest-util": "^24.0.0"
+        "@jest/environment": "^24.3.1",
+        "@jest/fake-timers": "^24.3.0",
+        "@jest/types": "^24.3.0",
+        "jest-mock": "^24.3.0",
+        "jest-util": "^24.3.0"
       }
     },
     "jest-get-type": {
-      "version": "24.0.0",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.0.0.tgz",
-      "integrity": "sha512-z6/Eyf6s9ZDGz7eOvl+fzpuJmN9i0KyTt1no37/dHu8galssxz5ZEgnc1KaV8R31q1khxyhB4ui/X5ZjjPk77w==",
+      "version": "24.3.0",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.3.0.tgz",
+      "integrity": "sha512-HYF6pry72YUlVcvUx3sEpMRwXEWGEPlJ0bSPVnB3b3n++j4phUEoSPcS6GC0pPJ9rpyPSe4cb5muFo6D39cXow==",
       "dev": true
     },
     "jest-haste-map": {
-      "version": "24.0.0",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.0.0.tgz",
-      "integrity": "sha512-CcViJyUo41IQqttLxXVdI41YErkzBKbE6cS6dRAploCeutePYfUimWd3C9rQEWhX0YBOQzvNsC0O9nYxK2nnxQ==",
+      "version": "24.3.1",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.3.1.tgz",
+      "integrity": "sha512-OTMQle+astr1lWKi62Ccmk2YWn6OtUoU/8JpJdg8zdsnpFIry/k0S4sQ4nWocdM07PFdvqcthWc78CkCE6sXvA==",
       "dev": true,
       "requires": {
+        "@jest/types": "^24.3.0",
         "fb-watchman": "^2.0.0",
         "graceful-fs": "^4.1.15",
         "invariant": "^2.2.4",
-        "jest-serializer": "^24.0.0",
-        "jest-util": "^24.0.0",
-        "jest-worker": "^24.0.0",
+        "jest-serializer": "^24.3.0",
+        "jest-util": "^24.3.0",
+        "jest-worker": "^24.3.1",
         "micromatch": "^3.1.10",
-        "sane": "^3.0.0"
+        "sane": "^4.0.3"
       }
     },
     "jest-jasmine2": {
-      "version": "24.1.0",
-      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-24.1.0.tgz",
-      "integrity": "sha512-H+o76SdSNyCh9fM5K8upK45YTo/DiFx5w2YAzblQebSQmukDcoVBVeXynyr7DDnxh+0NTHYRCLwJVf3tC518wg==",
+      "version": "24.3.1",
+      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-24.3.1.tgz",
+      "integrity": "sha512-STo6ar1IyPlIPq9jPxDQhM7lC0dAX7KKN0LmCLMlgJeXwX+1XiVdtZDv1a4zyg6qhNdpo1arOBGY0BcovUK7ug==",
       "dev": true,
       "requires": {
         "@babel/traverse": "^7.1.0",
+        "@jest/environment": "^24.3.1",
+        "@jest/test-result": "^24.3.0",
+        "@jest/types": "^24.3.0",
         "chalk": "^2.0.1",
         "co": "^4.6.0",
-        "expect": "^24.1.0",
+        "expect": "^24.3.1",
         "is-generator-fn": "^2.0.0",
-        "jest-each": "^24.0.0",
-        "jest-matcher-utils": "^24.0.0",
-        "jest-message-util": "^24.0.0",
-        "jest-snapshot": "^24.1.0",
-        "jest-util": "^24.0.0",
-        "pretty-format": "^24.0.0",
+        "jest-each": "^24.3.1",
+        "jest-matcher-utils": "^24.3.1",
+        "jest-message-util": "^24.3.0",
+        "jest-runtime": "^24.3.1",
+        "jest-snapshot": "^24.3.1",
+        "jest-util": "^24.3.0",
+        "pretty-format": "^24.3.1",
         "throat": "^4.0.0"
       }
     },
     "jest-leak-detector": {
-      "version": "24.0.0",
-      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-24.0.0.tgz",
-      "integrity": "sha512-ZYHJYFeibxfsDSKowjDP332pStuiFT2xfc5R67Rjm/l+HFJWJgNIOCOlQGeXLCtyUn3A23+VVDdiCcnB6dTTrg==",
+      "version": "24.3.1",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-24.3.1.tgz",
+      "integrity": "sha512-GncRwEtAw/SohdSyY4bk2RE06Ac1dZrtQGZQ2j35hSuN4gAAAKSYMszJS2WDixsAEaFN+GHBHG+d8pjVGklKyw==",
       "dev": true,
       "requires": {
-        "pretty-format": "^24.0.0"
+        "pretty-format": "^24.3.1"
       }
     },
     "jest-matcher-utils": {
-      "version": "24.0.0",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.0.0.tgz",
-      "integrity": "sha512-LQTDmO+aWRz1Tf9HJg+HlPHhDh1E1c65kVwRFo5mwCVp5aQDzlkz4+vCvXhOKFjitV2f0kMdHxnODrXVoi+rlA==",
+      "version": "24.3.1",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.3.1.tgz",
+      "integrity": "sha512-P5VIsUTJeI0FYvWVMwEHjxK1L83vEkDiKMV0XFPIrT2jzWaWPB2+dPCHkP2ID9z4eUKElaHqynZnJiOdNVHfXQ==",
       "dev": true,
       "requires": {
         "chalk": "^2.0.1",
-        "jest-diff": "^24.0.0",
-        "jest-get-type": "^24.0.0",
-        "pretty-format": "^24.0.0"
+        "jest-diff": "^24.3.1",
+        "jest-get-type": "^24.3.0",
+        "pretty-format": "^24.3.1"
       }
     },
     "jest-message-util": {
-      "version": "24.0.0",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-24.0.0.tgz",
-      "integrity": "sha512-J9ROJIwz/IeC+eV1XSwnRK4oAwPuhmxEyYx1+K5UI+pIYwFZDSrfZaiWTdq0d2xYFw4Xiu+0KQWsdsQpgJMf3Q==",
+      "version": "24.3.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-24.3.0.tgz",
+      "integrity": "sha512-lXM0YgKYGqN5/eH1NGw4Ix+Pk2I9Y77beyRas7xM24n+XTTK3TbT0VkT3L/qiyS7WkW0YwyxoXnnAaGw4hsEDA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
+        "@jest/test-result": "^24.3.0",
+        "@jest/types": "^24.3.0",
+        "@types/stack-utils": "^1.0.1",
         "chalk": "^2.0.1",
         "micromatch": "^3.1.10",
         "slash": "^2.0.0",
@@ -6484,125 +6763,143 @@
       }
     },
     "jest-mock": {
-      "version": "24.0.0",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-24.0.0.tgz",
-      "integrity": "sha512-sQp0Hu5fcf5NZEh1U9eIW2qD0BwJZjb63Yqd98PQJFvf/zzUTBoUAwv/Dc/HFeNHIw1f3hl/48vNn+j3STaI7A==",
-      "dev": true
+      "version": "24.3.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-24.3.0.tgz",
+      "integrity": "sha512-AhAo0qjbVWWGvcbW5nChFjR0ObQImvGtU6DodprNziDOt+pP0CBdht/sYcNIOXeim8083QUi9bC8QdKB8PTK4Q==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^24.3.0"
+      }
     },
     "jest-regex-util": {
-      "version": "24.0.0",
-      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-24.0.0.tgz",
-      "integrity": "sha512-Jv/uOTCuC+PY7WpJl2mpoI+WbY2ut73qwwO9ByJJNwOCwr1qWhEW2Lyi2S9ZewUdJqeVpEBisdEVZSI+Zxo58Q==",
+      "version": "24.3.0",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-24.3.0.tgz",
+      "integrity": "sha512-tXQR1NEOyGlfylyEjg1ImtScwMq8Oh3iJbGTjN7p0J23EuVX1MA8rwU69K4sLbCmwzgCUbVkm0FkSF9TdzOhtg==",
       "dev": true
     },
     "jest-resolve": {
-      "version": "24.1.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-24.1.0.tgz",
-      "integrity": "sha512-TPiAIVp3TG6zAxH28u/6eogbwrvZjBMWroSLBDkwkHKrqxB/RIdwkWDye4uqPlZIXWIaHtifY3L0/eO5Z0f2wg==",
+      "version": "24.3.1",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-24.3.1.tgz",
+      "integrity": "sha512-N+Q3AcVuKxpn/kjQMxUVLwBk32ZE1diP4MPcHyjVwcKpCUuKrktfRR3Mqe/T2HoD25wyccstaqcPUKIudl41bg==",
       "dev": true,
       "requires": {
+        "@jest/types": "^24.3.0",
         "browser-resolve": "^1.11.3",
         "chalk": "^2.0.1",
-        "realpath-native": "^1.0.0"
+        "realpath-native": "^1.1.0"
       }
     },
     "jest-resolve-dependencies": {
-      "version": "24.1.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-24.1.0.tgz",
-      "integrity": "sha512-2VwPsjd3kRPu7qe2cpytAgowCObk5AKeizfXuuiwgm1a9sijJDZe8Kh1sFj6FKvSaNEfCPlBVkZEJa2482m/Uw==",
+      "version": "24.3.1",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-24.3.1.tgz",
+      "integrity": "sha512-9JUejNImGnJjbNR/ttnod+zQIWANpsrYMPt18s2tYGK6rP191qFsyEQ2BhAQMdYDRkTmi8At+Co9tL+jTPqdpw==",
       "dev": true,
       "requires": {
-        "jest-regex-util": "^24.0.0",
-        "jest-snapshot": "^24.1.0"
+        "@jest/types": "^24.3.0",
+        "jest-regex-util": "^24.3.0",
+        "jest-snapshot": "^24.3.1"
       }
     },
     "jest-runner": {
-      "version": "24.1.0",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-24.1.0.tgz",
-      "integrity": "sha512-CDGOkT3AIFl16BLL/OdbtYgYvbAprwJ+ExKuLZmGSCSldwsuU2dEGauqkpvd9nphVdAnJUcP12e/EIlnTX0QXg==",
+      "version": "24.3.1",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-24.3.1.tgz",
+      "integrity": "sha512-Etc9hQ5ruwg+q7DChm+E8qzHHdNTLeUdlo+whPQRSpNSgl0AEgc2r2mT4lxODREqmnHg9A8JHA44pIG4GE0Gzg==",
       "dev": true,
       "requires": {
+        "@jest/console": "^24.3.0",
+        "@jest/environment": "^24.3.1",
+        "@jest/test-result": "^24.3.0",
+        "@jest/types": "^24.3.0",
         "chalk": "^2.4.2",
         "exit": "^0.1.2",
         "graceful-fs": "^4.1.15",
-        "jest-config": "^24.1.0",
-        "jest-docblock": "^24.0.0",
-        "jest-haste-map": "^24.0.0",
-        "jest-jasmine2": "^24.1.0",
-        "jest-leak-detector": "^24.0.0",
-        "jest-message-util": "^24.0.0",
-        "jest-runtime": "^24.1.0",
-        "jest-util": "^24.0.0",
-        "jest-worker": "^24.0.0",
+        "jest-config": "^24.3.1",
+        "jest-docblock": "^24.3.0",
+        "jest-haste-map": "^24.3.1",
+        "jest-jasmine2": "^24.3.1",
+        "jest-leak-detector": "^24.3.1",
+        "jest-message-util": "^24.3.0",
+        "jest-resolve": "^24.3.1",
+        "jest-runtime": "^24.3.1",
+        "jest-util": "^24.3.0",
+        "jest-worker": "^24.3.1",
         "source-map-support": "^0.5.6",
         "throat": "^4.0.0"
       }
     },
     "jest-runtime": {
-      "version": "24.1.0",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-24.1.0.tgz",
-      "integrity": "sha512-59/BY6OCuTXxGeDhEMU7+N33dpMQyXq7MLK07cNSIY/QYt2QZgJ7Tjx+rykBI0skAoigFl0A5tmT8UdwX92YuQ==",
+      "version": "24.3.1",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-24.3.1.tgz",
+      "integrity": "sha512-Qz/tJWbZ2naFJ2Kvy1p+RhhRgsPYh4e6wddVRy6aHBr32FTt3Ja33bfV7pkMFWXFbVuAsJMJVdengbvdhWzq4A==",
       "dev": true,
       "requires": {
-        "@babel/core": "^7.1.0",
-        "babel-plugin-istanbul": "^5.1.0",
+        "@jest/console": "^24.3.0",
+        "@jest/environment": "^24.3.1",
+        "@jest/source-map": "^24.3.0",
+        "@jest/transform": "^24.3.1",
+        "@jest/types": "^24.3.0",
+        "@types/yargs": "^12.0.2",
         "chalk": "^2.0.1",
-        "convert-source-map": "^1.4.0",
         "exit": "^0.1.2",
-        "fast-json-stable-stringify": "^2.0.0",
         "glob": "^7.1.3",
         "graceful-fs": "^4.1.15",
-        "jest-config": "^24.1.0",
-        "jest-haste-map": "^24.0.0",
-        "jest-message-util": "^24.0.0",
-        "jest-regex-util": "^24.0.0",
-        "jest-resolve": "^24.1.0",
-        "jest-snapshot": "^24.1.0",
-        "jest-util": "^24.0.0",
-        "jest-validate": "^24.0.0",
-        "micromatch": "^3.1.10",
-        "realpath-native": "^1.0.0",
+        "jest-config": "^24.3.1",
+        "jest-haste-map": "^24.3.1",
+        "jest-message-util": "^24.3.0",
+        "jest-mock": "^24.3.0",
+        "jest-regex-util": "^24.3.0",
+        "jest-resolve": "^24.3.1",
+        "jest-snapshot": "^24.3.1",
+        "jest-util": "^24.3.0",
+        "jest-validate": "^24.3.1",
+        "realpath-native": "^1.1.0",
         "slash": "^2.0.0",
         "strip-bom": "^3.0.0",
-        "write-file-atomic": "2.4.1",
         "yargs": "^12.0.2"
       }
     },
     "jest-serializer": {
-      "version": "24.0.0",
-      "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-24.0.0.tgz",
-      "integrity": "sha512-9FKxQyrFgHtx3ozU+1a8v938ILBE7S8Ko3uiAVjT8Yfi2o91j/fj81jacCQZ/Ihjiff/VsUCXVgQ+iF1XdImOw==",
+      "version": "24.3.0",
+      "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-24.3.0.tgz",
+      "integrity": "sha512-RiSpqo2OFbVLJN/PgAOwQIUeHDfss6NBUDTLhjiJM8Bb5rMrwRqHfkaqahIsOf9cXXB5UjcqDCzbQ7AIoMqWkg==",
       "dev": true
     },
     "jest-snapshot": {
-      "version": "24.1.0",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-24.1.0.tgz",
-      "integrity": "sha512-th6TDfFqEmXvuViacU1ikD7xFb7lQsPn2rJl7OEmnfIVpnrx3QNY2t3PE88meeg0u/mQ0nkyvmC05PBqO4USFA==",
+      "version": "24.3.1",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-24.3.1.tgz",
+      "integrity": "sha512-7wbNJWh0sBjmoaexTOWqS7nleTQME7o2W9XKU6CHCxG49Thjct4aVPC/QPNF5NHnvf4M/VDmudIDbwz6noJTRA==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.0.0",
+        "@jest/types": "^24.3.0",
         "chalk": "^2.0.1",
-        "jest-diff": "^24.0.0",
-        "jest-matcher-utils": "^24.0.0",
-        "jest-message-util": "^24.0.0",
-        "jest-resolve": "^24.1.0",
+        "expect": "^24.3.1",
+        "jest-diff": "^24.3.1",
+        "jest-matcher-utils": "^24.3.1",
+        "jest-message-util": "^24.3.0",
+        "jest-resolve": "^24.3.1",
         "mkdirp": "^0.5.1",
         "natural-compare": "^1.4.0",
-        "pretty-format": "^24.0.0",
+        "pretty-format": "^24.3.1",
         "semver": "^5.5.0"
       }
     },
     "jest-util": {
-      "version": "24.0.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-24.0.0.tgz",
-      "integrity": "sha512-QxsALc4wguYS7cfjdQSOr5HTkmjzkHgmZvIDkcmPfl1ib8PNV8QUWLwbKefCudWS0PRKioV+VbQ0oCUPC691fQ==",
+      "version": "24.3.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-24.3.0.tgz",
+      "integrity": "sha512-eKIAC+MTKWZthUUVOwZ3Tc5a0cKMnxalQHr6qZ4kPzKn6k09sKvsmjCygqZ1SxVVfUKoa8Sfn6XDv9uTJ1iXTg==",
       "dev": true,
       "requires": {
+        "@jest/console": "^24.3.0",
+        "@jest/fake-timers": "^24.3.0",
+        "@jest/source-map": "^24.3.0",
+        "@jest/test-result": "^24.3.0",
+        "@jest/types": "^24.3.0",
+        "@types/node": "*",
         "callsites": "^3.0.0",
         "chalk": "^2.0.1",
         "graceful-fs": "^4.1.15",
         "is-ci": "^2.0.0",
-        "jest-message-util": "^24.0.0",
         "mkdirp": "^0.5.1",
         "slash": "^2.0.0",
         "source-map": "^0.6.0"
@@ -6617,44 +6914,50 @@
       }
     },
     "jest-validate": {
-      "version": "24.0.0",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.0.0.tgz",
-      "integrity": "sha512-vMrKrTOP4BBFIeOWsjpsDgVXATxCspC9S1gqvbJ3Tnn/b9ACsJmteYeVx9830UMV28Cob1RX55x96Qq3Tfad4g==",
+      "version": "24.3.1",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.3.1.tgz",
+      "integrity": "sha512-ww3+IPNCOEMi1oKlrHdSnBXetXtdrrdSh0bqLNTVkWglduhORf94RJWd1ko9oEPU2TcEQS5QIPacYziQIUzc4A==",
       "dev": true,
       "requires": {
+        "@jest/types": "^24.3.0",
         "camelcase": "^5.0.0",
         "chalk": "^2.0.1",
-        "jest-get-type": "^24.0.0",
+        "jest-get-type": "^24.3.0",
         "leven": "^2.1.0",
-        "pretty-format": "^24.0.0"
+        "pretty-format": "^24.3.1"
       },
       "dependencies": {
         "camelcase": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
-          "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.2.0.tgz",
+          "integrity": "sha512-IXFsBS2pC+X0j0N/GE7Dm7j3bsEBp+oTpb7F50dwEVX7rf3IgwO9XatnegTsDtniKCUtEJH4fSU6Asw7uoVLfQ==",
           "dev": true
         }
       }
     },
     "jest-watcher": {
-      "version": "24.0.0",
-      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-24.0.0.tgz",
-      "integrity": "sha512-GxkW2QrZ4YxmW1GUWER05McjVDunBlKMFfExu+VsGmXJmpej1saTEKvONdx5RJBlVdpPI5x6E3+EDQSIGgl53g==",
+      "version": "24.3.0",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-24.3.0.tgz",
+      "integrity": "sha512-EpJS/aUG8D3DMuy9XNA4fnkKWy3DQdoWhY92ZUdlETIeEn1xya4Np/96MBSh4II5YvxwKe6JKwbu3Bnzfwa7vA==",
       "dev": true,
       "requires": {
+        "@jest/test-result": "^24.3.0",
+        "@jest/types": "^24.3.0",
+        "@types/node": "*",
+        "@types/yargs": "^12.0.9",
         "ansi-escapes": "^3.0.0",
         "chalk": "^2.0.1",
-        "jest-util": "^24.0.0",
+        "jest-util": "^24.3.0",
         "string-length": "^2.0.0"
       }
     },
     "jest-worker": {
-      "version": "24.0.0",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.0.0.tgz",
-      "integrity": "sha512-s64/OThpfQvoCeHG963MiEZOAAxu8kHsaL/rCMF7lpdzo7vgF0CtPml9hfguOMgykgH/eOm4jFP4ibfHLruytg==",
+      "version": "24.3.1",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.3.1.tgz",
+      "integrity": "sha512-ZCoAe/iGLzTJvWHrO8fyx3bmEQhpL16SILJmWHKe8joHhyF3z00psF1sCRT54DoHw5GJG0ZpUtGy+ylvwA4haA==",
       "dev": true,
       "requires": {
+        "@types/node": "*",
         "merge-stream": "^1.0.1",
         "supports-color": "^6.1.0"
       }
@@ -7460,12 +7763,6 @@
         }
       }
     },
-    "merge": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
-      "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==",
-      "dev": true
-    },
     "merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
@@ -7611,7 +7908,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
@@ -9477,13 +9774,15 @@
       }
     },
     "pretty-format": {
-      "version": "24.0.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.0.0.tgz",
-      "integrity": "sha512-LszZaKG665djUcqg5ZQq+XzezHLKrxsA86ZABTozp+oNhkdqa+tG2dX4qa6ERl5c/sRDrAa3lHmwnvKoP+OG/g==",
+      "version": "24.3.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.3.1.tgz",
+      "integrity": "sha512-NZGH1NWS6o4i9pvRWLsxIK00JB9pqOUzVrO7yWT6vjI2thdxwvxefBJO6O5T24UAhI8P5dMceZ7x5wphgVI7Mg==",
       "dev": true,
       "requires": {
+        "@jest/types": "^24.3.0",
         "ansi-regex": "^4.0.0",
-        "ansi-styles": "^3.2.0"
+        "ansi-styles": "^3.2.0",
+        "react-is": "^16.8.4"
       },
       "dependencies": {
         "ansi-regex": {
@@ -9717,6 +10016,12 @@
         "iconv-lite": "0.4.23",
         "unpipe": "1.0.0"
       }
+    },
+    "react-is": {
+      "version": "16.8.4",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.4.tgz",
+      "integrity": "sha512-PVadd+WaUDOAciICm/J1waJaSvgq+4rHE/K70j0PFqKhkTBsPv/82UGQJNXAngz1fOQLLxI6z1sEDmJDQhCTAA==",
+      "dev": true
     },
     "read-pkg": {
       "version": "2.0.0",
@@ -10204,21 +10509,20 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sane": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/sane/-/sane-3.1.0.tgz",
-      "integrity": "sha512-G5GClRRxT1cELXfdAq7UKtUsv8q/ZC5k8lQGmjEm4HcAl3HzBy68iglyNCmw4+0tiXPCBZntslHlRhbnsSws+Q==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/sane/-/sane-4.0.3.tgz",
+      "integrity": "sha512-hSLkC+cPHiBQs7LSyXkotC3UUtyn8C4FMn50TNaacRyvBlI+3ebcxMpqckmTdtXVtel87YS7GXN3UIOj7NiGVQ==",
       "dev": true,
       "requires": {
+        "@cnakazawa/watch": "^1.0.3",
         "anymatch": "^2.0.0",
         "capture-exit": "^1.2.0",
-        "exec-sh": "^0.2.0",
+        "exec-sh": "^0.3.2",
         "execa": "^1.0.0",
         "fb-watchman": "^2.0.0",
-        "fsevents": "^1.2.3",
         "micromatch": "^3.1.4",
         "minimist": "^1.1.1",
-        "walker": "~1.0.5",
-        "watch": "~0.18.0"
+        "walker": "~1.0.5"
       },
       "dependencies": {
         "minimist": {
@@ -11733,24 +12037,6 @@
       "dev": true,
       "requires": {
         "makeerror": "1.0.x"
-      }
-    },
-    "watch": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/watch/-/watch-0.18.0.tgz",
-      "integrity": "sha1-KAlUdsbffJDJYxOJkMClQj60uYY=",
-      "dev": true,
-      "requires": {
-        "exec-sh": "^0.2.0",
-        "minimist": "^1.2.0"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        }
       }
     },
     "watchpack": {

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "html-loader": "^0.5.5",
     "html-webpack-plugin": "^3.0.6",
     "husky": "^1.3.1",
-    "jest": "^24.0.0",
+    "jest": "^24.3.1",
     "jquery": "^3.2.1",
     "less": "^3.7.1",
     "less-loader": "^4.1.0",


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [ ] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

no

<!-- Please note that we won't approve your changes if you don't add tests. -->

### Motivation / Use-Case

Currently, jest-util occurs errors when we don't use its the latest version if we use Node11.11.0.

jest's issue: https://github.com/facebook/jest/issues/8069
node's pr: https://github.com/nodejs/node/pull/26488

<!--
  What existing problem does the pull request solve?

  Please explain the motivation or use-case for making this change.
  If this Pull Request addresses an issue, please link to the issue.
-->

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  potential migration path for existing applications.
-->

no
### Additional Info
