### PR TITLE
Remove broken/deprecated mime.wasm property setter

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -155,10 +155,6 @@ class Server {
     // eslint-disable-next-line
     const app = (this.app = new express());
 
-    // ref: https://github.com/webpack/webpack-dev-server/issues/1575
-    // remove this when send@^0.16.3
-    express.static.mime.types.wasm = 'application/wasm';
-
     app.all('*', (req, res, next) => {
       if (this.checkHost(req.headers)) {
         return next();


### PR DESCRIPTION
Since `mime@2.x`, the `mime.types` property has been deprecated and privatized. I also believe that this call is no longer needed in the new version.

Fixes #1724

<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [x] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

<!-- Please note that we won't approve your changes if you don't add tests. -->

### Motivation / Use-Case

<!--
  What existing problem does the pull request solve?

  Please explain the motivation or use-case for making this change.
  If this Pull Request addresses an issue, please link to the issue.
-->

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  potential migration path for existing applications.
-->

### Additional Info
