### PR TITLE
Delete a comma for Node.js <= v7.x

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -541,7 +541,7 @@ Server.prototype.checkHost = function (headers, headerToCheck) {
     // if hostHeader doesn't have scheme, add // for parsing.
     /^(.+:)?\/\//.test(hostHeader) ? hostHeader : `//${hostHeader}`,
     false,
-    true,
+    true
   ).hostname;
 
   // always allow requests with explicit IPv4 or IPv6-address.


### PR DESCRIPTION
This PR is a port of the https://github.com/webpack/webpack-dev-server/pull/1609 fix for v2