### PR TITLE
Fix: Default to localhost when no host option, remove entries that are now added automatically

### DIFF
--- a/examples/api/middleware/webpack.config.js
+++ b/examples/api/middleware/webpack.config.js
@@ -6,7 +6,7 @@ const { setup } = require('../../util');
 
 module.exports = setup({
   context: __dirname,
-  entry: ['./app.js', '../../../client/index.js?http://localhost:8080/'],
+  entry: './app.js',
   output: {
     filename: 'bundle.js',
   },

--- a/examples/api/simple/webpack.config.js
+++ b/examples/api/simple/webpack.config.js
@@ -6,7 +6,7 @@ const { setup } = require('../../util');
 
 module.exports = setup({
   context: __dirname,
-  entry: ['./app.js', '../../../client/index.js?http://localhost:8080/'],
+  entry: './app.js',
   output: {
     filename: 'bundle.js',
   },

--- a/lib/utils/createDomain.js
+++ b/lib/utils/createDomain.js
@@ -7,7 +7,7 @@ function createDomain(options, server) {
   const protocol = options.https ? 'https' : 'http';
   const hostname = options.useLocalIp
     ? ip.v4.sync() || 'localhost'
-    : options.host;
+    : options.host || 'localhost';
 
   // eslint-disable-next-line no-nested-ternary
   const port = options.socket ? 0 : server ? server.address().port : 0;

--- a/package-lock.json
+++ b/package-lock.json
@@ -4711,8 +4711,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4730,13 +4729,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4749,18 +4746,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4863,8 +4857,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4874,7 +4867,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4887,20 +4879,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4917,7 +4906,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4990,8 +4978,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5001,7 +4988,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5077,8 +5063,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5108,7 +5093,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5126,7 +5110,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5165,13 +5148,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },

--- a/test/Client.test.js
+++ b/test/Client.test.js
@@ -71,3 +71,41 @@ describe('Client code', () => {
     });
   });
 });
+
+describe('Client complex inline script path', () => {
+  beforeAll((done) => {
+    const options = {
+      port: 9000,
+      host: '0.0.0.0',
+      inline: true,
+      watchOptions: {
+        poll: true,
+      },
+      public: 'myhost.test',
+      sockPath: '/foo/test/bar/',
+    };
+    helper.startAwaitingCompilation(config, options, done);
+  });
+
+  afterAll(helper.close);
+
+  describe('browser client', () => {
+    jest.setTimeout(30000);
+
+    it('uses the correct public hostname and sockPath', (done) => {
+      runBrowser().then(({ page, browser }) => {
+        page
+          .waitForRequest((requestObj) =>
+            requestObj.url().match(/foo\/test\/bar/)
+          )
+          .then((requestObj) => {
+            expect(requestObj.url()).toMatch(
+              /^http:\/\/myhost\.test:9000\/foo\/test\/bar/
+            );
+            browser.close().then(done);
+          });
+        page.goto('http://localhost:9000/main');
+      });
+    });
+  });
+});

--- a/test/Util.test.js
+++ b/test/Util.test.js
@@ -33,6 +33,13 @@ describe('check utility functions', () => {
       expected: 'http://localhost:8080',
     },
     {
+      name: 'no host option',
+      options: {
+        port: 8080,
+      },
+      expected: 'http://localhost:8080',
+    },
+    {
       name: 'https',
       options: {
         host: 'localhost',


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [x] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

Yes, added a new test for `createDomain`.

### Motivation / Use-Case

Fixes https://github.com/webpack/webpack-dev-server/issues/1743

- Removed one of the entry scripts from the api examples because that is now added automatically
- `createDomain` should default to `localhost` when the `options.host` is not provided, that is what was resulting in `'http:/sockjs-node'` without the hostname in the middle.

<!--
  What existing problem does the pull request solve?

  Please explain the motivation or use-case for making this change.
  If this Pull Request addresses an issue, please link to the issue.
-->

### Breaking Changes

None
<!--
  If this PR introduces a breaking change, please describe the impact and a
  potential migration path for existing applications.
-->

### Additional Info
