### PR TITLE
feat: add webpack as argument to before and after options

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -497,7 +497,7 @@ class Server {
       },
       before: () => {
         if (typeof options.before === 'function') {
-          options.before(app, this);
+          options.before(app, this, compiler);
         }
       },
       middleware: () => {
@@ -507,7 +507,7 @@ class Server {
       },
       after: () => {
         if (typeof options.after === 'function') {
-          options.after(app, this);
+          options.after(app, this, compiler);
         }
       },
       headers: () => {

--- a/test/BeforeAndAfter.test.js
+++ b/test/BeforeAndAfter.test.js
@@ -1,0 +1,76 @@
+'use strict';
+
+const request = require('supertest');
+const helper = require('./helper');
+const config = require('./fixtures/simple-config/webpack.config');
+
+describe('Before And After options', () => {
+  let server;
+  let req;
+
+  beforeAll((done) => {
+    server = helper.start(
+      config,
+      {
+        before: (app, server, compiler) => {
+          if (!app) {
+            throw new Error('app is not defined');
+          }
+
+          if (!server) {
+            throw new Error('server is not defined');
+          }
+
+          if (!compiler) {
+            throw new Error('compiler is not defined');
+          }
+
+          app.get('/before/some/path', (req, res) => {
+            res.send('before');
+          });
+        },
+        after: (app, server, compiler) => {
+          if (!app) {
+            throw new Error('app is not defined');
+          }
+
+          if (!server) {
+            throw new Error('server is not defined');
+          }
+
+          if (!compiler) {
+            throw new Error('compiler is not defined');
+          }
+
+          app.get('/after/some/path', (req, res) => {
+            res.send('after');
+          });
+        },
+      },
+      done
+    );
+    req = request(server.app);
+  });
+
+  afterAll(helper.close);
+
+  it('should handle before route', () => {
+    return req
+      .get('/before/some/path')
+      .expect('Content-Type', 'text/html; charset=utf-8')
+      .expect(200)
+      .then((response) => {
+        expect(response.text).toBe('before');
+      });
+  });
+
+  it('should handle after route', () => {
+    return req
+      .get('/after/some/path')
+      .expect('Content-Type', 'text/html; charset=utf-8')
+      .expect(200)
+      .then((response) => {
+        expect(response.text).toBe('after');
+      });
+  });
+});

--- a/test/helper.js
+++ b/test/helper.js
@@ -15,6 +15,7 @@ module.exports = {
     if (options.quiet === undefined) {
       options.quiet = true;
     }
+
     // originally, inline was not working by default for tests with the API
     // if you need to test inline, it should be set explicitly,
     // rather than expecting it to be defaulted to
@@ -26,19 +27,26 @@ module.exports = {
     ) {
       options.inline = false;
     }
+
     // defaulting to this will hopefully help with problems on OSX in tests
     if (options.watchOptions === undefined) {
       options.watchOptions = {
         poll: true,
       };
     }
+
     const compiler = webpack(config);
+
     server = new Server(compiler, options);
 
     const port = options.port || 8080;
     const host = options.host || 'localhost';
+
     server.listen(port, host, (err) => {
-      if (err) return done(err);
+      if (err) {
+        return done(err);
+      }
+
       done();
     });
 
@@ -57,9 +65,11 @@ module.exports = {
     };
 
     const fullSetup = this.startFullSetup(config, options, ready);
+
     // wait for compilation, since dev server can start before this
     // https://github.com/webpack/webpack-dev-server/issues/847
     fullSetup.compiler.hooks.done.tap('done', ready);
+
     return fullSetup;
   },
   startAwaitingCompilation(config, options, done) {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [ ] This is a **bugfix**
- [x] This is a **feature**
- [ ] This is a **code refactor**
- [x] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

Yes

### Motivation / Use-Case

Allow to get information from webpack in `before` and `after`

### Breaking Changes

No

### Additional Info

No