### PR TITLE
test: compress option

### DIFF
--- a/test/Compress.test.js
+++ b/test/Compress.test.js
@@ -7,29 +7,77 @@
 
 const request = require('supertest');
 const helper = require('./helper');
-const config = require('./fixtures/simple-config/webpack.config');
+const config = require('./fixtures/simple-config-other/webpack.config');
 
 describe('Compress', () => {
   let server;
   let req;
 
-  beforeAll((done) => {
-    server = helper.start(
-      config,
-      {
-        compress: true,
-      },
-      done
-    );
-    req = request(server.app);
+  describe('undefined', () => {
+    beforeAll((done) => {
+      server = helper.start(config, {}, done);
+      req = request(server.app);
+    });
+
+    afterAll(helper.close);
+
+    it('request to bundle file', (done) => {
+      req
+        .get('/main.js')
+        .expect((res) => {
+          if (res.header['content-encoding']) {
+            throw new Error('Expected `content-encoding` header is undefined.');
+          }
+        })
+        .expect(200, done);
+    });
   });
 
-  afterAll(helper.close);
+  describe('true', () => {
+    beforeAll((done) => {
+      server = helper.start(
+        config,
+        {
+          compress: true,
+        },
+        done
+      );
+      req = request(server.app);
+    });
 
-  it.skip('request to bundle file', (done) => {
-    req
-      .get('/bundle.js')
-      .expect('Content-Encoding', 'gzip')
-      .expect(200, done);
+    afterAll(helper.close);
+
+    it('request to bundle file', (done) => {
+      req
+        .get('/main.js')
+        .expect('Content-Encoding', 'gzip')
+        .expect(200, done);
+    });
+  });
+
+  describe('false', () => {
+    beforeAll((done) => {
+      server = helper.start(
+        config,
+        {
+          compress: false,
+        },
+        done
+      );
+      req = request(server.app);
+    });
+
+    afterAll(helper.close);
+
+    it('request to bundle file', (done) => {
+      req
+        .get('/main.js')
+        .expect((res) => {
+          if (res.header['content-encoding']) {
+            throw new Error('Expected `content-encoding` header is undefined.');
+          }
+        })
+        .expect(200, done);
+    });
   });
 });

--- a/test/fixtures/simple-config-other/foo.js
+++ b/test/fixtures/simple-config-other/foo.js
@@ -1,0 +1,5 @@
+'use strict';
+
+console.log(
+  'Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Very Long Line.'
+);

--- a/test/fixtures/simple-config-other/webpack.config.js
+++ b/test/fixtures/simple-config-other/webpack.config.js
@@ -1,0 +1,11 @@
+'use strict';
+
+module.exports = {
+  mode: 'development',
+  context: __dirname,
+  entry: './foo.js',
+  output: {
+    path: '/',
+  },
+  node: false,
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [ ] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [x] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

yep

### Motivation / Use-Case

Avoid skip test

### Breaking Changes

No

### Additional Info

/cc @hiroppy I think we should enable `compress` by default in next major for better DX, 99% developers set it to true