### PR TITLE
Feature: add --stdin as an option in webpack.config.js

### DIFF
--- a/lib/options.json
+++ b/lib/options.json
@@ -407,6 +407,7 @@
       "socket": "should be {String} (https://webpack.js.org/configuration/dev-server/#devserversocket)",
       "staticOptions": "should be {Object} (https://webpack.js.org/configuration/dev-server/#devserverstaticoptions)",
       "stats": "should be {Object|Boolean} (https://webpack.js.org/configuration/dev-server/#devserverstats-)",
+      "stdin": "should be {Boolean} (https://webpack.js.org/configuration/dev-server/#stdindevserverstdin---cli-only)",
       "useLocalIp": "should be {Boolean} (https://webpack.js.org/configuration/dev-server/#devserveruselocalip)",
       "warn": "should be {Function}",
       "watchContentBase": "should be {Boolean} (https://webpack.js.org/configuration/dev-server/#devserverwatchcontentbase)",

--- a/lib/options.json
+++ b/lib/options.json
@@ -113,6 +113,9 @@
     "hot": {
       "type": "boolean"
     },
+    "stdin": {
+      "type": "boolean"
+    },
     "hotOnly": {
       "type": "boolean"
     },

--- a/lib/utils/createConfig.js
+++ b/lib/utils/createConfig.js
@@ -67,7 +67,7 @@ function createConfig(config, argv, { port }) {
     options.watchOptions = firstWpOpt.watchOptions;
   }
 
-  if (argv.stdin) {
+  if (argv.stdin || options.stdin) {
     process.stdin.on('end', () => {
       // eslint-disable-next-line no-process-exit
       process.exit(0);


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [ ] This is a **bugfix**
- [x] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?
Test already exist 'should exit the process when SIGINT is detected' test in CLI.test
<!-- Please note that we won't approve your changes if you don't add tests. -->

### Motivation / Use-Case
solve these issues : https://github.com/webpack/webpack-cli/issues/789 , https://github.com/webpack/webpack-dev-server/issues/1712
<!--
  What existing problem does the pull request solve?

  Please explain the motivation or use-case for making this change.
  If this Pull Request addresses an issue, please link to the issue.
-->

### Breaking Changes
No
<!--
  If this PR introduces a breaking change, please describe the impact and a
  potential migration path for existing applications.
-->

### Additional Info
Minimum reproducible repo : https://github.com/EslamHiko/webpack-dev-server/tree/add-stdin-option
go to examples/cli/stdin and add that config : 
```
'use strict';

module.exports = {
  context: __dirname,
  entry: './app.js',
  devServer:{
    stdin:true
  }
};

```
Run `npm run webpack-dev-server` without `--stdin` flag
The server will accept input and closes when you exit CTRL+C/CTRL+D the same behavior when you add `--stdin` flag
if you don't add the option and run `npm run webpack-dev-server` without `--stdin` it won't accept input