### PR TITLE
Only add entries after compilers have been created

### DIFF
--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -20,7 +20,6 @@ const webpack = require('webpack');
 const options = require('./options');
 const Server = require('../lib/Server');
 
-const addEntries = require('../lib/utils/addEntries');
 const colors = require('../lib/utils/colors');
 const createConfig = require('../lib/utils/createConfig');
 const createDomain = require('../lib/utils/createDomain');
@@ -139,8 +138,6 @@ function processOptions(config) {
 
 function startDevServer(config, options) {
   const log = createLogger(options);
-
-  addEntries(config, options);
 
   let compiler;
 

--- a/test/Server.test.js
+++ b/test/Server.test.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { relative, sep } = require('path');
 const webpack = require('webpack');
 const request = require('supertest');
 const Server = require('../lib/Server');
@@ -7,6 +8,64 @@ const config = require('./fixtures/simple-config/webpack.config');
 const helper = require('./helper');
 
 describe('Server', () => {
+  describe('addEntries', () => {
+    it('add hot option', () => {
+      return new Promise((res) => {
+        // eslint-disable-next-line
+        const Server = require('../lib/Server');
+        const compiler = webpack(config);
+        const server = new Server(compiler, {
+          hot: true,
+        });
+
+        expect(
+          server.middleware.context.compiler.options.entry.map((p) => {
+            return relative('.', p).split(sep);
+          })
+        ).toMatchSnapshot();
+        expect(
+          server.middleware.context.compiler.options.plugins
+        ).toMatchSnapshot();
+
+        compiler.hooks.done.tap('webpack-dev-server', () => {
+          server.close(() => {
+            res();
+          });
+        });
+
+        compiler.run(() => {});
+      });
+    });
+
+    it('add hotOnly option', () => {
+      return new Promise((res) => {
+        // eslint-disable-next-line
+        const Server = require('../lib/Server');
+        const compiler = webpack(config);
+        const server = new Server(compiler, {
+          hotOnly: true,
+        });
+
+        expect(
+          server.middleware.context.compiler.options.entry.map((p) => {
+            return relative('.', p).split(sep);
+          })
+        ).toMatchSnapshot();
+        expect(
+          server.middleware.context.compiler.options.plugins
+        ).toMatchSnapshot();
+
+        compiler.hooks.done.tap('webpack-dev-server', () => {
+          server.close(() => {
+            res();
+          });
+        });
+
+        compiler.run(() => {});
+      });
+    });
+  });
+
   // issue: https://github.com/webpack/webpack-dev-server/issues/1724
   describe('express.static.mine.types', () => {
     beforeEach(() => {

--- a/test/__snapshots__/Server.test.js.snap
+++ b/test/__snapshots__/Server.test.js.snap
@@ -1,5 +1,65 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Server addEntries add hot option 1`] = `
+Array [
+  Array [
+    "client",
+    "index.js?http:",
+    "localhost",
+  ],
+  Array [
+    "node_modules",
+    "webpack",
+    "hot",
+    "dev-server.js",
+  ],
+  Array [
+    "foo.js",
+  ],
+]
+`;
+
+exports[`Server addEntries add hot option 2`] = `
+Array [
+  HotModuleReplacementPlugin {
+    "fullBuildTimeout": 200,
+    "multiStep": undefined,
+    "options": Object {},
+    "requestTimeout": 10000,
+  },
+]
+`;
+
+exports[`Server addEntries add hotOnly option 1`] = `
+Array [
+  Array [
+    "client",
+    "index.js?http:",
+    "localhost",
+  ],
+  Array [
+    "node_modules",
+    "webpack",
+    "hot",
+    "only-dev-server.js",
+  ],
+  Array [
+    "foo.js",
+  ],
+]
+`;
+
+exports[`Server addEntries add hotOnly option 2`] = `
+Array [
+  HotModuleReplacementPlugin {
+    "fullBuildTimeout": 200,
+    "multiStep": undefined,
+    "options": Object {},
+    "requestTimeout": 10000,
+  },
+]
+`;
+
 exports[`Server stats should works with difference stats values (contains 'hash', 'assets', 'warnings' and 'errors') 1`] = `
 Array [
   "errors",


### PR DESCRIPTION
- [x] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [x] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

No...

### Motivation / Use-Case

Currently `addEntries` is called twice when using the `cli`. First it is called [here](https://github.com/webpack/webpack-dev-server/blob/master/bin/webpack-dev-server.js#L143) in the cli bin, and then always called again when we create the dev server instance [by calling updateCompiler](https://github.com/webpack/webpack-dev-server/blob/master/lib/Server.js#L98) then [here](https://github.com/webpack/webpack-dev-server/blob/master/lib/utils/updateCompiler.js#L47).

This extra call is not needed, and actually causes an issue with my specific setup. In my Webpack config the `entry` is set dynamically via a plugin once the plugin has initialized. Since the first call to `addEntries` is ran on the raw config before any plugins run it is inaccurate and thinks that I have no entries, causing some issues. This would cause issues for any plugin which mutates the entries assuming it is used with the `webpack-dev-server` cli.

### Additional Info

If a test case is required for this then I'd be happy to work with someone to figure out the best way to integrate such a test into this suite. It looks like the CLI tests are fairly basic and separated from the server  tests.