### PR TITLE
fix(addEntries): only add client entry to web targets

### DIFF
--- a/lib/options.json
+++ b/lib/options.json
@@ -172,6 +172,26 @@
     "inline": {
       "type": "boolean"
     },
+    "injectClient": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "instanceof": "Function"
+        }
+      ]
+    },
+    "injectHot": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "instanceof": "Function"
+        }
+      ]
+    },
     "disableHostCheck": {
       "type": "boolean"
     },

--- a/lib/utils/addEntries.js
+++ b/lib/utils/addEntries.js
@@ -18,26 +18,31 @@ function addEntries(config, options, server) {
     const domain = createDomain(options, app);
     const sockPath = options.sockPath ? `&sockPath=${options.sockPath}` : '';
     const sockPort = options.sockPort ? `&sockPort=${options.sockPort}` : '';
-    const entries = [
-      `${require.resolve('../../client/')}?${domain}${sockPath}${sockPort}`,
-    ];
+    const clientEntry = `${require.resolve(
+      '../../client/'
+    )}?${domain}${sockPath}${sockPort}`;
+    let hotEntry;
+
     if (options.hotOnly) {
-      entries.push(require.resolve('webpack/hot/only-dev-server'));
+      hotEntry = require.resolve('webpack/hot/only-dev-server');
     } else if (options.hot) {
-      entries.push(require.resolve('webpack/hot/dev-server'));
+      hotEntry = require.resolve('webpack/hot/dev-server');
     }
 
-    const prependEntry = (entry) => {
-      if (typeof entry === 'function') {
-        return () => Promise.resolve(entry()).then(prependEntry);
+    const prependEntry = (originalEntry, additionalEntries) => {
+      if (typeof originalEntry === 'function') {
+        return () =>
+          Promise.resolve(originalEntry()).then((entry) =>
+            prependEntry(entry, additionalEntries)
+          );
       }
 
-      if (typeof entry === 'object' && !Array.isArray(entry)) {
+      if (typeof originalEntry === 'object' && !Array.isArray(originalEntry)) {
         const clone = {};
 
-        Object.keys(entry).forEach((key) => {
+        Object.keys(originalEntry).forEach((key) => {
           // entry[key] should be a string here
-          clone[key] = prependEntry(entry[key]);
+          clone[key] = prependEntry(originalEntry[key], additionalEntries);
         });
 
         return clone;
@@ -45,8 +50,8 @@ function addEntries(config, options, server) {
 
       // in this case, entry is a string or an array.
       // make sure that we do not add duplicates.
-      const entriesClone = entries.slice(0);
-      [].concat(entry).forEach((newEntry) => {
+      const entriesClone = additionalEntries.slice(0);
+      [].concat(originalEntry).forEach((newEntry) => {
         if (!entriesClone.includes(newEntry)) {
           entriesClone.push(newEntry);
         }
@@ -56,7 +61,17 @@ function addEntries(config, options, server) {
 
     // eslint-disable-next-line no-shadow
     [].concat(config).forEach((config) => {
-      config.entry = prependEntry(config.entry || './src');
+      const webTarget =
+        config.target === 'web' ||
+        config.target === 'webworker' ||
+        config.target == null;
+      const additionalEntries = webTarget ? [clientEntry] : [];
+
+      if (hotEntry) {
+        additionalEntries.push(hotEntry);
+      }
+
+      config.entry = prependEntry(config.entry || './src', additionalEntries);
 
       if (options.hot || options.hotOnly) {
         config.plugins = config.plugins || [];

--- a/lib/utils/addEntries.js
+++ b/lib/utils/addEntries.js
@@ -60,14 +60,27 @@ function addEntries(config, options, server) {
     };
 
     // eslint-disable-next-line no-shadow
+    const checkInject = (option, config, defaultValue) => {
+      if (typeof option === 'boolean') return option;
+      if (typeof option === 'function') return option(config);
+      return defaultValue;
+    };
+
+    // eslint-disable-next-line no-shadow
     [].concat(config).forEach((config) => {
       const webTarget =
         config.target === 'web' ||
         config.target === 'webworker' ||
         config.target == null;
-      const additionalEntries = webTarget ? [clientEntry] : [];
+      const additionalEntries = checkInject(
+        options.injectClient,
+        config,
+        webTarget
+      )
+        ? [clientEntry]
+        : [];
 
-      if (hotEntry) {
+      if (hotEntry && checkInject(options.injectHot, config, true)) {
         additionalEntries.push(hotEntry);
       }
 

--- a/test/UniversalCompiler.test.js
+++ b/test/UniversalCompiler.test.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const request = require('supertest');
+const helper = require('./helper');
+const config = require('./fixtures/universal-compiler-config/webpack.config');
+
+describe('UniversalCompiler', () => {
+  let server;
+  let req;
+  beforeAll((done) => {
+    server = helper.start(config, { inline: true }, done);
+    req = request(server.app);
+  });
+
+  afterAll(helper.close);
+
+  it('client bundle should have the inlined the client runtime', (done) => {
+    req
+      .get('/client.js')
+      .expect('Content-Type', 'application/javascript; charset=UTF-8')
+      .expect(200)
+      .end((err, res) => {
+        if (err) {
+          return done(err);
+        }
+        expect(res.text).toContain('Hello from the client');
+        expect(res.text).toContain('webpack-dev-server/client');
+        done();
+      });
+  });
+
+  it('server bundle should NOT have the inlined the client runtime', (done) => {
+    // we wouldn't normally request a server bundle
+    // but we'll do it here to check the contents
+    req
+      .get('/server.js')
+      .expect('Content-Type', 'application/javascript; charset=UTF-8')
+      .expect(200)
+      .end((err, res) => {
+        if (err) {
+          return done(err);
+        }
+        expect(res.text).toContain('Hello from the server');
+        expect(res.text).not.toContain('webpack-dev-server/client');
+        done();
+      });
+  });
+});

--- a/test/fixtures/universal-compiler-config/client.js
+++ b/test/fixtures/universal-compiler-config/client.js
@@ -1,0 +1,3 @@
+'use strict';
+
+console.log('Hello from the client');

--- a/test/fixtures/universal-compiler-config/server.js
+++ b/test/fixtures/universal-compiler-config/server.js
@@ -1,0 +1,3 @@
+'use strict';
+
+console.log('Hello from the server');

--- a/test/fixtures/universal-compiler-config/webpack.config.js
+++ b/test/fixtures/universal-compiler-config/webpack.config.js
@@ -1,0 +1,25 @@
+'use strict';
+
+module.exports = [
+  {
+    mode: 'development',
+    context: __dirname,
+    entry: './client.js',
+    output: {
+      path: '/',
+      filename: 'client.js',
+    },
+    node: false,
+  },
+  {
+    mode: 'development',
+    context: __dirname,
+    target: 'node',
+    entry: './server.js',
+    output: {
+      path: '/',
+      filename: 'server.js',
+    },
+    node: false,
+  },
+];


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [x] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

<!-- Please note that we won't approve your changes if you don't add tests. -->
Yes

### Motivation / Use-Case

<!--
  What existing problem does the pull request solve?

  Please explain the motivation or use-case for making this change.
  If this Pull Request addresses an issue, please link to the issue.
-->

When using an universal/isomorphic multicompiler setup and using the default setting of `inline:true`, the client runtime gets injected into the entries for each compilation.  However, as far as I can tell, the client runtime is only designed to work in the browser (`target:"web"` or `target:"webworker"`).  

With `target:"node"`, the following error is thrown:

```
urlParts.port = self.location.port;
                ^
ReferenceError: self is not defined
```

From

https://github.com/webpack/webpack-dev-server/blob/99e8db0f8cc441bb8f6acc60d786e33c38b8fc1d/client-src/default/index.js#L46

### Changes

This PR updates `addEntries` to check the compilation target for each compiler.  Since the client runtime is only designed for web targets, it is only prepended to those compilations.  The HMR runtimes are still prepended for all compile targets (when `options.hot` or `options.hotOnly` are set), because as far as I can tell, these should work regardless of the compilation target.

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  potential migration path for existing applications.
-->

None, if my assumptions are correct.

### Additional Info

Related: #1256 #1338 #1441