### PR TITLE
chore(deps): adds webpack-cli to the peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "ws": "6.2.1"
   },
   "peerDependencies": {
+    "webpack-cli": "^3.3.0",
     "webpack": "^4.0.0"
   },
   "husky": {


### PR DESCRIPTION
- [x] This is a **metadata update**

### Motivation / Use-Case

This package [requires `webpack-cli`](https://github.com/webpack/webpack-dev-server/blob/b31cbaaf49417eb4adf8949cd87c36ca82653b25/bin/webpack-dev-server.js#L59-L107) to work properly, but the dependency isn't listed anywhere. My best guess is that it's intended to be a peer dependency, so I added it to the manifest listing.

### Breaking Changes

n/a

### Additional Info

n/a
