### PR TITLE
fix: update clientLogLevel to match docs and error

### DIFF
--- a/bin/options.js
+++ b/bin/options.js
@@ -85,7 +85,8 @@ const options = {
     type: 'string',
     group: DISPLAY_GROUP,
     default: 'info',
-    describe: 'Log level in the browser (info, warning, error or none)',
+    describe:
+      'Log level in the browser (trace, debug, info, warn, error or silent)',
   },
   https: {
     type: 'boolean',

--- a/client-src/default/index.js
+++ b/client-src/default/index.js
@@ -54,9 +54,11 @@ let useErrorOverlay = false;
 let useProgress = false;
 
 const INFO = 'info';
-const WARNING = 'warning';
+const WARN = 'warn';
 const ERROR = 'error';
-const NONE = 'none';
+const DEBUG = 'debug';
+const TRACE = 'trace';
+const SILENT = 'silent';
 
 // Set the default log level
 log.setDefaultLevel(INFO);
@@ -108,14 +110,13 @@ const onSocketMsg = {
     }
     switch (level) {
       case INFO:
+      case WARN:
+      case DEBUG:
+      case TRACE:
       case ERROR:
         log.setLevel(level);
         break;
-      case WARNING:
-        // loglevel's warning name is different from webpack's
-        log.setLevel('warn');
-        break;
-      case NONE:
+      case SILENT:
         log.disableAll();
         break;
       default:

--- a/lib/options.json
+++ b/lib/options.json
@@ -37,7 +37,7 @@
       ]
     },
     "clientLogLevel": {
-      "enum": ["none", "info", "error", "warning"]
+      "enum": ["info", "warn", "error", "debug", "trace", "silent"]
     },
     "compress": {
       "type": "boolean"
@@ -354,7 +354,7 @@
       "bonjour": "should be {Boolean} (https://webpack.js.org/configuration/dev-server/#devserverbonjour)",
       "ca": "should be {String|Buffer}",
       "cert": "should be {String|Buffer}",
-      "clientLogLevel": "should be {String} and equal to one of the allowed values\n\n [ 'none', 'info', 'error', 'warning' ]\n\n (https://webpack.js.org/configuration/dev-server/#devserverclientloglevel)",
+      "clientLogLevel": "should be {String} and equal to one of the allowed values\n\n [ 'info', 'warn', 'error', 'debug', 'trace', 'silent' ]\n\n (https://webpack.js.org/configuration/dev-server/#devserverclientloglevel)",
       "compress": "should be {Boolean} (https://webpack.js.org/configuration/dev-server/#devservercompress)",
       "contentBase": "should be {Number|String|Array} (https://webpack.js.org/configuration/dev-server/#devservercontentbase)",
       "disableHostCheck": "should be {Boolean} (https://webpack.js.org/configuration/dev-server/#devserverdisablehostcheck)",

--- a/test/options/__snapshots__/options.test.js.snap
+++ b/test/options/__snapshots__/options.test.js.snap
@@ -10,7 +10,7 @@ Object {
   "cert": "should be {String|Buffer}",
   "clientLogLevel": "should be {String} and equal to one of the allowed values
 
- [ 'none', 'info', 'error', 'warning' ]
+ [ 'info', 'warn', 'error', 'debug', 'trace', 'silent' ]
 
  (https://webpack.js.org/configuration/dev-server/#devserverclientloglevel)",
   "compress": "should be {Boolean} (https://webpack.js.org/configuration/dev-server/#devservercompress)",
@@ -109,10 +109,12 @@ Object {
   },
   "clientLogLevel": Object {
     "enum": Array [
-      "none",
       "info",
+      "warn",
       "error",
-      "warning",
+      "debug",
+      "trace",
+      "silent",
     ],
   },
   "compress": Object {

--- a/test/options/clientLogLevel.test.js
+++ b/test/options/clientLogLevel.test.js
@@ -27,10 +27,10 @@ describe('Validation', () => {
       }
     });
 
-    it('should allow clientLogLevel to be a "none"', () => {
+    it('should allow clientLogLevel to be a "silent"', () => {
       let error = null;
       try {
-        const clientLogLevel = 'none';
+        const clientLogLevel = 'silent';
         server = new Server(compiler, { clientLogLevel });
       } catch (err) {
         error = err;
@@ -60,10 +60,32 @@ describe('Validation', () => {
       expect(error).toBe(null);
     });
 
-    it('should allow clientLogLevel to be a "warning"', () => {
+    it('should allow clientLogLevel to be a "warn"', () => {
       let error = null;
       try {
-        const clientLogLevel = 'warning';
+        const clientLogLevel = 'warn';
+        server = new Server(compiler, { clientLogLevel });
+      } catch (err) {
+        error = err;
+      }
+      expect(error).toBe(null);
+    });
+
+    it('should allow clientLogLevel to be a "trace"', () => {
+      let error = null;
+      try {
+        const clientLogLevel = 'trace';
+        server = new Server(compiler, { clientLogLevel });
+      } catch (err) {
+        error = err;
+      }
+      expect(error).toBe(null);
+    });
+
+    it('should allow clientLogLevel to be a "debug"', () => {
+      let error = null;
+      try {
+        const clientLogLevel = 'debug';
         server = new Server(compiler, { clientLogLevel });
       } catch (err) {
         error = err;


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [x] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

<!-- Please note that we won't approve your changes if you don't add tests. -->
Yes

### Motivation / Use-Case

<!--
  What existing problem does the pull request solve?

  Please explain the motivation or use-case for making this change.
  If this Pull Request addresses an issue, please link to the issue.
-->

The `clientLogLevel` implementation was incorrect with the documentation.
https://webpack.js.org/configuration/dev-server/#devserverclientloglevel
This PR brings it up to date.

Currently if you use `trace`, `debug`, `warn`, or `silent` or will receive a cli incorrect param error.
<img width="588" alt="Screen Shot 2019-04-26 at 12 38 42 PM" src="https://user-images.githubusercontent.com/14303404/56829809-f9764d00-6821-11e9-8e6a-458ca16fcca5.png">

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  potential migration path for existing applications.
-->

This  will cause a cli error for users using `"clientLogLevel": "warning | none"`.
The correct property should be `"warn"` or `"silent"`.