### PR TITLE
Added sockHost, changed how sock URL is built

### DIFF
--- a/client-src/default/index.js
+++ b/client-src/default/index.js
@@ -225,9 +225,9 @@ if (
 let sockHost = hostname;
 let sockPath = '/sockjs-node';
 let sockPort = urlParts.port;
-// eslint-disable-next-line no-undefined
 if (
   urlParts.path !== null &&
+  // eslint-disable-next-line no-undefined
   urlParts.path !== undefined &&
   urlParts.path !== '/'
 ) {

--- a/client-src/default/index.js
+++ b/client-src/default/index.js
@@ -220,21 +220,30 @@ if (
 ) {
   protocol = self.location.protocol;
 }
+
+// default values of the sock url if they are not provided
+let sockHost = hostname;
+let sockPath = '/sockjs-node';
+let sockPort = urlParts.port;
+if (urlParts.path != null && urlParts.port !== '/') {
+  const parsedQuery = querystring.parse(urlParts.path);
+  // all of these sock url params are optionally passed in through
+  // __resourceQuery, so we need to fall back to the default if
+  // they are not provided
+  sockHost = parsedQuery.sockHost || sockHost;
+  sockPath = parsedQuery.sockPath || sockPath;
+  sockPort = parsedQuery.sockPort || sockPort;
+}
+
 const socketUrl = url.format({
   protocol,
   auth: urlParts.auth,
-  hostname,
-  port:
-    urlParts.path == null || urlParts.path === '/'
-      ? urlParts.port
-      : querystring.parse(urlParts.path).sockPort || urlParts.port,
+  hostname: sockHost,
+  port: sockPort,
   // If sockPath is provided it'll be passed in via the __resourceQuery as a
   // query param so it has to be parsed out of the querystring in order for the
   // client to open the socket to the correct location.
-  pathname:
-    urlParts.path == null || urlParts.path === '/'
-      ? '/sockjs-node'
-      : querystring.parse(urlParts.path).sockPath || urlParts.path,
+  pathname: sockPath,
 });
 
 socket(socketUrl, onSocketMsg);

--- a/client-src/default/index.js
+++ b/client-src/default/index.js
@@ -225,7 +225,7 @@ if (
 let sockHost = hostname;
 let sockPath = '/sockjs-node';
 let sockPort = urlParts.port;
-if (urlParts.path != null && urlParts.port !== '/') {
+if (urlParts.path != null && urlParts.path !== '/') {
   const parsedQuery = querystring.parse(urlParts.path);
   // all of these sock url params are optionally passed in through
   // __resourceQuery, so we need to fall back to the default if

--- a/client-src/default/index.js
+++ b/client-src/default/index.js
@@ -225,7 +225,12 @@ if (
 let sockHost = hostname;
 let sockPath = '/sockjs-node';
 let sockPort = urlParts.port;
-if (urlParts.path != null && urlParts.path !== '/') {
+// eslint-disable-next-line no-undefined
+if (
+  urlParts.path !== null &&
+  urlParts.path !== undefined &&
+  urlParts.path !== '/'
+) {
   const parsedQuery = querystring.parse(urlParts.path);
   // all of these sock url params are optionally passed in through
   // __resourceQuery, so we need to fall back to the default if

--- a/lib/options.json
+++ b/lib/options.json
@@ -289,14 +289,7 @@
       "instanceof": "Function"
     },
     "sockHost": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
+      "type": "string"
     },
     "sockPath": {
       "type": "string"

--- a/lib/options.json
+++ b/lib/options.json
@@ -288,6 +288,16 @@
     "setup": {
       "instanceof": "Function"
     },
+    "sockHost": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "sockPath": {
       "type": "string"
     },
@@ -395,8 +405,9 @@
       "serveIndex": "should be {Boolean} (https://webpack.js.org/configuration/dev-server/#devserverserveindex)",
       "serverSideRender": "should be {Boolean} (https://github.com/webpack/webpack-dev-middleware#serversiderender)",
       "setup": "should be {Function} (https://webpack.js.org/configuration/dev-server/#devserversetup)",
+      "sockHost": "should be {String|Null} (https://webpack.js.org/configuration/dev-server/#devserversockhost)",
       "sockPath": "should be {String} (https://webpack.js.org/configuration/dev-server/#devserversockpath)",
-      "sockPort": "should be {Number|String|Null}",
+      "sockPort": "should be {Number|String|Null} (https://webpack.js.org/configuration/dev-server/#devserversockport)",
       "socket": "should be {String} (https://webpack.js.org/configuration/dev-server/#devserversocket)",
       "staticOptions": "should be {Object} (https://webpack.js.org/configuration/dev-server/#devserverstaticoptions)",
       "stats": "should be {Object|Boolean} (https://webpack.js.org/configuration/dev-server/#devserverstats-)",

--- a/lib/utils/addEntries.js
+++ b/lib/utils/addEntries.js
@@ -16,11 +16,12 @@ function addEntries(config, options, server) {
     };
 
     const domain = createDomain(options, app);
+    const sockHost = options.sockHost ? `&sockHost=${options.sockHost}` : '';
     const sockPath = options.sockPath ? `&sockPath=${options.sockPath}` : '';
     const sockPort = options.sockPort ? `&sockPort=${options.sockPort}` : '';
     const clientEntry = `${require.resolve(
       '../../client/'
-    )}?${domain}${sockPath}${sockPort}`;
+    )}?${domain}${sockHost}${sockPath}${sockPort}`;
     let hotEntry;
 
     if (options.hotOnly) {

--- a/lib/utils/createConfig.js
+++ b/lib/utils/createConfig.js
@@ -30,6 +30,10 @@ function createConfig(config, argv, { port }) {
     options.socket = argv.socket;
   }
 
+  if (argv.sockHost) {
+    options.sockHost = argv.sockHost;
+  }
+
   if (argv.sockPath) {
     options.sockPath = argv.sockPath;
   }

--- a/test/Client.test.js
+++ b/test/Client.test.js
@@ -156,3 +156,76 @@ describe('Client complex inline script path with sockPort', () => {
     });
   });
 });
+
+// previously, using sockPort without sockPath had the ability
+// to alter the sockPath (based on a bug in client-src/index.js)
+// so we need to make sure sockPath is not altered in this case
+describe('Client complex inline script path with sockPort, no sockPath', () => {
+  beforeAll((done) => {
+    const options = {
+      port: 9000,
+      host: '0.0.0.0',
+      inline: true,
+      watchOptions: {
+        poll: true,
+      },
+      sockPort: 8080,
+    };
+    helper.startAwaitingCompilation(config, options, done);
+  });
+
+  afterAll(helper.close);
+
+  describe('browser client', () => {
+    jest.setTimeout(30000);
+
+    it('uses the correct sockPort and sockPath', (done) => {
+      runBrowser().then(({ page, browser }) => {
+        page
+          .waitForRequest((requestObj) => requestObj.url().match(/sockjs-node/))
+          .then((requestObj) => {
+            expect(requestObj.url()).toMatch(
+              /^http:\/\/localhost:8080\/sockjs-node/
+            );
+            browser.close().then(done);
+          });
+        page.goto('http://localhost:9000/main');
+      });
+    });
+  });
+});
+
+describe('Client complex inline script path with sockHost', () => {
+  beforeAll((done) => {
+    const options = {
+      port: 9000,
+      host: '0.0.0.0',
+      inline: true,
+      watchOptions: {
+        poll: true,
+      },
+      sockHost: 'myhost.test',
+    };
+    helper.startAwaitingCompilation(config, options, done);
+  });
+
+  afterAll(helper.close);
+
+  describe('browser client', () => {
+    jest.setTimeout(30000);
+
+    it('uses the correct sockHost', (done) => {
+      runBrowser().then(({ page, browser }) => {
+        page
+          .waitForRequest((requestObj) => requestObj.url().match(/sockjs-node/))
+          .then((requestObj) => {
+            expect(requestObj.url()).toMatch(
+              /^http:\/\/myhost\.test:9000\/sockjs-node/
+            );
+            browser.close().then(done);
+          });
+        page.goto('http://localhost:9000/main');
+      });
+    });
+  });
+});

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -337,6 +337,10 @@ describe('options', () => {
         success: [''],
         failure: [false],
       },
+      sockHost: {
+        success: ['', null],
+        failure: [false],
+      },
       sockPath: {
         success: [''],
         failure: [false],

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -338,7 +338,7 @@ describe('options', () => {
         failure: [false],
       },
       sockHost: {
-        success: ['', null],
+        success: [''],
         failure: [false],
       },
       sockPath: {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [ ] This is a **bugfix**
- [x] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

Yes

### Motivation / Use-Case

As mentioned here: https://github.com/webpack/webpack-dev-server/issues/1777, there could potentially be a need for a `sockHost` which is different from the `host` option.

I also realized that when `sockPort` was added, a problem could occur if `sockPort` was included but `sockPath` was not. Specifically, they both check `urlParts.path === '/'` to see if the query string should be parsed or not, but that method of checking only works if a single option is passed in through `urlParts.path`. I can make a minimum reproducible test repo for this problem if needed. This is the reasoning behind partially changing how the sock url is built.

### Breaking Changes

None

### Additional Info
