### PR TITLE
migrate Server.listen from bin

### DIFF
--- a/examples/api/simple/server.js
+++ b/examples/api/simple/server.js
@@ -6,6 +6,7 @@ const webpackConfig = require('./webpack.config');
 
 const compiler = Webpack(webpackConfig);
 const devServerOptions = Object.assign({}, webpackConfig.devServer, {
+  open: true,
   stats: {
     colors: true,
   },

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -27,6 +27,9 @@ const validateOptions = require('schema-utils');
 const updateCompiler = require('./utils/updateCompiler');
 const createLogger = require('./utils/createLogger');
 const getCertificate = require('./utils/getCertificate');
+const status = require('./utils/status');
+const createDomain = require('./utils/createDomain');
+const runBonjour = require('./utils/runBonjour');
 const routes = require('./utils/routes');
 const schema = require('./options.json');
 
@@ -808,6 +811,41 @@ class Server {
       socket.installHandlers(this.listeningApp, {
         prefix: this.sockPath,
       });
+
+      if (this.options.bonjour) {
+        runBonjour(this.options);
+      }
+
+      const showStatus = () => {
+        const suffix =
+          this.options.inline !== false || this.options.lazy === true
+            ? '/'
+            : '/webpack-dev-server/';
+
+        const uri = `${createDomain(this.options, this.listeningApp)}${suffix}`;
+
+        status(
+          uri,
+          this.options,
+          this.log,
+          this.options.stats && this.options.stats.colors
+        );
+      };
+
+      if (this.options.socket) {
+        // chmod 666 (rw rw rw)
+        const READ_WRITE = 438;
+
+        fs.chmod(this.options.socket, READ_WRITE, (err) => {
+          if (err) {
+            throw err;
+          }
+
+          showStatus();
+        });
+      } else {
+        showStatus();
+      }
 
       if (fn) {
         fn.call(this.listeningApp, err);

--- a/lib/utils/status.js
+++ b/lib/utils/status.js
@@ -3,6 +3,7 @@
 const open = require('opn');
 const colors = require('./colors');
 
+// TODO: don't emit logs when webpack-dev-server is used via Node.js API
 function status(uri, options, log, useColor) {
   const contentBase = Array.isArray(options.contentBase)
     ? options.contentBase.join(', ')
@@ -51,7 +52,7 @@ function status(uri, options, log, useColor) {
       openMessage += `: ${options.open}`;
     }
 
-    open(uri + (options.openPage || ''), openOptions).catch(() => {
+    open(`${uri}${options.openPage || ''}`, openOptions).catch(() => {
       log.warn(
         `${openMessage}. If you are running in a headless environment, please do not use the --open flag`
       );


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [x] This is a **bugfix**
- [ ] This is a **feature**
- [x] This is a **code refactor**
- [x] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

Yep

<!-- Please note that we won't approve your changes if you don't add tests. -->

### Motivation / Use-Case

fixes: #1510 
closes: #1657
closes: #1627

webpack-dev-server can be opened via Node api now.
`Server.listen` process was unified to `Server` class.

<!--
  What existing problem does the pull request solve?

  Please explain the motivation or use-case for making this change.
  If this Pull Request addresses an issue, please link to the issue.
-->

### Breaking Changes

Nope but be careful

<!--
  If this PR introduces a breaking change, please describe the impact and a
  potential migration path for existing applications.
-->

### Additional Info
