### PR TITLE
fix(stats): add errors-warnings preset

### DIFF
--- a/lib/options.json
+++ b/lib/options.json
@@ -325,7 +325,14 @@
           "type": "boolean"
         },
         {
-          "enum": ["none", "errors-only", "minimal", "normal", "verbose"]
+          "enum": [
+            "none",
+            "errors-only",
+            "errors-warnings",
+            "minimal",
+            "normal",
+            "verbose"
+          ]
         }
       ]
     },

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -359,6 +359,7 @@ describe('options', () => {
           {},
           'none',
           'errors-only',
+          'errors-warnings',
           'minimal',
           'normal',
           'verbose',


### PR DESCRIPTION
Add the new errors-warnings preset shipped in v4.31.0. Keeping
webpack-dev-server presets supported consistent with Webpack will make
both tools easier to use.

https://github.com/webpack/webpack/releases/tag/v4.31.0

https://github.com/webpack/webpack/pull/8919/files#diff-baf371f5446dc9bc4b41022587e05b48

<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [x] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

<!-- Please note that we won't approve your changes if you don't add tests. -->

### Motivation / Use-Case

<!--
  What existing problem does the pull request solve?

  Please explain the motivation or use-case for making this change.
  If this Pull Request addresses an issue, please link to the issue.
-->

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  potential migration path for existing applications.
-->

### Additional Info
