### PR TITLE
feat: `onListening` option

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -414,6 +414,8 @@ class Server {
   }
 
   setupBeforeFeature() {
+    // Todo rename onBeforeSetupMiddleware in next major release
+    // Todo pass only `this` argument
     this.options.before(this.app, this, this.compiler);
   }
 
@@ -422,6 +424,8 @@ class Server {
   }
 
   setupAfterFeature() {
+    // Todo rename onAfterSetupMiddleware in next major release
+    // Todo pass only `this` argument
     this.options.after(this.app, this, this.compiler);
   }
 
@@ -721,6 +725,10 @@ class Server {
 
       if (fn) {
         fn.call(this.listeningApp, err);
+      }
+
+      if (typeof this.options.onListening === 'function') {
+        this.options.onListening(this);
       }
     });
   }

--- a/lib/options.json
+++ b/lib/options.json
@@ -195,6 +195,9 @@
     "noInfo": {
       "type": "boolean"
     },
+    "onListening": {
+      "instanceof": "Function"
+    },
     "open": {
       "anyOf": [
         {
@@ -402,6 +405,7 @@
       "logTime": "should be {Boolean} (https://github.com/webpack/webpack-dev-middleware#logtime)",
       "mimeTypes": "should be {Object} (https://webpack.js.org/configuration/dev-server/#devservermimetypes-)",
       "noInfo": "should be {Boolean} (https://webpack.js.org/configuration/dev-server/#devservernoinfo-)",
+      "onListening": "should be {Function} (https://webpack.js.org/configuration/dev-server/#onlistening)",
       "open": "should be {String|Boolean} (https://webpack.js.org/configuration/dev-server/#devserveropen)",
       "openPage": "should be {String} (https://webpack.js.org/configuration/dev-server/#devserveropenpage)",
       "overlay": "should be {Boolean|Object} (https://webpack.js.org/configuration/dev-server/#devserveroverlay)",

--- a/test/CreateConfig.test.js
+++ b/test/CreateConfig.test.js
@@ -967,4 +967,16 @@ describe('createConfig', () => {
     ).toMatchSnapshot();
     expect(webpackConfigNoStats).toMatchSnapshot();
   });
+
+  it('onListening option', () => {
+    const config = createConfig(
+      Object.assign({}, webpackConfig, {
+        devServer: { onListening: () => {} },
+      }),
+      argv,
+      { port: 8080 }
+    );
+
+    expect(config).toMatchSnapshot();
+  });
 });

--- a/test/__snapshots__/CreateConfig.test.js.snap
+++ b/test/__snapshots__/CreateConfig.test.js.snap
@@ -740,6 +740,21 @@ Object {
 }
 `;
 
+exports[`createConfig onListening option 1`] = `
+Object {
+  "hot": true,
+  "hotOnly": false,
+  "noInfo": true,
+  "onListening": [Function],
+  "port": 8080,
+  "publicPath": "/",
+  "stats": Object {
+    "cached": false,
+    "cachedAssets": false,
+  },
+}
+`;
+
 exports[`createConfig open option (boolean) (in devServer config) 1`] = `
 Object {
   "hot": true,

--- a/test/onListening.test.js
+++ b/test/onListening.test.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const testServer = require('./helpers/test-server');
+const config = require('./fixtures/simple-config/webpack.config');
+
+describe('Before And After options', () => {
+  let onListeningIsRunning = false;
+
+  beforeAll((done) => {
+    testServer.start(
+      config,
+      {
+        onListening: (devServer) => {
+          if (!devServer) {
+            throw new Error('webpack-dev-server is not defined');
+          }
+
+          onListeningIsRunning = true;
+        },
+      },
+      done
+    );
+  });
+
+  afterAll(testServer.close);
+
+  it('should handle before route', () => {
+    expect(onListeningIsRunning).toBe(true);
+  });
+});

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -244,6 +244,10 @@ describe('options', () => {
         success: [true],
         failure: [''],
       },
+      onListening: {
+        success: [() => {}],
+        failure: [''],
+      },
       open: {
         success: [true, ''],
         failure: [{}],


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [ ] This is a **bugfix**
- [x] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

yes

### Motivation / Use-Case

fixes #1569 

### Breaking Changes

No

### Additional Info

- Also added deprecation for next major release
- This option allow to developers run own scripts after run webpack-dev-server