### PR TITLE
refactor: utils and server

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -711,6 +711,21 @@ class Server {
     });
   }
 
+  showStatus() {
+    const suffix =
+      this.options.inline !== false || this.options.lazy === true
+        ? '/'
+        : '/webpack-dev-server/';
+    const uri = `${createDomain(this.options, this.listeningApp)}${suffix}`;
+
+    status(
+      uri,
+      this.options,
+      this.log,
+      this.options.stats && this.options.stats.colors
+    );
+  }
+
   listen(port, hostname, fn) {
     this.hostname = hostname;
 
@@ -876,21 +891,6 @@ class Server {
 
     // disallow
     return false;
-  }
-
-  showStatus() {
-    const suffix =
-      this.options.inline !== false || this.options.lazy === true
-        ? '/'
-        : '/webpack-dev-server/';
-    const uri = `${createDomain(this.options, this.listeningApp)}${suffix}`;
-
-    status(
-      uri,
-      this.options,
-      this.log,
-      this.options.stats && this.options.stats.colors
-    );
   }
 
   // eslint-disable-next-line

--- a/lib/utils/runOpen.js
+++ b/lib/utils/runOpen.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const open = require('opn');
+
+function runOpen(uri, options, log) {
+  let openOptions = {};
+  let openMessage = 'Unable to open browser';
+
+  if (typeof options.open === 'string') {
+    openOptions = { app: options.open };
+    openMessage += `: ${options.open}`;
+  }
+
+  open(`${uri}${options.openPage || ''}`, openOptions).catch(() => {
+    log.warn(
+      `${openMessage}. If you are running in a headless environment, please do not use the --open flag`
+    );
+  });
+}
+
+module.exports = runOpen;

--- a/lib/utils/status.js
+++ b/lib/utils/status.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const open = require('opn');
 const colors = require('./colors');
+const runOpen = require('./runOpen');
 
 // TODO: don't emit logs when webpack-dev-server is used via Node.js API
 function status(uri, options, log, useColor) {
@@ -44,19 +44,7 @@ function status(uri, options, log, useColor) {
   }
 
   if (options.open) {
-    let openOptions = {};
-    let openMessage = 'Unable to open browser';
-
-    if (typeof options.open === 'string') {
-      openOptions = { app: options.open };
-      openMessage += `: ${options.open}`;
-    }
-
-    open(`${uri}${options.openPage || ''}`, openOptions).catch(() => {
-      log.warn(
-        `${openMessage}. If you are running in a headless environment, please do not use the --open flag`
-      );
-    });
+    runOpen(uri, options, log);
   }
 }
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [ ] This is a **bugfix**
- [ ] This is a **feature**
- [x] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

no need

### Motivation / Use-Case

move `opn` login to own util like `bonjour`

We should move `opn` logic from `status` util because it is misleading status should only output logs (based on name of util), so let's do it in next pr

### Breaking Changes

No

### Additional Info

No