### PR TITLE
feat(client): add clientMode option

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -54,8 +54,6 @@ class Server {
 
     validateOptions(schema, options, 'webpack Dev Server');
 
-    updateCompiler(compiler, options);
-
     this.compiler = compiler;
     this.options = options;
 
@@ -67,6 +65,7 @@ class Server {
 
     this.log = _log || createLogger(options);
 
+    // set serverMode default
     if (this.options.serverMode === undefined) {
       this.options.serverMode = 'sockjs';
     } else {
@@ -74,6 +73,16 @@ class Server {
         'serverMode is an experimental option, meaning its usage could potentially change without warning'
       );
     }
+    // set clientMode default
+    if (this.options.clientMode === undefined) {
+      this.options.clientMode = 'sockjs';
+    } else {
+      this.log.warn(
+        'clientMode is an experimental option, meaning its usage could potentially change without warning'
+      );
+    }
+
+    updateCompiler(this.compiler, this.options);
 
     // this.SocketServerImplementation is a class, so it must be instantiated before use
     this.socketServerImplementation = getSocketServerImplementation(

--- a/lib/options.json
+++ b/lib/options.json
@@ -434,7 +434,7 @@
       "reporter": "should be {Function} (https://github.com/webpack/webpack-dev-middleware#reporter)",
       "requestCert": "should be {Boolean}",
       "serveIndex": "should be {Boolean} (https://webpack.js.org/configuration/dev-server/#devserverserveindex)",
-      "serverMode": "should be {String|Function} (https://webpack.js.org/configuration/dev-server/#devserverservermode-)",
+      "serverMode": "should be {String|Function} (https://webpack.js.org/configuration/dev-server/#devserverservermode)",
       "serverSideRender": "should be {Boolean} (https://github.com/webpack/webpack-dev-middleware#serversiderender)",
       "setup": "should be {Function} (https://webpack.js.org/configuration/dev-server/#devserversetup)",
       "sockHost": "should be {String|Null} (https://webpack.js.org/configuration/dev-server/#devserversockhost)",

--- a/lib/options.json
+++ b/lib/options.json
@@ -48,6 +48,9 @@
         "warning"
       ]
     },
+    "clientMode": {
+      "type": "string"
+    },
     "compress": {
       "type": "boolean"
     },
@@ -390,6 +393,7 @@
       "ca": "should be {String|Buffer}",
       "cert": "should be {String|Buffer}",
       "clientLogLevel": "should be {String} and equal to one of the allowed values\n\n [ 'none', 'silent', 'info', 'debug', 'trace', 'error', 'warning', 'warn' ]\n\n (https://webpack.js.org/configuration/dev-server/#devserverclientloglevel)",
+      "clientMode": "should be {String} (https://webpack.js.org/configuration/dev-server/#devserverclientmode-)",
       "compress": "should be {Boolean} (https://webpack.js.org/configuration/dev-server/#devservercompress)",
       "contentBase": "should be {Number|String|Array} (https://webpack.js.org/configuration/dev-server/#devservercontentbase)",
       "disableHostCheck": "should be {Boolean} (https://webpack.js.org/configuration/dev-server/#devserverdisablehostcheck)",

--- a/lib/options.json
+++ b/lib/options.json
@@ -393,7 +393,7 @@
       "ca": "should be {String|Buffer}",
       "cert": "should be {String|Buffer}",
       "clientLogLevel": "should be {String} and equal to one of the allowed values\n\n [ 'none', 'silent', 'info', 'debug', 'trace', 'error', 'warning', 'warn' ]\n\n (https://webpack.js.org/configuration/dev-server/#devserverclientloglevel)",
-      "clientMode": "should be {String} (https://webpack.js.org/configuration/dev-server/#devserverclientmode-)",
+      "clientMode": "should be {String} (https://webpack.js.org/configuration/dev-server/#devserverclientmode)",
       "compress": "should be {Boolean} (https://webpack.js.org/configuration/dev-server/#devservercompress)",
       "contentBase": "should be {Number|String|Array} (https://webpack.js.org/configuration/dev-server/#devservercontentbase)",
       "disableHostCheck": "should be {Boolean} (https://webpack.js.org/configuration/dev-server/#devserverdisablehostcheck)",

--- a/lib/utils/getSocketClientPath.js
+++ b/lib/utils/getSocketClientPath.js
@@ -8,7 +8,7 @@ function getSocketClientPath(options) {
       // could be 'sockjs', in the future 'ws', or a path that should be required
       if (options.clientMode === 'sockjs') {
         // eslint-disable-next-line global-require
-        ClientImplementation = require('../clients/SockJSClient');
+        ClientImplementation = require('../../client/clients/SockJSClient');
       } else {
         try {
           // eslint-disable-next-line global-require, import/no-dynamic-require
@@ -25,7 +25,7 @@ function getSocketClientPath(options) {
   if (!clientImplFound) {
     throw new Error(
       "clientMode must be a string denoting a default implementation (e.g. 'sockjs') or a full path to " +
-        'a JS file which exports a class extending BaseClient (webpack-dev-server/lib/clients/BaseClient) ' +
+        'a JS file which exports a class extending BaseClient (webpack-dev-server/client-src/clients/BaseClient) ' +
         'via require.resolve(...)'
     );
   }

--- a/lib/utils/getSocketClientPath.js
+++ b/lib/utils/getSocketClientPath.js
@@ -1,0 +1,36 @@
+'use strict';
+
+function getSocketClientPath(options) {
+  let ClientImplementation;
+  let clientImplFound = true;
+  switch (typeof options.clientMode) {
+    case 'string':
+      // could be 'sockjs', in the future 'ws', or a path that should be required
+      if (options.clientMode === 'sockjs') {
+        // eslint-disable-next-line global-require
+        ClientImplementation = require('../clients/SockJSClient');
+      } else {
+        try {
+          // eslint-disable-next-line global-require, import/no-dynamic-require
+          ClientImplementation = require(options.clientMode);
+        } catch (e) {
+          clientImplFound = false;
+        }
+      }
+      break;
+    default:
+      clientImplFound = false;
+  }
+
+  if (!clientImplFound) {
+    throw new Error(
+      "clientMode must be a string denoting a default implementation (e.g. 'sockjs') or a full path to " +
+        'a JS file which exports a class extending BaseClient (webpack-dev-server/lib/clients/BaseClient) ' +
+        'via require.resolve(...)'
+    );
+  }
+
+  return ClientImplementation.getClientPath(options);
+}
+
+module.exports = getSocketClientPath;

--- a/lib/utils/updateCompiler.js
+++ b/lib/utils/updateCompiler.js
@@ -6,6 +6,7 @@
 */
 const webpack = require('webpack');
 const addEntries = require('./addEntries');
+const getSocketClientPath = require('./getSocketClientPath');
 
 function updateCompiler(compiler, options) {
   if (options.inline !== false) {
@@ -50,10 +51,7 @@ function updateCompiler(compiler, options) {
       compiler.hooks.entryOption.call(config.context, config.entry);
 
       const providePlugin = new webpack.ProvidePlugin({
-        // SockJSClient.getClientPath(options)
-        __webpack_dev_server_client__: require.resolve(
-          '../../client/clients/SockJSClient.js'
-        ),
+        __webpack_dev_server_client__: getSocketClientPath(options),
       });
       providePlugin.apply(compiler);
     });

--- a/test/GetSocketClientPath.test.js
+++ b/test/GetSocketClientPath.test.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const getSocketClientPath = require('../lib/utils/getSocketClientPath');
+
+const sockjsClientPath = require.resolve('../lib/clients/SockJSClient');
+const baseClientPath = require.resolve('../lib/clients/BaseClient');
+
+describe('getSocketClientPath', () => {
+  it("should work with clientMode: 'sockjs'", () => {
+    let result;
+
+    expect(() => {
+      result = getSocketClientPath({
+        clientMode: 'sockjs',
+      });
+    }).not.toThrow();
+
+    expect(result).toEqual(sockjsClientPath);
+  });
+
+  it('should work with clientMode: SockJSClient full path', () => {
+    let result;
+
+    expect(() => {
+      result = getSocketClientPath({
+        clientMode: sockjsClientPath,
+      });
+    }).not.toThrow();
+
+    expect(result).toEqual(sockjsClientPath);
+  });
+
+  it('should throw with clientMode: bad path', () => {
+    expect(() => {
+      getSocketClientPath({
+        clientMode: '/bad/path/to/implementation',
+      });
+    }).toThrow(/clientMode must be a string/);
+  });
+
+  it('should throw with clientMode: unimplemented client', () => {
+    expect(() => {
+      getSocketClientPath({
+        clientMode: baseClientPath,
+      });
+    }).toThrow('Client needs implementation');
+  });
+});

--- a/test/e2e/ClientMode.test.js
+++ b/test/e2e/ClientMode.test.js
@@ -3,12 +3,13 @@
 const testServer = require('../helpers/test-server');
 const config = require('../fixtures/client-config/webpack.config');
 const runBrowser = require('../helpers/run-browser');
+const port = require('../ports-map').ClientMode;
 
 describe('clientMode', () => {
   describe('sockjs', () => {
     beforeAll((done) => {
       const options = {
-        port: 9000,
+        port,
         host: '0.0.0.0',
         inline: true,
         clientMode: 'sockjs',
@@ -22,7 +23,7 @@ describe('clientMode', () => {
       it('logs as usual', (done) => {
         runBrowser().then(({ page, browser }) => {
           const res = [];
-          page.goto('http://localhost:9000/main');
+          page.goto(`http://localhost:${port}/main`);
           page.on('console', ({ _text }) => {
             res.push(_text);
           });
@@ -39,7 +40,7 @@ describe('clientMode', () => {
   describe('custom client', () => {
     beforeAll((done) => {
       const options = {
-        port: 9000,
+        port,
         host: '0.0.0.0',
         inline: true,
         clientMode: require.resolve(
@@ -55,7 +56,7 @@ describe('clientMode', () => {
       it('logs additional messages to console', (done) => {
         runBrowser().then(({ page, browser }) => {
           const res = [];
-          page.goto('http://localhost:9000/main');
+          page.goto(`http://localhost:${port}/main`);
           page.on('console', ({ _text }) => {
             res.push(_text);
           });

--- a/test/e2e/ClientMode.test.js
+++ b/test/e2e/ClientMode.test.js
@@ -17,8 +17,6 @@ describe('clientMode', () => {
       testServer.startAwaitingCompilation(config, options, done);
     });
 
-    afterAll(testServer.close);
-
     describe('on browser client', () => {
       it('logs as usual', (done) => {
         runBrowser().then(({ page, browser }) => {
@@ -29,8 +27,13 @@ describe('clientMode', () => {
           });
 
           setTimeout(() => {
-            expect(res).toMatchSnapshot();
-            browser.close().then(done);
+            testServer.close(() => {
+              // make sure the client gets the close message
+              setTimeout(() => {
+                expect(res).toMatchSnapshot();
+                browser.close().then(done);
+              }, 1000);
+            });
           }, 3000);
         });
       });
@@ -50,8 +53,6 @@ describe('clientMode', () => {
       testServer.startAwaitingCompilation(config, options, done);
     });
 
-    afterAll(testServer.close);
-
     describe('on browser client', () => {
       it('logs additional messages to console', (done) => {
         runBrowser().then(({ page, browser }) => {
@@ -62,8 +63,13 @@ describe('clientMode', () => {
           });
 
           setTimeout(() => {
-            expect(res).toMatchSnapshot();
-            browser.close().then(done);
+            testServer.close(() => {
+              // make sure the client gets the close message
+              setTimeout(() => {
+                expect(res).toMatchSnapshot();
+                browser.close().then(done);
+              }, 1000);
+            });
           }, 3000);
         });
       });

--- a/test/e2e/ClientMode.test.js
+++ b/test/e2e/ClientMode.test.js
@@ -30,8 +30,10 @@ describe('clientMode', () => {
             testServer.close(() => {
               // make sure the client gets the close message
               setTimeout(() => {
-                expect(res).toMatchSnapshot();
-                browser.close().then(done);
+                browser.close().then(() => {
+                  expect(res).toMatchSnapshot();
+                  done();
+                });
               }, 1000);
             });
           }, 3000);
@@ -66,8 +68,10 @@ describe('clientMode', () => {
             testServer.close(() => {
               // make sure the client gets the close message
               setTimeout(() => {
-                expect(res).toMatchSnapshot();
-                browser.close().then(done);
+                browser.close().then(() => {
+                  expect(res).toMatchSnapshot();
+                  done();
+                });
               }, 1000);
             });
           }, 3000);

--- a/test/e2e/ClientMode.test.js
+++ b/test/e2e/ClientMode.test.js
@@ -1,0 +1,71 @@
+'use strict';
+
+const testServer = require('../helpers/test-server');
+const config = require('../fixtures/client-config/webpack.config');
+const runBrowser = require('../helpers/run-browser');
+
+describe('clientMode', () => {
+  describe('sockjs', () => {
+    beforeAll((done) => {
+      const options = {
+        port: 9000,
+        host: '0.0.0.0',
+        inline: true,
+        clientMode: 'sockjs',
+      };
+      testServer.startAwaitingCompilation(config, options, done);
+    });
+
+    afterAll(testServer.close);
+
+    describe('on browser client', () => {
+      it('logs as usual', (done) => {
+        runBrowser().then(({ page, browser }) => {
+          const res = [];
+          page.goto('http://localhost:9000/main');
+          page.on('console', ({ _text }) => {
+            res.push(_text);
+          });
+
+          setTimeout(() => {
+            expect(res).toMatchSnapshot();
+            browser.close().then(done);
+          }, 3000);
+        });
+      });
+    });
+  });
+
+  describe('custom client', () => {
+    beforeAll((done) => {
+      const options = {
+        port: 9000,
+        host: '0.0.0.0',
+        inline: true,
+        clientMode: require.resolve(
+          '../fixtures/custom-client/CustomSockJSClient'
+        ),
+      };
+      testServer.startAwaitingCompilation(config, options, done);
+    });
+
+    afterAll(testServer.close);
+
+    describe('on browser client', () => {
+      it('logs additional messages to console', (done) => {
+        runBrowser().then(({ page, browser }) => {
+          const res = [];
+          page.goto('http://localhost:9000/main');
+          page.on('console', ({ _text }) => {
+            res.push(_text);
+          });
+
+          setTimeout(() => {
+            expect(res).toMatchSnapshot();
+            browser.close().then(done);
+          }, 3000);
+        });
+      });
+    });
+  });
+});

--- a/test/e2e/__snapshots__/ClientMode.test.js.snap
+++ b/test/e2e/__snapshots__/ClientMode.test.js.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`clientMode custom client on browser client logs additional messages to console 1`] = `
+Array [
+  "Hey.",
+  "open",
+  "liveReload",
+  "[WDS] Live Reloading enabled.",
+  "hash",
+  "ok",
+]
+`;
+
+exports[`clientMode sockjs on browser client logs as usual 1`] = `
+Array [
+  "Hey.",
+  "[WDS] Live Reloading enabled.",
+]
+`;

--- a/test/e2e/__snapshots__/ClientMode.test.js.snap
+++ b/test/e2e/__snapshots__/ClientMode.test.js.snap
@@ -8,6 +8,8 @@ Array [
   "[WDS] Live Reloading enabled.",
   "hash",
   "ok",
+  "close",
+  "[WDS] Disconnected!",
 ]
 `;
 
@@ -15,5 +17,6 @@ exports[`clientMode sockjs on browser client logs as usual 1`] = `
 Array [
   "Hey.",
   "[WDS] Live Reloading enabled.",
+  "[WDS] Disconnected!",
 ]
 `;

--- a/test/fixtures/custom-client/CustomSockJSClient.js
+++ b/test/fixtures/custom-client/CustomSockJSClient.js
@@ -1,0 +1,41 @@
+'use strict';
+
+/* eslint-disable
+  no-unused-vars
+*/
+const SockJS = require('sockjs-client/dist/sockjs');
+const BaseClient = require('../../../lib/clients/BaseClient');
+
+module.exports = class SockJSClient extends BaseClient {
+  constructor(url) {
+    super();
+    this.sock = new SockJS(url);
+  }
+
+  static getClientPath(options) {
+    return require.resolve('./CustomSockJSClient');
+  }
+
+  onOpen(f) {
+    this.sock.onopen = () => {
+      console.log('open');
+      f();
+    };
+  }
+
+  onClose(f) {
+    this.sock.onclose = () => {
+      console.log('close');
+      f();
+    };
+  }
+
+  // call f with the message string as the first argument
+  onMessage(f) {
+    this.sock.onmessage = (e) => {
+      const obj = JSON.parse(e.data);
+      console.log(obj.type);
+      f(e.data);
+    };
+  }
+};

--- a/test/fixtures/custom-client/CustomSockJSClient.js
+++ b/test/fixtures/custom-client/CustomSockJSClient.js
@@ -4,7 +4,7 @@
   no-unused-vars
 */
 const SockJS = require('sockjs-client/dist/sockjs');
-const BaseClient = require('../../../lib/clients/BaseClient');
+const BaseClient = require('../../../client/clients/BaseClient');
 
 module.exports = class SockJSClient extends BaseClient {
   constructor(url) {

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -138,7 +138,7 @@ describe('options', () => {
         failure: ['whoops!'],
       },
       clientMode: {
-        success: ['sockjs', require.resolve('../lib/clients/SockJSClient')],
+        success: ['sockjs', require.resolve('../client/clients/SockJSClient')],
         failure: [false],
       },
       compress: {

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -139,7 +139,7 @@ describe('options', () => {
       },
       clientMode: {
         success: ['sockjs', require.resolve('../lib/clients/SockJSClient')],
-        failure: ['', false],
+        failure: [false],
       },
       compress: {
         success: [true],

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -137,6 +137,10 @@ describe('options', () => {
         ],
         failure: ['whoops!'],
       },
+      clientMode: {
+        success: ['sockjs', require.resolve('../lib/clients/SockJSClient')],
+        failure: ['', false],
+      },
       compress: {
         success: [true],
         failure: [''],

--- a/test/ports-map.js
+++ b/test/ports-map.js
@@ -6,6 +6,7 @@ const portsList = {
   sockJSClient: 1,
   SockJSServer: 1,
   Client: 1,
+  ClientMode: 1,
   ClientOptions: 3,
   MultiCompiler: 1,
   UniversalCompiler: 1,

--- a/test/ports-map.js
+++ b/test/ports-map.js
@@ -1,12 +1,12 @@
 'use strict';
 
 // test-file-name: the number of ports
+// important: new port mappings must be added to the bottom of this list
 const portsList = {
   cli: 2,
   sockJSClient: 1,
   SockJSServer: 1,
   Client: 1,
-  ClientMode: 1,
   ClientOptions: 3,
   MultiCompiler: 1,
   UniversalCompiler: 1,
@@ -38,6 +38,7 @@ const portsList = {
   ProvidePlugin: 1,
   WebsocketClient: 1,
   WebsocketServer: 1,
+  ClientMode: 1,
 };
 
 let startPort = 8079;

--- a/test/server/utils/getSocketClientPath.test.js
+++ b/test/server/utils/getSocketClientPath.test.js
@@ -1,9 +1,11 @@
 'use strict';
 
-const getSocketClientPath = require('../lib/utils/getSocketClientPath');
-
-const sockjsClientPath = require.resolve('../lib/clients/SockJSClient');
-const baseClientPath = require.resolve('../lib/clients/BaseClient');
+const getSocketClientPath = require('../../../lib/utils/getSocketClientPath');
+// 'npm run prepare' must be done for this test to pass
+const sockjsClientPath = require.resolve(
+  '../../../client/clients/SockJSClient'
+);
+const baseClientPath = require.resolve('../../../client/clients/BaseClient');
 
 describe('getSocketClientPath', () => {
   it("should work with clientMode: 'sockjs'", () => {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [ ] This is a **bugfix**
- [x] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

Yes

### Motivation / Use-Case

This option makes it possible to provide a custom client socket implementation.

This mimics the `serverMode` implementation with one exception: `clientMode` does not accept a function (specifically, a class, as `serverMode` does). The reason for this is that it is not possible (or just pointlessly complex and impractical) to make a class within an executing server-side script, then pass it along to the client. There must be a path to the file that `module.exports` the client implementation.

Since the only thing we really need to pass to the client is the path to the implementation, I made the helper `getSocketClientPath`. There is no reason for a helper to be returning the whole `ClientImplementation` class, since it is not actually used server-side.

### Breaking Changes

None

### Additional Info

One consideration:
Should more error handling be added to confirm that the `serverMode/clientMode` are implemented correctly? For example, there could be some functionality in the Dev Server that tests the contents of `ClientImplementation.protoype`, to see if all the required functions are implemented.