### PR TITLE
 feat(client): delete `none` and `warning` from clientLogLevel

### DIFF
--- a/client-src/default/utils/log.js
+++ b/client-src/default/utils/log.js
@@ -8,11 +8,6 @@ const ERROR = 'error';
 const DEBUG = 'debug';
 const TRACE = 'trace';
 const SILENT = 'silent';
-// deprecated
-// TODO: remove these at major released
-// https://github.com/webpack/webpack-dev-server/pull/1825
-const WARNING = 'warning';
-const NONE = 'none';
 
 // Set the default log level
 log.setDefaultLevel(INFO);
@@ -26,13 +21,6 @@ export function setLogLevel(level) {
     case TRACE:
       log.setLevel(level);
       break;
-    // deprecated
-    case WARNING:
-      // loglevel's warning name is different from webpack's
-      log.setLevel('warn');
-      break;
-    // deprecated
-    case NONE:
     case SILENT:
       log.disableAll();
       break;

--- a/lib/options.json
+++ b/lib/options.json
@@ -37,16 +37,7 @@
       ]
     },
     "clientLogLevel": {
-      "enum": [
-        "info",
-        "warn",
-        "error",
-        "debug",
-        "trace",
-        "silent",
-        "none",
-        "warning"
-      ]
+      "enum": ["info", "warn", "error", "debug", "trace", "silent"]
     },
     "compress": {
       "type": "boolean"

--- a/test/client/utils/__snapshots__/log.test.js.snap
+++ b/test/client/utils/__snapshots__/log.test.js.snap
@@ -19,8 +19,5 @@ Array [
   Array [
     "trace",
   ],
-  Array [
-    "warn",
-  ],
 ]
 `;

--- a/test/client/utils/log.test.js
+++ b/test/client/utils/log.test.js
@@ -35,7 +35,7 @@ describe('log', () => {
   });
 
   test('should set log level via setLogLevel', () => {
-    ['info', 'warn', 'error', 'debug', 'trace', 'warning'].forEach((level) => {
+    ['info', 'warn', 'error', 'debug', 'trace'].forEach((level) => {
       setLogLevel(level);
     });
 
@@ -44,14 +44,12 @@ describe('log', () => {
     ).toMatchSnapshot();
   });
 
-  test('should set none and silent via setLogLevel', () => {
-    ['none', 'silent'].forEach((level) => {
-      setLogLevel(level);
-    });
+  test('should set silent via setLogLevel', () => {
+    setLogLevel('silent');
 
     expect(
       logMock.getLogger.mock.results[0].value.disableAll.mock.results
-    ).toHaveLength(2);
+    ).toHaveLength(1);
   });
 
   test('should output exception log when the level is unknown', () => {

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -121,19 +121,8 @@ describe('options', () => {
         failure: [false],
       },
       clientLogLevel: {
-        success: [
-          'silent',
-          'info',
-          'error',
-          'warn',
-          'trace',
-          'debug',
-          // deprecated
-          'none',
-          // deprecated
-          'warning',
-        ],
-        failure: ['whoops!'],
+        success: ['silent', 'info', 'error', 'warn', 'trace', 'debug'],
+        failure: ['whoops!', 'none', 'warning'],
       },
       compress: {
         success: [true],


### PR DESCRIPTION
ISSUE: https://github.com/webpack/webpack-dev-server/pull/1901

<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [ ] This is a **bugfix**
- [x] This is a **feature**
- [ ] This is a **code refactor**
- [x] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

yes

<!-- Please note that we won't approve your changes if you don't add tests. -->

### Motivation / Use-Case

See the title.

<!--
  What existing problem does the pull request solve?

  Please explain the motivation or use-case for making this change.
  If this Pull Request addresses an issue, please link to the issue.
-->

### Breaking Changes

yes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  potential migration path for existing applications.
-->

### Additional Info
