### PR TITLE
test(options): set jest.setTimeout

### DIFF
--- a/test/options.test.js
+++ b/test/options.test.js
@@ -10,6 +10,8 @@ const SockJSServer = require('../lib/servers/SockJSServer');
 const config = require('./fixtures/simple-config/webpack.config');
 
 describe('options', () => {
+  jest.setTimeout(20000);
+
   it('should match properties and errorMessage', () => {
     const properties = Object.keys(options.properties);
     const messages = Object.keys(options.errorMessage.properties);


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [ ] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [x] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

modify only

<!-- Please note that we won't approve your changes if you don't add tests. -->

### Motivation / Use-Case

We changed the time from 30000 to 60000, but options.test.js has many execution times.
So, I specified 20000 as jest.setTime to options.tests.js.
in next branch, this file is refactored and the execution is quite fast.
https://github.com/webpack/webpack-dev-server/blob/feature/refactor-tests/test/options.test.js

<!--
  What existing problem does the pull request solve?

  Please explain the motivation or use-case for making this change.
  If this Pull Request addresses an issue, please link to the issue.
-->

### Breaking Changes

no

<!--
  If this PR introduces a breaking change, please describe the impact and a
  potential migration path for existing applications.
-->

### Additional Info
