### PR TITLE
fix(open): set `wait: false` to run server.close successfully

### DIFF
--- a/lib/utils/runOpen.js
+++ b/lib/utils/runOpen.js
@@ -3,11 +3,14 @@
 const open = require('opn');
 
 function runOpen(uri, options, log) {
-  let openOptions = {};
+  // https://github.com/webpack/webpack-dev-server/issues/1990
+  const openOptions = { wait: false };
   let openMessage = 'Unable to open browser';
 
   if (typeof options.open === 'string') {
-    openOptions = { app: options.open };
+    Object.assign(openOptions, {
+      app: options.open,
+    });
     openMessage += `: ${options.open}`;
   }
 

--- a/lib/utils/runOpen.js
+++ b/lib/utils/runOpen.js
@@ -4,13 +4,11 @@ const open = require('opn');
 
 function runOpen(uri, options, log) {
   // https://github.com/webpack/webpack-dev-server/issues/1990
-  const openOptions = { wait: false };
+  let openOptions = { wait: false };
   let openMessage = 'Unable to open browser';
 
   if (typeof options.open === 'string') {
-    Object.assign(openOptions, {
-      app: options.open,
-    });
+    openOptions = Object.assign({}, openOptions, { app: options.open });
     openMessage += `: ${options.open}`;
   }
 

--- a/test/server/open-option.test.js
+++ b/test/server/open-option.test.js
@@ -21,9 +21,18 @@ describe('open option', () => {
     });
 
     compiler.hooks.done.tap('webpack-dev-server', () => {
-      expect(opn.mock.calls[0]).toEqual(['http://localhost:8080/', {}]);
-      expect(opn.mock.invocationCallOrder[0]).toEqual(1);
-      server.close(done);
+      server.close(() => {
+        expect(opn.mock.calls[0]).toMatchInlineSnapshot(`
+          Array [
+            "http://localhost:8080/",
+            Object {
+              "wait": false,
+            },
+          ]
+        `);
+        expect(opn.mock.invocationCallOrder[0]).toEqual(1);
+        done();
+      });
     });
 
     compiler.run(() => {});

--- a/test/server/utils/runOpen.test.js
+++ b/test/server/utils/runOpen.test.js
@@ -17,7 +17,14 @@ describe('runOpen util', () => {
 
     it('on specify URL', () => {
       return runOpen('https://example.com', {}, console).then(() => {
-        expect(opn.mock.calls[0]).toEqual(['https://example.com', {}]);
+        expect(opn.mock.calls[0]).toMatchInlineSnapshot(`
+          Array [
+            "https://example.com",
+            Object {
+              "wait": false,
+            },
+          ]
+        `);
       });
     });
 
@@ -27,10 +34,14 @@ describe('runOpen util', () => {
         { openPage: '/index.html' },
         console
       ).then(() => {
-        expect(opn.mock.calls[0]).toEqual([
-          'https://example.com/index.html',
-          {},
-        ]);
+        expect(opn.mock.calls[0]).toMatchInlineSnapshot(`
+          Array [
+            "https://example.com/index.html",
+            Object {
+              "wait": false,
+            },
+          ]
+        `);
       });
     });
 
@@ -40,10 +51,15 @@ describe('runOpen util', () => {
         { open: 'Google Chrome' },
         console
       ).then(() => {
-        expect(opn.mock.calls[0]).toEqual([
-          'https://example.com',
-          { app: 'Google Chrome' },
-        ]);
+        expect(opn.mock.calls[0]).toMatchInlineSnapshot(`
+          Array [
+            "https://example.com",
+            Object {
+              "app": "Google Chrome",
+              "wait": false,
+            },
+          ]
+        `);
       });
     });
 
@@ -53,10 +69,15 @@ describe('runOpen util', () => {
         { open: 'Google Chrome', openPage: '/index.html' },
         console
       ).then(() => {
-        expect(opn.mock.calls[0]).toEqual([
-          'https://example.com/index.html',
-          { app: 'Google Chrome' },
-        ]);
+        expect(opn.mock.calls[0]).toMatchInlineSnapshot(`
+          Array [
+            "https://example.com/index.html",
+            Object {
+              "app": "Google Chrome",
+              "wait": false,
+            },
+          ]
+        `);
       });
     });
   });
@@ -77,7 +98,14 @@ describe('runOpen util', () => {
         expect(logMock.warn.mock.calls[0][0]).toMatchInlineSnapshot(
           `"Unable to open browser. If you are running in a headless environment, please do not use the --open flag"`
         );
-        expect(opn.mock.calls[0]).toEqual(['https://example.com', {}]);
+        expect(opn.mock.calls[0]).toMatchInlineSnapshot(`
+          Array [
+            "https://example.com",
+            Object {
+              "wait": false,
+            },
+          ]
+        `);
       });
     });
 
@@ -90,10 +118,14 @@ describe('runOpen util', () => {
         expect(logMock.warn.mock.calls[0][0]).toMatchInlineSnapshot(
           `"Unable to open browser. If you are running in a headless environment, please do not use the --open flag"`
         );
-        expect(opn.mock.calls[0]).toEqual([
-          'https://example.com/index.html',
-          {},
-        ]);
+        expect(opn.mock.calls[0]).toMatchInlineSnapshot(`
+          Array [
+            "https://example.com/index.html",
+            Object {
+              "wait": false,
+            },
+          ]
+        `);
       });
     });
 
@@ -106,12 +138,15 @@ describe('runOpen util', () => {
         expect(logMock.warn.mock.calls[0][0]).toMatchInlineSnapshot(
           `"Unable to open browser: Google Chrome. If you are running in a headless environment, please do not use the --open flag"`
         );
-        expect(opn.mock.calls[0]).toEqual([
-          'https://example.com',
-          {
-            app: 'Google Chrome',
-          },
-        ]);
+        expect(opn.mock.calls[0]).toMatchInlineSnapshot(`
+          Array [
+            "https://example.com",
+            Object {
+              "app": "Google Chrome",
+              "wait": false,
+            },
+          ]
+        `);
       });
     });
 
@@ -124,10 +159,15 @@ describe('runOpen util', () => {
         expect(logMock.warn.mock.calls[0][0]).toMatchInlineSnapshot(
           `"Unable to open browser: Google Chrome. If you are running in a headless environment, please do not use the --open flag"`
         );
-        expect(opn.mock.calls[0]).toEqual([
-          'https://example.com/index.html',
-          { app: 'Google Chrome' },
-        ]);
+        expect(opn.mock.calls[0]).toMatchInlineSnapshot(`
+          Array [
+            "https://example.com/index.html",
+            Object {
+              "app": "Google Chrome",
+              "wait": false,
+            },
+          ]
+        `);
       });
     });
   });


### PR DESCRIPTION
fixes: https://github.com/webpack/webpack-dev-server/issues/1990

<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [x] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

yes

<!-- Please note that we won't approve your changes if you don't add tests. -->

### Motivation / Use-Case

see https://github.com/webpack/webpack-dev-server/issues/1990

commit: https://github.com/sindresorhus/open/commit/da2d663d163ad29bffea95540b1b9ea302e17871#diff-168726dbe96b3ce427e7fedce31bb0bcR23

Our open(opn)'s version is old, and `wait` seems to be `true` by default in this version.

<!--
  What existing problem does the pull request solve?

  Please explain the motivation or use-case for making this change.
  If this Pull Request addresses an issue, please link to the issue.
-->

### Breaking Changes

no

<!--
  If this PR introduces a breaking change, please describe the impact and a
  potential migration path for existing applications.
-->

### Additional Info
