### PR TITLE
test(e2e): make browser close before tests run

### DIFF
--- a/test/e2e/Client.test.js
+++ b/test/e2e/Client.test.js
@@ -48,8 +48,6 @@ describe('reload', () => {
                 return bgColor;
               })
               .then((color) => {
-                expect(color).toEqual('rgb(0, 0, 255)');
-
                 page.setRequestInterception(true).then(() => {
                   page.on('request', (req) => {
                     if (
@@ -66,8 +64,6 @@ describe('reload', () => {
                     'body { background-color: rgb(255, 0, 0); }'
                   );
                   page.waitFor(10000).then(() => {
-                    expect(refreshed).toBeFalsy();
-
                     page
                       .evaluate(() => {
                         const body = document.body;
@@ -77,8 +73,12 @@ describe('reload', () => {
                         return bgColor;
                       })
                       .then((color2) => {
-                        expect(color2).toEqual('rgb(255, 0, 0)');
-                        browser.close().then(done);
+                        browser.close().then(() => {
+                          expect(color).toEqual('rgb(0, 0, 255)');
+                          expect(color2).toEqual('rgb(255, 0, 0)');
+                          expect(refreshed).toBeFalsy();
+                          done();
+                        });
                       });
                   });
                 });
@@ -126,8 +126,6 @@ describe('reload', () => {
                 return bgColor;
               })
               .then((color) => {
-                expect(color).toEqual('rgb(0, 0, 255)');
-
                 page.setRequestInterception(true).then(() => {
                   page.on('request', (req) => {
                     if (
@@ -144,8 +142,6 @@ describe('reload', () => {
                     'body { background-color: rgb(255, 0, 0); }'
                   );
                   page.waitFor(10000).then(() => {
-                    expect(refreshed).toBeTruthy();
-
                     page
                       .evaluate(() => {
                         const body = document.body;
@@ -155,8 +151,12 @@ describe('reload', () => {
                         return bgColor;
                       })
                       .then((color2) => {
-                        expect(color2).toEqual('rgb(255, 0, 0)');
-                        browser.close().then(done);
+                        browser.close().then(() => {
+                          expect(color).toEqual('rgb(0, 0, 255)');
+                          expect(color2).toEqual('rgb(255, 0, 0)');
+                          expect(refreshed).toBeTruthy();
+                          done();
+                        });
                       });
                   });
                 });

--- a/test/e2e/ClientOptions.test.js
+++ b/test/e2e/ClientOptions.test.js
@@ -69,10 +69,14 @@ describe('Client code', () => {
         page
           .waitForRequest((requestObj) => requestObj.url().match(/sockjs-node/))
           .then((requestObj) => {
-            expect(
-              requestObj.url().includes(`http://localhost:${port1}/sockjs-node`)
-            ).toBeTruthy();
-            browser.close().then(done);
+            browser.close().then(() => {
+              expect(
+                requestObj
+                  .url()
+                  .includes(`http://localhost:${port1}/sockjs-node`)
+              ).toBeTruthy();
+              done();
+            });
           });
         page.goto(`http://localhost:${port2}/main`);
       });
@@ -105,12 +109,14 @@ describe('Client complex inline script path', () => {
             requestObj.url().match(/foo\/test\/bar/)
           )
           .then((requestObj) => {
-            expect(
-              requestObj
-                .url()
-                .includes(`http://myhost.test:${port2}/foo/test/bar/`)
-            ).toBeTruthy();
-            browser.close().then(done);
+            browser.close().then(() => {
+              expect(
+                requestObj
+                  .url()
+                  .includes(`http://myhost.test:${port2}/foo/test/bar/`)
+              ).toBeTruthy();
+              done();
+            });
           });
         page.goto(`http://localhost:${port2}/main`);
       });
@@ -143,12 +149,14 @@ describe('Client complex inline script path with sockPort', () => {
             requestObj.url().match(/foo\/test\/bar/)
           )
           .then((requestObj) => {
-            expect(
-              requestObj
-                .url()
-                .includes(`http://localhost:${port3}/foo/test/bar`)
-            ).toBeTruthy();
-            browser.close().then(done);
+            browser.close().then(() => {
+              expect(
+                requestObj
+                  .url()
+                  .includes(`http://localhost:${port3}/foo/test/bar`)
+              ).toBeTruthy();
+              done();
+            });
           });
 
         page.goto(`http://localhost:${port2}/main`);
@@ -182,10 +190,14 @@ describe('Client complex inline script path with sockPort, no sockPath', () => {
         page
           .waitForRequest((requestObj) => requestObj.url().match(/sockjs-node/))
           .then((requestObj) => {
-            expect(
-              requestObj.url().includes(`http://localhost:${port3}/sockjs-node`)
-            ).toBeTruthy();
-            browser.close().then(done);
+            browser.close().then(() => {
+              expect(
+                requestObj
+                  .url()
+                  .includes(`http://localhost:${port3}/sockjs-node`)
+              ).toBeTruthy();
+              done();
+            });
           });
         page.goto(`http://localhost:${port2}/main`);
       });
@@ -215,12 +227,14 @@ describe('Client complex inline script path with sockHost', () => {
         page
           .waitForRequest((requestObj) => requestObj.url().match(/sockjs-node/))
           .then((requestObj) => {
-            expect(
-              requestObj
-                .url()
-                .includes(`http://myhost.test:${port2}/sockjs-node`)
-            ).toBeTruthy();
-            browser.close().then(done);
+            browser.close().then(() => {
+              expect(
+                requestObj
+                  .url()
+                  .includes(`http://myhost.test:${port2}/sockjs-node`)
+              ).toBeTruthy();
+              done();
+            });
           });
         page.goto(`http://localhost:${port2}/main`);
       });
@@ -286,8 +300,10 @@ describe('Client console.log', () => {
               res.push(_text);
             });
             setTimeout(() => {
-              expect(res).toMatchSnapshot();
-              browser.close().then(resolve);
+              browser.close().then(() => {
+                expect(res).toMatchSnapshot();
+                resolve();
+              });
             }, 1000);
           });
         })

--- a/test/e2e/ProvidePlugin.test.js
+++ b/test/e2e/ProvidePlugin.test.js
@@ -30,8 +30,10 @@ describe('ProvidePlugin', () => {
                 return window.injectedClient === window.expectedClient;
               })
               .then((isCorrectClient) => {
-                expect(isCorrectClient).toBeTruthy();
-                browser.close().then(done);
+                browser.close().then(() => {
+                  expect(isCorrectClient).toBeTruthy();
+                  done();
+                });
               });
           });
           page.goto(`http://localhost:${port}/main`);
@@ -65,8 +67,10 @@ describe('ProvidePlugin', () => {
                 return window.injectedClient === undefined;
               })
               .then((isCorrectClient) => {
-                expect(isCorrectClient).toBeTruthy();
-                browser.close().then(done);
+                browser.close().then(() => {
+                  expect(isCorrectClient).toBeTruthy();
+                  done();
+                });
               });
           });
           page.goto(`http://localhost:${port}/main`);


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [ ] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [x] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

<!-- Please note that we won't approve your changes if you don't add tests. -->

### Motivation / Use-Case

Jest seems to have problems with the browser taking a while to close after a test has failed. Running tests after the browser has closed seems to be a workaround. I believe this will fix hanging on Windows CI.

### Breaking Changes

None

### Additional Info
