### PR TITLE
feat/refactor(server): move CLI server start into API listen method

### DIFF
--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -112,7 +112,11 @@ function startDevServer(config, options) {
     throw err;
   }
 
-  server.start();
+  server.listen(options.socket || options.port, options.host, (err) => {
+    if (err) {
+      throw err;
+    }
+  });
 }
 
 processOptions(config, argv, (config, options) => {

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -810,7 +810,7 @@ class Server {
           const clientSocket = new net.Socket();
 
           clientSocket.on('error', (err) => {
-            if (err.code === 'ECONNREFUSED') {
+            if (err.code === 'ECONNREFUSED' || err.code === 'ENOTSOCK') {
               // No other server listening on this socket so it can be safely removed
               fs.unlinkSync(socket);
 

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -784,8 +784,29 @@ class Server {
       // set this so that status helper can identify how the project is being run correctly
       this.options.socket = socket;
 
-      this.listeningApp.on('error', (e) => {
-        if (e.code === 'EADDRINUSE') {
+      const chmodSocket = (done) => {
+        // chmod 666 (rw rw rw) - octal
+        const READ_WRITE = 438;
+        fs.chmod(socket, READ_WRITE, done);
+      };
+
+      const startSocket = () => {
+        this.listeningApp.listen(socket, hostname, (err) => {
+          if (err) {
+            fullCallback(err);
+          } else {
+            chmodSocket(fullCallback);
+          }
+        });
+      };
+
+      fs.access(socket, fs.constants.F_OK, (err) => {
+        if (err) {
+          // file does not exist
+          startSocket();
+        } else {
+          // file exists
+
           const clientSocket = new net.Socket();
 
           clientSocket.on('error', (err) => {
@@ -793,9 +814,7 @@ class Server {
               // No other server listening on this socket so it can be safely removed
               fs.unlinkSync(socket);
 
-              // TODO: if this line is reached, the user's callback is called twice.
-              // Is this the functionality we want?
-              this.listeningApp.listen(socket, hostname, fullCallback);
+              startSocket();
             }
           });
 
@@ -803,26 +822,10 @@ class Server {
             // if a client socket successfully connects to the given socket path,
             // it means that the socket is in use
             const err = new Error('This socket is already used');
+            clientSocket.destroy();
+            // do not call onListening or the setup method, since the server
+            // cannot start listening on a used socket
             userCallback(err);
-          });
-        }
-      });
-
-      this.listeningApp.listen(socket, hostname, (err) => {
-        setupCallback();
-        // when this functionality was only in the CLI, an error would
-        // be thrown here if an error was recieved. Instead, the err should
-        // be passed along to the user, and chmod should only be performed
-        // if there is no err
-        if (err) {
-          userCallback(err);
-          onListeningCallback();
-        } else {
-          // chmod 666 (rw rw rw)
-          const READ_WRITE = 438;
-          fs.chmod(socket, READ_WRITE, (chmodErr) => {
-            userCallback(chmodErr);
-            onListeningCallback();
           });
         }
       });

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -6,6 +6,7 @@
   func-names
 */
 const fs = require('fs');
+const net = require('net');
 const path = require('path');
 const tls = require('tls');
 const url = require('url');
@@ -31,6 +32,7 @@ const createDomain = require('./utils/createDomain');
 const runBonjour = require('./utils/runBonjour');
 const routes = require('./utils/routes');
 const getSocketServerImplementation = require('./utils/getSocketServerImplementation');
+const findPort = require('./utils/findPort');
 const schema = require('./options.json');
 
 // Workaround for node ^8.6.0, ^9.0.0
@@ -736,6 +738,70 @@ class Server {
       this.log,
       this.options.stats && this.options.stats.colors
     );
+  }
+
+  start(fn) {
+    if (this.options.socket) {
+      this.listeningApp.on('error', (e) => {
+        if (e.code === 'EADDRINUSE') {
+          const clientSocket = new net.Socket();
+
+          clientSocket.on('error', (err) => {
+            if (err.code === 'ECONNREFUSED') {
+              // No other server listening on this socket so it can be safely removed
+              fs.unlinkSync(this.options.socket);
+
+              this.listen(this.options.socket, this.options.host, (error) => {
+                if (fn) {
+                  fn.call(this.listeningApp, err);
+                }
+                if (error) {
+                  throw error;
+                }
+              });
+            }
+          });
+
+          clientSocket.connect({ path: this.options.socket }, () => {
+            throw new Error('This socket is already used');
+          });
+        }
+      });
+
+      this.listen(this.options.socket, this.options.host, (err) => {
+        if (fn) {
+          fn.call(this.listeningApp, err);
+        }
+        if (err) {
+          throw err;
+        }
+
+        // chmod 666 (rw rw rw)
+        const READ_WRITE = 438;
+
+        fs.chmod(this.options.socket, READ_WRITE, (err) => {
+          if (err) {
+            throw err;
+          }
+        });
+      });
+    } else {
+      findPort(this.options.port)
+        .then((port) => {
+          this.options.port = port;
+          this.listen(this.options.port, this.options.host, (err) => {
+            if (fn) {
+              fn.call(this.listeningApp, err);
+            }
+            if (err) {
+              throw err;
+            }
+          });
+        })
+        .catch((err) => {
+          throw err;
+        });
+    }
   }
 
   listen(port, hostname, fn) {

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -822,6 +822,7 @@ class Server {
     }
     findPort(port)
       .then((resPort) => {
+        this.options.port = resPort;
         this.listeningApp.listen(resPort, hostname, fullCallback);
       })
       .catch((err) => {

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -754,13 +754,16 @@ class Server {
       this.showStatus();
     };
 
-    // between setupCallback and finalCallback should be any other needed handling,
+    // between setupCallback and userCallback should be any other needed handling,
     // specifically so that things are done in the right order to prevent
     // backwards compatability issues
-    const finalCallback = (err) => {
+    const userCallback = (err) => {
       if (fn) {
         fn.call(this.listeningApp, err);
       }
+    };
+
+    const onListeningCallback = () => {
       if (typeof this.options.onListening === 'function') {
         this.options.onListening(this);
       }
@@ -768,7 +771,8 @@ class Server {
 
     const fullCallback = (err) => {
       setupCallback();
-      finalCallback(err);
+      userCallback(err);
+      onListeningCallback();
     };
 
     // try to follow the Node standard in terms of deciding
@@ -777,9 +781,9 @@ class Server {
     if (typeof port === 'string' && tryParseInt(port) === null) {
       // in this case the "port" argument is actually a socket path
       const socket = port;
+      // set this so that status helper can identify how the project is being run correctly
+      this.options.socket = socket;
 
-      // if the EADDRINUSE error event happens here,
-      // the listeningApp.listen callback below will not be called
       this.listeningApp.on('error', (e) => {
         if (e.code === 'EADDRINUSE') {
           const clientSocket = new net.Socket();
@@ -789,16 +793,17 @@ class Server {
               // No other server listening on this socket so it can be safely removed
               fs.unlinkSync(socket);
 
+              // TODO: if this line is reached, the user's callback is called twice.
+              // Is this the functionality we want?
               this.listeningApp.listen(socket, hostname, fullCallback);
             }
           });
 
-          // the callback of this will not get called if an
-          // ECONNREFUSED error event is recieved
           clientSocket.connect({ path: socket }, () => {
-            // do not call the user's callback because the
-            // server did not start successfully
-            throw new Error('This socket is already used');
+            // if a client socket successfully connects to the given socket path,
+            // it means that the socket is in use
+            const err = new Error('This socket is already used');
+            userCallback(err);
           });
         }
       });
@@ -810,23 +815,27 @@ class Server {
         // be passed along to the user, and chmod should only be performed
         // if there is no err
         if (err) {
-          finalCallback(err);
+          userCallback(err);
+          onListeningCallback();
         } else {
           // chmod 666 (rw rw rw)
           const READ_WRITE = 438;
           fs.chmod(socket, READ_WRITE, (chmodErr) => {
-            finalCallback(chmodErr);
+            userCallback(chmodErr);
+            onListeningCallback();
           });
         }
       });
     } else {
       findPort(port)
         .then((resPort) => {
+          // we need to set this because runBonjour uses this.options.port
           this.options.port = resPort;
           this.listeningApp.listen(resPort, hostname, fullCallback);
         })
         .catch((err) => {
-          throw err;
+          // if there is no available port, the server can't start
+          userCallback(err);
         });
     }
 

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -775,6 +775,7 @@ class Server {
     // whether this is a socket or a port that we will listen on:
     // https://github.com/nodejs/node/blob/64219741218aa87e259cf8257596073b8e747f0a/lib/net.js#L196
     if (typeof port === 'string' && tryParseInt(port) === null) {
+      console.log('hit');
       // in this case the "port" argument is actually a socket path
       const socket = port;
 
@@ -819,15 +820,16 @@ class Server {
           });
         }
       });
-    }
-    findPort(port)
-      .then((resPort) => {
-        this.options.port = resPort;
-        this.listeningApp.listen(resPort, hostname, fullCallback);
-      })
-      .catch((err) => {
-        throw err;
-      });
+    } 
+      findPort(port)
+        .then((resPort) => {
+          this.options.port = resPort;
+          this.listeningApp.listen(resPort, hostname, fullCallback);
+        })
+        .catch((err) => {
+          throw err;
+        });
+    
   }
 
   close(cb) {

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -775,7 +775,6 @@ class Server {
     // whether this is a socket or a port that we will listen on:
     // https://github.com/nodejs/node/blob/64219741218aa87e259cf8257596073b8e747f0a/lib/net.js#L196
     if (typeof port === 'string' && tryParseInt(port) === null) {
-      console.log('hit');
       // in this case the "port" argument is actually a socket path
       const socket = port;
 

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -757,8 +757,10 @@ class Server {
     // between setupCallback and userCallback should be any other needed handling,
     // specifically so that things are done in the right order to prevent
     // backwards compatability issues
+    let userCallbackCalled = false;
     const userCallback = (err) => {
-      if (fn) {
+      if (fn && !userCallbackCalled) {
+        userCallbackCalled = true;
         fn.call(this.listeningApp, err);
       }
     };
@@ -791,6 +793,10 @@ class Server {
       };
 
       const startSocket = () => {
+        this.listeningApp.on('error', (err) => {
+          userCallback(err);
+        });
+
         this.listeningApp.listen(socket, hostname, (err) => {
           if (err) {
             fullCallback(err);

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -33,6 +33,7 @@ const runBonjour = require('./utils/runBonjour');
 const routes = require('./utils/routes');
 const getSocketServerImplementation = require('./utils/getSocketServerImplementation');
 const findPort = require('./utils/findPort');
+const tryParseInt = require('./utils/tryParseInt');
 const schema = require('./options.json');
 
 // Workaround for node ^8.6.0, ^9.0.0
@@ -740,74 +741,10 @@ class Server {
     );
   }
 
-  start(fn) {
-    if (this.options.socket) {
-      this.listeningApp.on('error', (e) => {
-        if (e.code === 'EADDRINUSE') {
-          const clientSocket = new net.Socket();
-
-          clientSocket.on('error', (err) => {
-            if (err.code === 'ECONNREFUSED') {
-              // No other server listening on this socket so it can be safely removed
-              fs.unlinkSync(this.options.socket);
-
-              this.listen(this.options.socket, this.options.host, (error) => {
-                if (fn) {
-                  fn.call(this.listeningApp, err);
-                }
-                if (error) {
-                  throw error;
-                }
-              });
-            }
-          });
-
-          clientSocket.connect({ path: this.options.socket }, () => {
-            throw new Error('This socket is already used');
-          });
-        }
-      });
-
-      this.listen(this.options.socket, this.options.host, (err) => {
-        if (fn) {
-          fn.call(this.listeningApp, err);
-        }
-        if (err) {
-          throw err;
-        }
-
-        // chmod 666 (rw rw rw)
-        const READ_WRITE = 438;
-
-        fs.chmod(this.options.socket, READ_WRITE, (err) => {
-          if (err) {
-            throw err;
-          }
-        });
-      });
-    } else {
-      findPort(this.options.port)
-        .then((port) => {
-          this.options.port = port;
-          this.listen(this.options.port, this.options.host, (err) => {
-            if (fn) {
-              fn.call(this.listeningApp, err);
-            }
-            if (err) {
-              throw err;
-            }
-          });
-        })
-        .catch((err) => {
-          throw err;
-        });
-    }
-  }
-
   listen(port, hostname, fn) {
     this.hostname = hostname;
 
-    return this.listeningApp.listen(port, hostname, (err) => {
+    const setupCallback = () => {
       this.createSocketServer();
 
       if (this.options.bonjour) {
@@ -815,15 +752,81 @@ class Server {
       }
 
       this.showStatus();
+    };
 
+    // between setupCallback and finalCallback should be any other needed handling,
+    // specifically so that things are done in the right order to prevent
+    // backwards compatability issues
+    const finalCallback = (err) => {
       if (fn) {
         fn.call(this.listeningApp, err);
       }
-
       if (typeof this.options.onListening === 'function') {
         this.options.onListening(this);
       }
-    });
+    };
+
+    const fullCallback = (err) => {
+      setupCallback();
+      finalCallback(err);
+    };
+
+    // try to follow the Node standard in terms of deciding
+    // whether this is a socket or a port that we will listen on:
+    // https://github.com/nodejs/node/blob/64219741218aa87e259cf8257596073b8e747f0a/lib/net.js#L196
+    if (typeof port === 'string' && tryParseInt(port) === null) {
+      // in this case the "port" argument is actually a socket path
+      const socket = port;
+
+      // if the EADDRINUSE error event happens here,
+      // the listeningApp.listen callback below will not be called
+      this.listeningApp.on('error', (e) => {
+        if (e.code === 'EADDRINUSE') {
+          const clientSocket = new net.Socket();
+
+          clientSocket.on('error', (err) => {
+            if (err.code === 'ECONNREFUSED') {
+              // No other server listening on this socket so it can be safely removed
+              fs.unlinkSync(socket);
+
+              this.listeningApp.listen(socket, hostname, fullCallback);
+            }
+          });
+
+          // the callback of this will not get called if an
+          // ECONNREFUSED error event is recieved
+          clientSocket.connect({ path: socket }, () => {
+            // do not call the user's callback because the
+            // server did not start successfully
+            throw new Error('This socket is already used');
+          });
+        }
+      });
+
+      return this.listeningApp.listen(socket, hostname, (err) => {
+        setupCallback();
+        // when this functionality was only in the CLI, an error would
+        // be thrown here if an error was recieved. Instead, the err should
+        // be passed along to the user, and chmod should only be performed
+        // if there is no err
+        if (err) {
+          finalCallback(err);
+        } else {
+          // chmod 666 (rw rw rw)
+          const READ_WRITE = 438;
+          fs.chmod(socket, READ_WRITE, (chmodErr) => {
+            finalCallback(chmodErr);
+          });
+        }
+      });
+    }
+    findPort(port)
+      .then((resPort) => {
+        this.listeningApp.listen(resPort, hostname, fullCallback);
+      })
+      .catch((err) => {
+        throw err;
+      });
   }
 
   close(cb) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,29 +53,6 @@
         "source-map": "^0.5.0"
       },
       "dependencies": {
-        "@babel/parser": {
-          "version": "7.4.5",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz",
-          "integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==",
-          "dev": true
-        },
-        "@babel/traverse": {
-          "version": "7.4.5",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.5.tgz",
-          "integrity": "sha512-Vc+qjynwkjRmIFGxy0KYoPj4FdVDxLej89kMHFsWScq999uX+pwcX4v9mWRjW0KcAYTPAuVQl2LKP1wEVLsp+A==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.0.0",
-            "@babel/generator": "^7.4.4",
-            "@babel/helper-function-name": "^7.1.0",
-            "@babel/helper-split-export-declaration": "^7.4.4",
-            "@babel/parser": "^7.4.5",
-            "@babel/types": "^7.4.4",
-            "debug": "^4.1.0",
-            "globals": "^11.1.0",
-            "lodash": "^4.17.11"
-          }
-        },
         "semver": {
           "version": "5.7.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
@@ -312,9 +289,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.4.tgz",
-      "integrity": "sha512-5pCS4mOsL+ANsFZGdvNLybx4wtqAZJ0MJjMHxvzI3bvIsz6sQvzW8XX92EYIkiPtIvcfG3Aj+Ir5VNyjnZhP7w==",
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz",
+      "integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==",
       "dev": true
     },
     "@babel/plugin-proposal-async-generator-functions": {
@@ -823,16 +800,16 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.4.tgz",
-      "integrity": "sha512-Gw6qqkw/e6AGzlyj9KnkabJX7VcubqPtkUQVAwkc0wUMldr3A/hezNB3Rc5eIvId95iSGkGIOe5hh1kMKf951A==",
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.5.tgz",
+      "integrity": "sha512-Vc+qjynwkjRmIFGxy0KYoPj4FdVDxLej89kMHFsWScq999uX+pwcX4v9mWRjW0KcAYTPAuVQl2LKP1wEVLsp+A==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "@babel/generator": "^7.4.4",
         "@babel/helper-function-name": "^7.1.0",
         "@babel/helper-split-export-declaration": "^7.4.4",
-        "@babel/parser": "^7.4.4",
+        "@babel/parser": "^7.4.5",
         "@babel/types": "^7.4.4",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
@@ -1383,9 +1360,9 @@
       }
     },
     "@types/babel__traverse": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.6.tgz",
-      "integrity": "sha512-XYVgHF2sQ0YblLRMLNPB3CkFMewzFmlDsH/TneZFHUXDlABQgh88uOxuez7ZcXxayLFrqLwtDH1t+FmlFwNZxw==",
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.7.tgz",
+      "integrity": "sha512-CeBpmX1J8kWLcDEnI3Cl2Eo6RfbGvzUctA+CjZUhOKDFbLfcr7fc4usEqLNWetrlJd7RhAkyYe2czXop4fICpw==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.3.0"
@@ -1437,9 +1414,9 @@
       "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
     },
     "@types/node": {
-      "version": "12.0.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.2.tgz",
-      "integrity": "sha512-5tabW/i+9mhrfEOUcLDu2xBPsHJ+X5Orqy9FKpale3SjDA17j5AEpYq5vfy3oAeAHGcvANRCO3NV3d2D6q3NiA=="
+      "version": "12.0.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.8.tgz",
+      "integrity": "sha512-b8bbUOTwzIY3V5vDTY1fIJ+ePKDUBqt2hC2woVGotdQQhG/2Sh62HOKHrT7ab+VerXAcPyAiTEipPu/FsreUtg=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -1707,9 +1684,9 @@
       "dev": true
     },
     "agent-base": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
-      "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+      "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
       "dev": true,
       "requires": {
         "es6-promisify": "^5.0.0"
@@ -2070,12 +2047,6 @@
         "regenerator-runtime": "^0.10.5"
       },
       "dependencies": {
-        "core-js": {
-          "version": "2.6.5",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
-          "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==",
-          "dev": true
-        },
         "regenerator-runtime": {
           "version": "0.10.5",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
@@ -2102,14 +2073,6 @@
       "requires": {
         "core-js": "^2.4.0",
         "regenerator-runtime": "^0.11.0"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "2.6.5",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
-          "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==",
-          "dev": true
-        }
       }
     },
     "balanced-match": {
@@ -2199,9 +2162,9 @@
       "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw=="
     },
     "bluebird": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.4.tgz",
-      "integrity": "sha512-FG+nFEZChJrbQ9tIccIfZJBz3J7mLrAhxakAbnrJWn8d7aKOC+LWifa0G+p4ZqKp4y13T7juYvdhq9NzKdsrjw==",
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
+      "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
       "dev": true
     },
     "bn.js": {
@@ -2398,14 +2361,14 @@
       }
     },
     "browserslist": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.0.tgz",
-      "integrity": "sha512-Jk0YFwXBuMOOol8n6FhgkDzn3mY9PYLYGk29zybF05SbRTsMgPqmTNeQQhOghCxq5oFqAXE3u4sYddr4C0uRhg==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.2.tgz",
+      "integrity": "sha512-2neU/V0giQy9h3XMPwLhEY3+Ao0uHSwHvU8Q1Ea6AgLVL1sXbX3dzPrJ8NWe5Hi4PoTkCYXOtVR9rfRLI0J/8Q==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30000967",
-        "electron-to-chromium": "^1.3.133",
-        "node-releases": "^1.1.19"
+        "caniuse-lite": "^1.0.30000974",
+        "electron-to-chromium": "^1.3.150",
+        "node-releases": "^1.1.23"
       }
     },
     "bser": {
@@ -2457,22 +2420,22 @@
       "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
     },
     "cacache": {
-      "version": "11.3.2",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-11.3.2.tgz",
-      "integrity": "sha512-E0zP4EPGDOaT2chM08Als91eYnf8Z+eH1awwwVsngUmgppfM5jjJ8l3z5vO5p5w/I3LsiXawb1sW0VY65pQABg==",
+      "version": "11.3.3",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-11.3.3.tgz",
+      "integrity": "sha512-p8WcneCytvzPxhDvYp31PD039vi77I12W+/KfR9S8AZbaiARFBCpsPJS+9uhWfeBfeAtW7o/4vt3MUqLkbY6nA==",
       "dev": true,
       "requires": {
-        "bluebird": "^3.5.3",
+        "bluebird": "^3.5.5",
         "chownr": "^1.1.1",
         "figgy-pudding": "^3.5.1",
-        "glob": "^7.1.3",
+        "glob": "^7.1.4",
         "graceful-fs": "^4.1.15",
         "lru-cache": "^5.1.1",
         "mississippi": "^3.0.0",
         "mkdirp": "^0.5.1",
         "move-concurrently": "^1.0.1",
         "promise-inflight": "^1.0.1",
-        "rimraf": "^2.6.2",
+        "rimraf": "^2.6.3",
         "ssri": "^6.0.1",
         "unique-filename": "^1.1.1",
         "y18n": "^4.0.0"
@@ -2561,9 +2524,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30000971",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000971.tgz",
-      "integrity": "sha512-TQFYFhRS0O5rdsmSbF1Wn+16latXYsQJat66f7S7lizXW1PVpWJeZw9wqqVLIjuxDRz7s7xRUj13QCfd8hKn6g==",
+      "version": "1.0.30000974",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000974.tgz",
+      "integrity": "sha512-xc3rkNS/Zc3CmpMKuczWEdY2sZgx09BkAxfvkxlAEBTqcMHeL8QnPqhKse+5sRTi3nrw2pJwToD2WvKn1Uhvww==",
       "dev": true
     },
     "capture-exit": {
@@ -3046,13 +3009,13 @@
       },
       "dependencies": {
         "conventional-commits-parser": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.0.2.tgz",
-          "integrity": "sha512-y5eqgaKR0F6xsBNVSQ/5cI5qIF3MojddSUi1vKIggRkqUTbkqFKH9P5YX/AT1BVZp9DtSzBTIkvjyVLotLsVog==",
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.0.3.tgz",
+          "integrity": "sha512-KaA/2EeUkO4bKjinNfGUyqPTX/6w9JGshuQRik4r/wJz7rUw3+D3fDG6sZSEqJvKILzKXFQuFkpPLclcsAuZcg==",
           "dev": true,
           "requires": {
             "JSONStream": "^1.0.4",
-            "is-text-path": "^1.0.0",
+            "is-text-path": "^2.0.0",
             "lodash": "^4.2.1",
             "meow": "^4.0.0",
             "split2": "^2.0.0",
@@ -3085,6 +3048,15 @@
             }
           }
         },
+        "is-text-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-2.0.0.tgz",
+          "integrity": "sha512-+oDTluR6WEjdXEJMnC2z6A4FRwFoYuvShVVEGsS7ewc0UTi2QtAKMDJuL4BDEVt+5T7MjFo12RP8ghOM75oKJw==",
+          "dev": true,
+          "requires": {
+            "text-extensions": "^2.0.0"
+          }
+        },
         "meow": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
@@ -3106,6 +3078,12 @@
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "text-extensions": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-2.0.0.tgz",
+          "integrity": "sha512-F91ZqLgvi1E0PdvmxMgp+gcf6q8fMH7mhdwWfzXnl1k+GbpQDmi8l7DzLC5JTASKbwpY3TfxajAUzAXcv2NmsQ==",
           "dev": true
         },
         "through2": {
@@ -3172,9 +3150,9 @@
       "dev": true
     },
     "conventional-changelog-writer": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.0.5.tgz",
-      "integrity": "sha512-g/Myp4MaJ1A+f7Ai+SnVhkcWtaHk6flw0SYN7A+vQ+MTu0+gSovQWs4Pg4NtcNUcIztYQ9YHsoxHP+GGQplI7Q==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.0.6.tgz",
+      "integrity": "sha512-ou/sbrplJMM6KQpR5rKFYNVQYesFjN7WpNGdudQSWNi6X+RgyFUcSv871YBYkrUYV9EX8ijMohYVzn9RUb+4ag==",
       "dev": true,
       "requires": {
         "compare-func": "^1.3.1",
@@ -3184,7 +3162,7 @@
         "json-stringify-safe": "^5.0.1",
         "lodash": "^4.2.1",
         "meow": "^4.0.0",
-        "semver": "^5.5.0",
+        "semver": "^6.0.0",
         "split": "^1.0.0",
         "through2": "^3.0.0"
       },
@@ -3210,12 +3188,6 @@
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        },
-        "semver": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
           "dev": true
         },
         "through2": {
@@ -3308,13 +3280,13 @@
           }
         },
         "conventional-commits-parser": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.0.2.tgz",
-          "integrity": "sha512-y5eqgaKR0F6xsBNVSQ/5cI5qIF3MojddSUi1vKIggRkqUTbkqFKH9P5YX/AT1BVZp9DtSzBTIkvjyVLotLsVog==",
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.0.3.tgz",
+          "integrity": "sha512-KaA/2EeUkO4bKjinNfGUyqPTX/6w9JGshuQRik4r/wJz7rUw3+D3fDG6sZSEqJvKILzKXFQuFkpPLclcsAuZcg==",
           "dev": true,
           "requires": {
             "JSONStream": "^1.0.4",
-            "is-text-path": "^1.0.0",
+            "is-text-path": "^2.0.0",
             "lodash": "^4.2.1",
             "meow": "^4.0.0",
             "split2": "^2.0.0",
@@ -3362,6 +3334,15 @@
             }
           }
         },
+        "is-text-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-2.0.0.tgz",
+          "integrity": "sha512-+oDTluR6WEjdXEJMnC2z6A4FRwFoYuvShVVEGsS7ewc0UTi2QtAKMDJuL4BDEVt+5T7MjFo12RP8ghOM75oKJw==",
+          "dev": true,
+          "requires": {
+            "text-extensions": "^2.0.0"
+          }
+        },
         "meow": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
@@ -3386,15 +3367,21 @@
           "dev": true
         },
         "readable-stream": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
-          "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
             "util-deprecate": "^1.0.1"
           }
+        },
+        "text-extensions": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-2.0.0.tgz",
+          "integrity": "sha512-F91ZqLgvi1E0PdvmxMgp+gcf6q8fMH7mhdwWfzXnl1k+GbpQDmi8l7DzLC5JTASKbwpY3TfxajAUzAXcv2NmsQ==",
+          "dev": true
         },
         "through2": {
           "version": "3.0.1",
@@ -3499,21 +3486,27 @@
         }
       }
     },
+    "core-js": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
+      "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==",
+      "dev": true
+    },
     "core-js-compat": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.1.2.tgz",
-      "integrity": "sha512-X0Ch5f6itrHxhg5HSJucX6nNLNAGr+jq+biBh6nPGc3YAWz2a8p/ZIZY8cUkDzSRNG54omAuu3hoEF8qZbu/6Q==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.1.4.tgz",
+      "integrity": "sha512-Z5zbO9f1d0YrJdoaQhphVAnKPimX92D6z8lCGphH89MNRxlL1prI9ExJPqVwP0/kgkQCv8c4GJGT8X16yUncOg==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.6.0",
-        "core-js-pure": "3.1.2",
-        "semver": "^6.0.0"
+        "browserslist": "^4.6.2",
+        "core-js-pure": "3.1.4",
+        "semver": "^6.1.1"
       }
     },
     "core-js-pure": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.1.2.tgz",
-      "integrity": "sha512-5ckIdBF26B3ldK9PM177y2ZcATP2oweam9RskHSoqfZCrJ2As6wVg8zJ1zTriFsZf6clj/N1ThDFRGaomMsh9w==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.1.4.tgz",
+      "integrity": "sha512-uJ4Z7iPNwiu1foygbcZYJsJs1jiXrTTCvxfLDXNhI/I+NHbSIEyr548y4fcsCEyWY0XgfAG/qqaunJ1SThHenA==",
       "dev": true
     },
     "core-util-is": {
@@ -3762,9 +3755,9 @@
       },
       "dependencies": {
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
@@ -4094,9 +4087,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "electron-to-chromium": {
-      "version": "1.3.136",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.136.tgz",
-      "integrity": "sha512-xHkYkbEi4kI+2w5v6yBGCQTRXL7N0PWscygTFZu/1bArnPSo2WR9xjdw4m06RR4J5PncrWJcuOVv+MAG2mK5JQ==",
+      "version": "1.3.164",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.164.tgz",
+      "integrity": "sha512-VLlalqUeduN4+fayVtRZvGP2Hl1WrRxlwzh2XVVMJym3IFrQUS29BFQ1GP/BxOJXJI1OFCrJ5BnFEsAe8NHtOg==",
       "dev": true
     },
     "elegant-spinner": {
@@ -4205,9 +4198,9 @@
       }
     },
     "es6-promise": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.6.tgz",
-      "integrity": "sha512-aRVgGdnmW2OiySVPUC9e6m+plolMAJKjZnQlCwNSuK5yQ0JN61DZSO1X1Ufd1foqWRAlig0rhduTCHe7sVtK5Q==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
       "dev": true
     },
     "es6-promisify": {
@@ -5191,9 +5184,9 @@
           }
         },
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
@@ -6498,9 +6491,9 @@
       },
       "dependencies": {
         "readable-stream": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
-          "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -6528,9 +6521,9 @@
       }
     },
     "http-parser-js": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.0.tgz",
-      "integrity": "sha512-cZdEF7r4gfRIq7ezX9J0T+kQmJNOub71dWbgAXVHDct80TKP4MCETtZQ31xyv38UwgzkWPYF/Xc0ge55dW9Z9w=="
+      "version": "0.4.10",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.10.tgz",
+      "integrity": "sha1-ksnBN0w1CF912zWexWzCV8u5P6Q="
     },
     "http-proxy": {
       "version": "1.17.0",
@@ -6590,9 +6583,9 @@
           }
         },
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         }
       }
@@ -6633,6 +6626,12 @@
             "p-limit": "^2.2.0"
           }
         },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
         "pkg-dir": {
           "version": "4.2.0",
           "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
@@ -6643,12 +6642,13 @@
           },
           "dependencies": {
             "find-up": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.0.0.tgz",
-              "integrity": "sha512-zoH7ZWPkRdgwYCDVoQTzqjG8JSPANhtvLhh4KVUHyKnaUJJrNeFmWIkTcNuJmR3GLMEmGYEf2S2bjgx26JTF+Q==",
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+              "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
               "dev": true,
               "requires": {
-                "locate-path": "^5.0.0"
+                "locate-path": "^5.0.0",
+                "path-exists": "^4.0.0"
               }
             }
           }
@@ -6688,9 +6688,9 @@
       "dev": true
     },
     "icss-utils": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-4.1.0.tgz",
-      "integrity": "sha512-3DEun4VOeMvSczifM3F2cKQrDQ5Pj6WKhkOq6HD4QTnDUAq8MQRxy5TX6Sy1iY6WPBe4gQ3p5vTECjbIkglkkQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-4.1.1.tgz",
+      "integrity": "sha512-4aFq7wvWyMHKgxsH8QQtGpvbASCf+eM3wPRLI6R+MgAnTCZ6STYsRvttLvRWK0Nfif5piF394St3HeJDaljGPA==",
       "dev": true,
       "requires": {
         "postcss": "^7.0.14"
@@ -6764,12 +6764,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
       "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
-      "dev": true
-    },
-    "indexof": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
-      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
       "dev": true
     },
     "inflight": {
@@ -7382,9 +7376,9 @@
       "dev": true
     },
     "jest-haste-map": {
-      "version": "24.8.0",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.8.0.tgz",
-      "integrity": "sha512-ZBPRGHdPt1rHajWelXdqygIDpJx8u3xOoLyUBWRW28r3tagrgoepPrzAozW7kW9HrQfhvmiv1tncsxqHJO1onQ==",
+      "version": "24.8.1",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.8.1.tgz",
+      "integrity": "sha512-SwaxMGVdAZk3ernAx2Uv2sorA7jm3Kx+lR0grp6rMmnY06Kn/urtKx1LPN2mGTea4fCT38impYT28FfcLUhX0g==",
       "dev": true,
       "requires": {
         "@jest/types": "^24.8.0",
@@ -7816,9 +7810,9 @@
       "dev": true
     },
     "json3": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
-      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE="
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.3.tgz",
+      "integrity": "sha512-c7/8mbUsKigAbLkD5B010BK4D9LZm7A1pNItkEwiUZRpIN66exu/e7YQWysGun+TRKaJp8MhemM+VkfWv42aCA=="
     },
     "json5": {
       "version": "2.1.0",
@@ -8754,9 +8748,9 @@
       "dev": true
     },
     "node-libs-browser": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.0.tgz",
-      "integrity": "sha512-5MQunG/oyOaBdttrL40dA7bUfPORLRWMUJLQtMg7nluxUvk5XwnLdL9twQHFAjRx/y7mIMkLKT9++qPbbk6BZA==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.1.tgz",
+      "integrity": "sha512-h/zcD8H9kaDZ9ALUWwlBUDo6TKF8a7qBSCSEGfjTVIYeqsioSKaAX+BN7NgiMGp6iSIXZ3PxgCu8KS3b71YK5Q==",
       "dev": true,
       "requires": {
         "assert": "^1.1.1",
@@ -8769,7 +8763,7 @@
         "events": "^3.0.0",
         "https-browserify": "^1.0.0",
         "os-browserify": "^0.3.0",
-        "path-browserify": "0.0.0",
+        "path-browserify": "0.0.1",
         "process": "^0.11.10",
         "punycode": "^1.2.4",
         "querystring-es3": "^0.2.0",
@@ -8781,7 +8775,7 @@
         "tty-browserify": "0.0.0",
         "url": "^0.11.0",
         "util": "^0.11.0",
-        "vm-browserify": "0.0.4"
+        "vm-browserify": "^1.0.1"
       },
       "dependencies": {
         "punycode": {
@@ -8820,9 +8814,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.20",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.20.tgz",
-      "integrity": "sha512-YnC3NemTLgzOkQTmR4+0yl/7pIsXZcfWXoquNp0Dql03GQ+CYURhnjUDFsSJxpX/Q9nw8lAjLFdnACQoKs6h5w==",
+      "version": "1.1.23",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.23.tgz",
+      "integrity": "sha512-uq1iL79YjfYC0WXoHbC/z28q/9pOl8kSHaXdWmAAc8No+bDwqkZbzIJz55g/MUsPgSGm9LZ7QSUbzTcH5tz47w==",
       "dev": true,
       "requires": {
         "semver": "^5.3.0"
@@ -9279,9 +9273,9 @@
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
     },
     "path-browserify": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
-      "integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo=",
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
+      "integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==",
       "dev": true
     },
     "path-dirname": {
@@ -9444,9 +9438,9 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
     },
     "postcss": {
-      "version": "7.0.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz",
-      "integrity": "sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==",
+      "version": "7.0.17",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.17.tgz",
+      "integrity": "sha512-546ZowA+KZ3OasvQZHsbuEpysvwTZNGJv9EfyCQdsIDltPSWHAeTQ5fQy/Npi2ZDtLI3zs7Ps/p6wThErhm9fQ==",
       "dev": true,
       "requires": {
         "chalk": "^2.4.2",
@@ -9601,9 +9595,9 @@
       "dev": true
     },
     "prompts": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.0.4.tgz",
-      "integrity": "sha512-HTzM3UWp/99A0gk51gAegwo1QRYA7xjcZufMNe33rCclFszUYAuHe1fIN/3ZmiHeGPkUsNaRyQm1hHOfM0PKxA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.1.0.tgz",
+      "integrity": "sha512-+x5TozgqYdOwWsQFZizE/Tra3fKvAoy037kOyU6cgz84n8f6zxngLOV4O32kTwt9FcLCxAqw0P/c8rOr9y+Gfg==",
       "dev": true,
       "requires": {
         "kleur": "^3.0.2",
@@ -9637,9 +9631,9 @@
       "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
     },
     "psl": {
-      "version": "1.1.31",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
-      "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==",
+      "version": "1.1.32",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.32.tgz",
+      "integrity": "sha512-MHACAkHpihU/REGGPLj4sEfc/XKW2bheigvHO1dUqjaKigMp1C8+WLQYRGgeKFMsw5PMfegZcaN8IDXK/cD0+g==",
       "dev": true
     },
     "public-encrypt": {
@@ -9710,9 +9704,9 @@
       },
       "dependencies": {
         "mime": {
-          "version": "2.4.3",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.3.tgz",
-          "integrity": "sha512-QgrPRJfE+riq5TPZMcHZOtm8c6K/yYrMbKIoRfapfiGLxS8OTeIfRhUGW5LU7MlRa52KOAGCfUNruqLrIBvWZw==",
+          "version": "2.4.4",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
+          "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==",
           "dev": true
         }
       }
@@ -10230,9 +10224,9 @@
       }
     },
     "rsvp": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.4.tgz",
-      "integrity": "sha512-6FomvYPfs+Jy9TfXmBpBuMWNH94SgCsZmJKcanySzgNNP6LjWxBvyLTa9KaMfDDM5oxRfrKDB0r/qeRsLwnBfA==",
+      "version": "4.8.5",
+      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
+      "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
       "dev": true
     },
     "run-async": {
@@ -10534,9 +10528,9 @@
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "simple-git": {
-      "version": "1.113.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-1.113.0.tgz",
-      "integrity": "sha512-i9WVsrK2u0G/cASI9nh7voxOk9mhanWY9eGtWBDSYql6m49Yk5/Fan6uZsDr/xmzv8n+eQ8ahKCoEr8cvU3h+g==",
+      "version": "1.115.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-1.115.0.tgz",
+      "integrity": "sha512-PXcDVDgXifUE7/M2xUfQQ8uG3r73+kYRyPmsbc/iWwUrPbOASHt8p+HEbu85k546qmXixbcSPDg83kegw1vqcA==",
       "dev": true,
       "requires": {
         "debug": "^4.0.1"
@@ -10701,17 +10695,17 @@
           }
         },
         "faye-websocket": {
-          "version": "0.11.1",
-          "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz",
-          "integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
+          "version": "0.11.3",
+          "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.3.tgz",
+          "integrity": "sha512-D2y4bovYpzziGgbHYtGCMjlJM36vAl/y+xUyn1C+FVx8szd1E+86KwVw6XvYSzOP8iMpm1X0I4xJD+QtUb36OA==",
           "requires": {
             "websocket-driver": ">=0.5.1"
           }
         },
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
@@ -10819,9 +10813,9 @@
       },
       "dependencies": {
         "readable-stream": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
-          "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -11001,9 +10995,9 @@
           }
         },
         "yargs-parser": {
-          "version": "13.1.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.0.tgz",
-          "integrity": "sha512-Yq+32PrijHRri0vVKQEm+ys8mbqWjLiwQkMFNXEENutzLPP0bE4Lcd4iA3OQY5HF+GD3xXxf0MEHb8E4/SA3AA==",
+          "version": "13.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
+          "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
           "dev": true,
           "requires": {
             "camelcase": "^5.0.0",
@@ -11243,9 +11237,9 @@
           }
         },
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         }
       }
@@ -11275,9 +11269,9 @@
       "dev": true
     },
     "symbol-tree": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
-      "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
     },
     "synchronous-promise": {
@@ -11287,9 +11281,9 @@
       "dev": true
     },
     "table": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/table/-/table-5.3.3.tgz",
-      "integrity": "sha512-3wUNCgdWX6PNpOe3amTTPWPuF6VGvgzjKCaO1snFj0z7Y3mUPWf5+zDtxUVGispJkDECPmR29wbzh6bVMOHbcw==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.4.1.tgz",
+      "integrity": "sha512-E6CK1/pZe2N75rGZQotFOdmzWQ1AILtgYbMAbAjvms0S1l5IDB47zG3nCnFGB/w+7nB3vKofbLXCH7HPBo864w==",
       "dev": true,
       "requires": {
         "ajv": "^6.9.1",
@@ -11596,9 +11590,9 @@
       "dev": true
     },
     "tslib": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
       "dev": true
     },
     "tty-browserify": {
@@ -11752,9 +11746,9 @@
       }
     },
     "unique-slug": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.1.tgz",
-      "integrity": "sha512-n9cU6+gITaVu7VGj1Z8feKMmfAjEAQGhwD9fE3zvpRRa0wEIx8ODYkVGfSc94M2OX00tUFV8wH3zYbm1I8mxFg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
+      "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
       "dev": true,
       "requires": {
         "imurmurhash": "^0.1.4"
@@ -11853,9 +11847,9 @@
       },
       "dependencies": {
         "mime": {
-          "version": "2.4.3",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.3.tgz",
-          "integrity": "sha512-QgrPRJfE+riq5TPZMcHZOtm8c6K/yYrMbKIoRfapfiGLxS8OTeIfRhUGW5LU7MlRa52KOAGCfUNruqLrIBvWZw==",
+          "version": "2.4.4",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
+          "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==",
           "dev": true
         }
       }
@@ -11947,13 +11941,10 @@
       }
     },
     "vm-browserify": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
-      "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
-      "dev": true,
-      "requires": {
-        "indexof": "0.0.1"
-      }
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.0.tgz",
+      "integrity": "sha512-iq+S7vZJE60yejDYM0ek6zg308+UZsdtPExWP9VZoCFCz1zkJoXFnAX7aZfd/ZwrkidzdUZL0C/ryW+JwAiIGw==",
+      "dev": true
     },
     "w3c-hr-time": {
       "version": "1.0.1",
@@ -11999,9 +11990,9 @@
       "dev": true
     },
     "webpack": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.33.0.tgz",
-      "integrity": "sha512-ggWMb0B2QUuYso6FPZKUohOgfm+Z0sVFs8WwWuSH1IAvkWs428VDNmOlAxvHGTB9Dm/qOB/qtE5cRx5y01clxw==",
+      "version": "4.34.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.34.0.tgz",
+      "integrity": "sha512-ry2IQy1wJjOefLe1uJLzn5tG/DdIKzQqNlIAd2L84kcaADqNvQDTBlo8UcCNyDaT5FiaB+16jhAkb63YeG3H8Q==",
       "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.8.5",
@@ -12073,9 +12064,9 @@
       },
       "dependencies": {
         "mime": {
-          "version": "2.4.3",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.3.tgz",
-          "integrity": "sha512-QgrPRJfE+riq5TPZMcHZOtm8c6K/yYrMbKIoRfapfiGLxS8OTeIfRhUGW5LU7MlRa52KOAGCfUNruqLrIBvWZw=="
+          "version": "2.4.4",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
+          "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA=="
         }
       }
     },
@@ -12107,11 +12098,12 @@
       }
     },
     "websocket-driver": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
-      "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.3.tgz",
+      "integrity": "sha512-bpxWlvbbB459Mlipc5GBzzZwhoZgGEZLuqPaR0INBGnPAY1vdBX6hPnoFXiw+3yWxDuHyQjO2oXTMyS8A5haFg==",
       "requires": {
-        "http-parser-js": ">=0.4.0",
+        "http-parser-js": ">=0.4.0 <0.4.11",
+        "safe-buffer": ">=5.1.0",
         "websocket-extensions": ">=0.1.1"
       }
     },

--- a/test/cli/cli.test.js
+++ b/test/cli/cli.test.js
@@ -81,24 +81,31 @@ describe('CLI', () => {
       .catch(done);
   });
 
-  // The Unix socket to listen to (instead of a host).
-  it('--socket', (done) => {
+  describe('Unix socket', () => {
     if (skipTestOnWindows('Unix sockets are not supported on Windows')) {
       return;
     }
-    const socketPath = join('.', 'webpack.sock');
 
-    testBin(`--socket ${socketPath}`)
-      .then((output) => {
-        expect(output.code).toEqual(0);
+    // The Unix socket to listen to (instead of a host).
+    it('--socket', (done) => {
+      const socketPath = join('.', 'webpack.sock');
 
-        expect(output.stdout.includes(socketPath)).toBe(true);
+      testBin(`--socket ${socketPath}`)
+        .then((output) => {
+          expect(output.code).toEqual(0);
 
-        unlink(socketPath, () => {
-          done();
-        });
-      })
-      .catch(done);
+          if (process.platform === 'win32') {
+            done();
+          } else {
+            expect(output.stdout.includes(socketPath)).toBe(true);
+
+            unlink(socketPath, () => {
+              done();
+            });
+          }
+        })
+        .catch(done);
+    });
   });
 
   it('should accept the promise function of webpack.config.js', (done) => {

--- a/test/cli/cli.test.js
+++ b/test/cli/cli.test.js
@@ -4,6 +4,7 @@ const { unlink } = require('fs');
 const { join, resolve } = require('path');
 const execa = require('execa');
 const testBin = require('../helpers/test-bin');
+const { skipTestOnWindows } = require('../helpers/conditional-test');
 
 const httpsCertificateDirectory = resolve(
   __dirname,
@@ -82,21 +83,20 @@ describe('CLI', () => {
 
   // The Unix socket to listen to (instead of a host).
   it('--socket', (done) => {
+    if (skipTestOnWindows('Unix sockets are not supported on Windows')) {
+      return;
+    }
     const socketPath = join('.', 'webpack.sock');
 
     testBin(`--socket ${socketPath}`)
       .then((output) => {
         expect(output.code).toEqual(0);
 
-        if (process.platform === 'win32') {
-          done();
-        } else {
-          expect(output.stdout.includes(socketPath)).toBe(true);
+        expect(output.stdout.includes(socketPath)).toBe(true);
 
-          unlink(socketPath, () => {
-            done();
-          });
-        }
+        unlink(socketPath, () => {
+          done();
+        });
       })
       .catch(done);
   });

--- a/test/helpers/test-server.js
+++ b/test/helpers/test-server.js
@@ -72,7 +72,7 @@ function startAwaitingCompilationFullSetup(config, options, done) {
   let readyCount = 0;
   let err;
   const ready = (e) => {
-    err = e instanceof Error ? e : err;
+    err = e instanceof Error || (typeof e === 'object' && e.code) ? e : err;
     readyCount += 1;
     if (readyCount === 2) {
       done(err);

--- a/test/helpers/test-server.js
+++ b/test/helpers/test-server.js
@@ -38,9 +38,16 @@ function startFullSetup(config, options, done) {
 
   server = new Server(compiler, options);
 
-  const port = Object.prototype.hasOwnProperty.call(options, 'port')
-    ? options.port
-    : 8080;
+  // originally the fallback default was 8080, but it should be
+  // undefined so that the server.listen method can choose it for us,
+  // and thus prevent port mapping collision between tests
+  let port;
+  if (Object.prototype.hasOwnProperty.call(options, 'port')) {
+    port = options.port;
+  } else if (Object.prototype.hasOwnProperty.call(options, 'socket')) {
+    port = options.socket;
+  }
+
   const host = Object.prototype.hasOwnProperty.call(options, 'host')
     ? options.host
     : 'localhost';
@@ -63,10 +70,12 @@ function startFullSetup(config, options, done) {
 
 function startAwaitingCompilationFullSetup(config, options, done) {
   let readyCount = 0;
-  const ready = () => {
+  let err;
+  const ready = (e) => {
+    err = e instanceof Error ? e : err;
     readyCount += 1;
     if (readyCount === 2) {
-      done();
+      done(err);
     }
   };
 

--- a/test/ports-map.js
+++ b/test/ports-map.js
@@ -37,7 +37,9 @@ const portsList = {
   ProvidePlugin: 1,
 };
 
-let startPort = 8079;
+// moved up start port from 8079 so that it does not overlap
+// with the typical default port of 8080
+let startPort = 8089;
 const ports = {};
 
 Object.keys(portsList).forEach((key) => {

--- a/test/server/__snapshots__/Server.test.js.snap
+++ b/test/server/__snapshots__/Server.test.js.snap
@@ -5,7 +5,7 @@ Array [
   Array [
     "client",
     "index.js?http:",
-    "localhost:8090",
+    "localhost:8100",
   ],
   Array [
     "node_modules",
@@ -35,7 +35,7 @@ Array [
   Array [
     "client",
     "index.js?http:",
-    "localhost:8090",
+    "localhost:8100",
   ],
   Array [
     "node_modules",

--- a/test/server/onListening-option.test.js
+++ b/test/server/onListening-option.test.js
@@ -5,6 +5,7 @@ const { join } = require('path');
 const testServer = require('../helpers/test-server');
 const config = require('../fixtures/simple-config/webpack.config');
 const port = require('../ports-map')['onListening-option'];
+const { skipTestOnWindows } = require('../helpers/conditional-test');
 
 describe('onListening option', () => {
   describe('with host and port', () => {
@@ -35,6 +36,10 @@ describe('onListening option', () => {
   });
 
   describe('with Unix socket', () => {
+    if (skipTestOnWindows('Unix sockets are not supported on Windows')) {
+      return;
+    }
+
     const socketPath = join('.', 'onListening.webpack.sock');
     let onListeningIsRunning = false;
 
@@ -58,13 +63,9 @@ describe('onListening option', () => {
     afterAll(testServer.close);
 
     it('should run onListening callback', (done) => {
-      if (process.platform === 'win32') {
-        done();
-      } else {
-        expect(onListeningIsRunning).toBe(true);
+      expect(onListeningIsRunning).toBe(true);
 
-        unlink(socketPath, done);
-      }
+      unlink(socketPath, done);
     });
   });
 });

--- a/test/server/onListening-option.test.js
+++ b/test/server/onListening-option.test.js
@@ -1,32 +1,70 @@
 'use strict';
 
+const { unlink } = require('fs');
+const { join } = require('path');
 const testServer = require('../helpers/test-server');
 const config = require('../fixtures/simple-config/webpack.config');
 const port = require('../ports-map')['onListening-option'];
 
 describe('onListening option', () => {
-  let onListeningIsRunning = false;
+  describe('with host and port', () => {
+    let onListeningIsRunning = false;
 
-  beforeAll((done) => {
-    testServer.start(
-      config,
-      {
-        onListening: (devServer) => {
-          if (!devServer) {
-            throw new Error('webpack-dev-server is not defined');
-          }
+    beforeAll((done) => {
+      testServer.start(
+        config,
+        {
+          onListening: (devServer) => {
+            if (!devServer) {
+              throw new Error('webpack-dev-server is not defined');
+            }
 
-          onListeningIsRunning = true;
+            onListeningIsRunning = true;
+          },
+          port,
         },
-        port,
-      },
-      done
-    );
+        done
+      );
+    });
+
+    afterAll(testServer.close);
+
+    it('should run onListening callback', () => {
+      expect(onListeningIsRunning).toBe(true);
+    });
   });
 
-  afterAll(testServer.close);
+  describe('with Unix socket', () => {
+    const socketPath = join('.', 'onListening.webpack.sock');
+    let onListeningIsRunning = false;
 
-  it('should runs onListening callback', () => {
-    expect(onListeningIsRunning).toBe(true);
+    beforeAll((done) => {
+      testServer.start(
+        config,
+        {
+          onListening: (devServer) => {
+            if (!devServer) {
+              throw new Error('webpack-dev-server is not defined');
+            }
+
+            onListeningIsRunning = true;
+          },
+          socket: socketPath,
+        },
+        done
+      );
+    });
+
+    afterAll(testServer.close);
+
+    it('should run onListening callback', (done) => {
+      if (process.platform === 'win32') {
+        done();
+      } else {
+        expect(onListeningIsRunning).toBe(true);
+
+        unlink(socketPath, done);
+      }
+    });
   });
 });

--- a/test/server/open-option.test.js
+++ b/test/server/open-option.test.js
@@ -26,7 +26,7 @@ describe('open option', () => {
       server.close(() => {
         expect(open.mock.calls[0]).toMatchInlineSnapshot(`
           Array [
-            "http://localhost:8110/",
+            "http://localhost:8120/",
             Object {
               "wait": false,
             },

--- a/test/server/port-option.test.js
+++ b/test/server/port-option.test.js
@@ -9,9 +9,15 @@ describe('port', () => {
   let server = null;
   let req = null;
 
-  describe('is not be specified', () => {
+  describe('is a string', () => {
     beforeAll((done) => {
-      server = testServer.start(config, { port }, done);
+      server = testServer.start(
+        config,
+        {
+          port: `${port}`,
+        },
+        done
+      );
       req = request(server.app);
     });
 
@@ -19,7 +25,54 @@ describe('port', () => {
       const address = server.listeningApp.address();
 
       expect(address.address).toBe('127.0.0.1');
-      // Random port
+      expect(address.port).toBe(port);
+    });
+
+    it('Request to index', (done) => {
+      req.get('/').expect(200, done);
+    });
+
+    afterAll(testServer.close);
+  });
+
+  describe('is a number', () => {
+    beforeAll((done) => {
+      server = testServer.start(
+        config,
+        {
+          port,
+        },
+        done
+      );
+      req = request(server.app);
+    });
+
+    it('server address', () => {
+      const address = server.listeningApp.address();
+
+      expect(address.address).toBe('127.0.0.1');
+      expect(address.port).toBe(port);
+    });
+
+    it('Request to index', (done) => {
+      req.get('/').expect(200, done);
+    });
+
+    afterAll(testServer.close);
+  });
+
+  describe('is not specified', () => {
+    beforeAll((done) => {
+      // the options object here should be empty, because port is not specified in this test
+      server = testServer.start(config, {}, done);
+      req = request(server.app);
+    });
+
+    it('server address', () => {
+      const address = server.listeningApp.address();
+
+      expect(address.address).toBe('127.0.0.1');
+      // Likely port 8080, but not guaranteed if port is taken
       expect(address.port).toBeDefined();
     });
 
@@ -47,7 +100,7 @@ describe('port', () => {
       const address = server.listeningApp.address();
 
       expect(address.address).toBe('127.0.0.1');
-      // Random port
+      // Likely port 8080, but not guaranteed if port is taken
       expect(address.port).toBeDefined();
     });
 
@@ -74,60 +127,8 @@ describe('port', () => {
       const address = server.listeningApp.address();
 
       expect(address.address).toBe('127.0.0.1');
-      // Random port
+      // Likely port 8080, but not guaranteed if port is taken
       expect(address.port).toBeDefined();
-    });
-
-    it('Request to index', (done) => {
-      req.get('/').expect(200, done);
-    });
-
-    afterAll(testServer.close);
-  });
-
-  describe('is "33333"', () => {
-    beforeAll((done) => {
-      server = testServer.start(
-        config,
-        {
-          port: '33333',
-        },
-        done
-      );
-      req = request(server.app);
-    });
-
-    it('server address', () => {
-      const address = server.listeningApp.address();
-
-      expect(address.address).toBe('127.0.0.1');
-      expect(address.port).toBe(33333);
-    });
-
-    it('Request to index', (done) => {
-      req.get('/').expect(200, done);
-    });
-
-    afterAll(testServer.close);
-  });
-
-  describe('is 33333', () => {
-    beforeAll((done) => {
-      server = testServer.start(
-        config,
-        {
-          port: '33333',
-        },
-        done
-      );
-      req = request(server.app);
-    });
-
-    it('server address', () => {
-      const address = server.listeningApp.address();
-
-      expect(address.address).toBe('127.0.0.1');
-      expect(address.port).toBe(33333);
     });
 
     it('Request to index', (done) => {

--- a/test/server/socket-option.test.js
+++ b/test/server/socket-option.test.js
@@ -1,0 +1,114 @@
+'use strict';
+
+const http = require('http');
+const net = require('net');
+const fs = require('fs');
+const path = require('path');
+const testServer = require('../helpers/test-server');
+const config = require('../fixtures/simple-config/webpack.config');
+
+describe('socket', () => {
+  const socketPath = path.join('.', 'socket-option.webpack.sock');
+  let server = null;
+
+  describe('path to a non-existent file', () => {
+    beforeAll((done) => {
+      server = testServer.start(
+        config,
+        {
+          socket: socketPath,
+        },
+        done
+      );
+    });
+
+    it('should work as Unix socket', (done) => {
+      if (process.platform === 'win32') {
+        done();
+      } else {
+        const clientSocket = new net.Socket();
+        clientSocket.connect({ path: socketPath }, () => {
+          // this means the connection was made successfully
+          expect(true).toBeTruthy();
+          fs.unlink(socketPath, done);
+        });
+      }
+    });
+
+    afterAll(testServer.close);
+  });
+
+  describe('path to existent, unused file', () => {
+    beforeAll((done) => {
+      fs.writeFileSync(socketPath, '');
+      server = testServer.start(
+        config,
+        {
+          socket: socketPath,
+        },
+        done
+      );
+    });
+
+    it('should work as Unix socket', (done) => {
+      if (process.platform === 'win32') {
+        fs.unlink(socketPath, done);
+      } else {
+        const clientSocket = new net.Socket();
+        clientSocket.connect({ path: socketPath }, () => {
+          // this means the connection was made successfully
+          expect(true).toBeTruthy();
+          fs.unlink(socketPath, done);
+        });
+      }
+    });
+
+    afterAll(testServer.close);
+  });
+
+  describe('path to existent file with listening server', () => {
+    let dummyServer;
+    const sockets = new Set();
+    beforeAll((done) => {
+      dummyServer = http.createServer();
+      dummyServer.listen(socketPath, 511, () => {
+        done();
+      });
+      dummyServer.on('connection', (socket) => {
+        sockets.add(socket);
+        socket.on('close', () => {
+          sockets.delete(socket);
+        });
+      });
+    });
+
+    it('should work as Unix socket', (done) => {
+      if (process.platform === 'win32') {
+        done();
+      } else {
+        server = testServer.start(
+          config,
+          {
+            socket: socketPath,
+          },
+          (err) => {
+            expect(err).not.toBeNull();
+            expect(err).not.toBeUndefined();
+            expect(err.message).toEqual('This socket is already used');
+            server.close(done);
+          }
+        );
+      }
+    });
+
+    afterAll((done) => {
+      // get rid of connected sockets on the dummyServer
+      for (const socket of sockets.values()) {
+        socket.destroy();
+      }
+      dummyServer.close(() => {
+        fs.unlink(socketPath, done);
+      });
+    });
+  });
+});

--- a/test/server/socket-option.test.js
+++ b/test/server/socket-option.test.js
@@ -15,22 +15,27 @@ describe('socket', () => {
   let server = null;
 
   describe('path to a non-existent file', () => {
-    if (skipTestOnWindows('Unix sockets are not supported on Windows')) {
-      return;
-    }
+    // if (skipTestOnWindows('Unix sockets are not supported on Windows')) {
+    //   return;
+    // }
 
+    let err;
     beforeAll((done) => {
       server = testServer.start(
         config,
         {
           socket: socketPath,
         },
-        done
+        (e) => {
+          err = e;
+          done();
+        }
       );
     });
 
-    it('should work as Unix socket', (done) => {
+    it('should work as Unix socket or error on windows', (done) => {
       if (process.platform === 'win32') {
+        expect(err.code).toEqual('EACCES');
         done();
       } else {
         const clientSocket = new net.Socket();

--- a/test/server/socket-option.test.js
+++ b/test/server/socket-option.test.js
@@ -4,14 +4,21 @@ const http = require('http');
 const net = require('net');
 const fs = require('fs');
 const path = require('path');
+const webpack = require('webpack');
 const testServer = require('../helpers/test-server');
 const config = require('../fixtures/simple-config/webpack.config');
+const Server = require('../../lib/Server');
+const { skipTestOnWindows } = require('../helpers/conditional-test');
 
 describe('socket', () => {
   const socketPath = path.join('.', 'socket-option.webpack.sock');
   let server = null;
 
   describe('path to a non-existent file', () => {
+    if (skipTestOnWindows('Unix sockets are not supported on Windows')) {
+      return;
+    }
+
     beforeAll((done) => {
       server = testServer.start(
         config,
@@ -30,15 +37,23 @@ describe('socket', () => {
         clientSocket.connect({ path: socketPath }, () => {
           // this means the connection was made successfully
           expect(true).toBeTruthy();
-          fs.unlink(socketPath, done);
+          done();
         });
       }
     });
 
-    afterAll(testServer.close);
+    afterAll((done) => {
+      testServer.close(() => {
+        fs.unlink(socketPath, done);
+      });
+    });
   });
 
   describe('path to existent, unused file', () => {
+    if (skipTestOnWindows('Unix sockets are not supported on Windows')) {
+      return;
+    }
+
     beforeAll((done) => {
       fs.writeFileSync(socketPath, '');
       server = testServer.start(
@@ -51,22 +66,26 @@ describe('socket', () => {
     });
 
     it('should work as Unix socket', (done) => {
-      if (process.platform === 'win32') {
-        fs.unlink(socketPath, done);
-      } else {
-        const clientSocket = new net.Socket();
-        clientSocket.connect({ path: socketPath }, () => {
-          // this means the connection was made successfully
-          expect(true).toBeTruthy();
-          fs.unlink(socketPath, done);
-        });
-      }
+      const clientSocket = new net.Socket();
+      clientSocket.connect({ path: socketPath }, () => {
+        // this means the connection was made successfully
+        expect(true).toBeTruthy();
+        done();
+      });
     });
 
-    afterAll(testServer.close);
+    afterAll((done) => {
+      testServer.close(() => {
+        fs.unlink(socketPath, done);
+      });
+    });
   });
 
   describe('path to existent file with listening server', () => {
+    if (skipTestOnWindows('Unix sockets are not supported on Windows')) {
+      return;
+    }
+
     let dummyServer;
     const sockets = new Set();
     beforeAll((done) => {
@@ -83,22 +102,18 @@ describe('socket', () => {
     });
 
     it('should work as Unix socket', (done) => {
-      if (process.platform === 'win32') {
-        done();
-      } else {
-        server = testServer.start(
-          config,
-          {
-            socket: socketPath,
-          },
-          (err) => {
-            expect(err).not.toBeNull();
-            expect(err).not.toBeUndefined();
-            expect(err.message).toEqual('This socket is already used');
-            server.close(done);
-          }
-        );
-      }
+      server = testServer.start(
+        config,
+        {
+          socket: socketPath,
+        },
+        (err) => {
+          expect(err).not.toBeNull();
+          expect(err).not.toBeUndefined();
+          expect(err.message).toEqual('This socket is already used');
+          server.close(done);
+        }
+      );
     });
 
     afterAll((done) => {
@@ -109,6 +124,40 @@ describe('socket', () => {
       dummyServer.close(() => {
         fs.unlink(socketPath, done);
       });
+    });
+  });
+
+  describe('path to existent, unused file', () => {
+    if (skipTestOnWindows('Unix sockets are not supported on Windows')) {
+      return;
+    }
+
+    let devServer;
+    const options = {
+      socket: socketPath,
+    };
+    beforeAll(() => {
+      fs.writeFileSync(socketPath, '');
+    });
+
+    // this test is significant because previously the callback was called
+    // twice if a file at the given socket path already existed, but
+    // could be removed
+    it('should only call server.listen callback once', (done) => {
+      const compiler = webpack(config);
+
+      devServer = new Server(compiler, options);
+      const onListen = jest.fn();
+      // eslint-disable-next-line no-undefined
+      devServer.listen(options.socket, undefined, onListen);
+      setTimeout(() => {
+        expect(onListen).toBeCalledTimes(1);
+        done();
+      }, 10000);
+    });
+
+    afterAll((done) => {
+      devServer.close(done);
     });
   });
 });


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [ ] This is a **bugfix**
- [x] This is a **feature**
- [x] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

Not yet, would like feedback on the idea first.

### Motivation / Use-Case

I have added a `start` method in the API, which the CLI calls, rather than calling the API's `listen` method.

- Firstly, the CLI will do significantly less configuration/error handling, as the API will do it instead
- API users can find more use in `start` method, because it does not make sense that they have to provide `host` and `port` via `listen(port, hostname, fn)`, when they probably already pass those into `new Server(options)` as dev server options.
- API users can make use of `socket` option and the automatic free port assignment via `start`, or opt out of those options via `listen`.

### Breaking Changes

Likely not, need to add tests to be sure though

### Additional Info
