### PR TITLE
feat/refactor(server): move socket handling into server.listen

### DIFF
--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -4,8 +4,6 @@
 
 /* eslint-disable no-shadow, no-console */
 
-const fs = require('fs');
-const net = require('net');
 const debug = require('debug')('webpack-dev-server');
 const importLocal = require('import-local');
 const yargs = require('yargs');
@@ -109,42 +107,10 @@ function startDevServer(config, options) {
   }
 
   if (options.socket) {
-    server.listeningApp.on('error', (e) => {
-      if (e.code === 'EADDRINUSE') {
-        const clientSocket = new net.Socket();
-
-        clientSocket.on('error', (err) => {
-          if (err.code === 'ECONNREFUSED') {
-            // No other server listening on this socket so it can be safely removed
-            fs.unlinkSync(options.socket);
-
-            server.listen(options.socket, options.host, (error) => {
-              if (error) {
-                throw error;
-              }
-            });
-          }
-        });
-
-        clientSocket.connect({ path: options.socket }, () => {
-          throw new Error('This socket is already used');
-        });
-      }
-    });
-
     server.listen(options.socket, options.host, (err) => {
       if (err) {
         throw err;
       }
-
-      // chmod 666 (rw rw rw)
-      const READ_WRITE = 438;
-
-      fs.chmod(options.socket, READ_WRITE, (err) => {
-        if (err) {
-          throw err;
-        }
-      });
     });
   } else {
     server.listen(options.port, options.host, (err) => {

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -755,20 +755,16 @@ class Server {
       }
     };
 
-    const listenCallback = () => {
+    const onListeningCallback = () => {
       if (typeof this.options.onListening === 'function') {
         this.options.onListening(this);
       }
     };
 
-    const setupAndListenCallback = () => {
-      setupCallback();
-      listenCallback();
-    };
-
     const fullCallback = (err) => {
-      setupAndListenCallback();
+      setupCallback();
       userCallback(err);
+      onListeningCallback();
     };
 
     // try to follow the Node standard in terms of deciding
@@ -780,12 +776,7 @@ class Server {
       // set this so that status helper can identify how the project is being run correctly
       this.options.socket = socket;
 
-      startUnixSocket(
-        this.listeningApp,
-        socket,
-        setupAndListenCallback,
-        userCallback
-      );
+      startUnixSocket(this.listeningApp, socket, fullCallback);
     } else {
       this.listeningApp.listen(port, hostname, fullCallback);
     }

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -6,7 +6,6 @@
   func-names
 */
 const fs = require('fs');
-const net = require('net');
 const path = require('path');
 const tls = require('tls');
 const url = require('url');
@@ -36,6 +35,7 @@ const routes = require('./utils/routes');
 const getSocketServerImplementation = require('./utils/getSocketServerImplementation');
 const handleStdin = require('./utils/handleStdin');
 const tryParseInt = require('./utils/tryParseInt');
+const startUnixSocket = require('./utils/startUnixSocket');
 const schema = require('./options.json');
 
 // Workaround for node ^8.6.0, ^9.0.0
@@ -776,55 +776,7 @@ class Server {
       // set this so that status helper can identify how the project is being run correctly
       this.options.socket = socket;
 
-      const chmodSocket = (done) => {
-        // chmod 666 (rw rw rw) - octal
-        const READ_WRITE = 438;
-        fs.chmod(socket, READ_WRITE, done);
-      };
-
-      const startSocket = () => {
-        this.listeningApp.on('error', (err) => {
-          userCallback(err);
-        });
-
-        this.listeningApp.listen(socket, hostname, (err) => {
-          if (err) {
-            fullCallback(err);
-          } else {
-            chmodSocket(fullCallback);
-          }
-        });
-      };
-
-      fs.access(socket, fs.constants.F_OK, (err) => {
-        if (err) {
-          // file does not exist
-          startSocket();
-        } else {
-          // file exists
-
-          const clientSocket = new net.Socket();
-
-          clientSocket.on('error', (err) => {
-            if (err.code === 'ECONNREFUSED' || err.code === 'ENOTSOCK') {
-              // No other server listening on this socket so it can be safely removed
-              fs.unlinkSync(socket);
-
-              startSocket();
-            }
-          });
-
-          clientSocket.connect({ path: socket }, () => {
-            // if a client socket successfully connects to the given socket path,
-            // it means that the socket is in use
-            const err = new Error('This socket is already used');
-            clientSocket.destroy();
-            // do not call onListening or the setup method, since the server
-            // cannot start listening on a used socket
-            userCallback(err);
-          });
-        }
-      });
+      startUnixSocket(this.listeningApp, socket, fullCallback, userCallback);
     } else {
       this.listeningApp.listen(port, hostname, fullCallback);
     }

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -6,6 +6,7 @@
   func-names
 */
 const fs = require('fs');
+const net = require('net');
 const path = require('path');
 const tls = require('tls');
 const url = require('url');
@@ -34,6 +35,7 @@ const runBonjour = require('./utils/runBonjour');
 const routes = require('./utils/routes');
 const getSocketServerImplementation = require('./utils/getSocketServerImplementation');
 const handleStdin = require('./utils/handleStdin');
+const tryParseInt = require('./utils/tryParseInt');
 const schema = require('./options.json');
 
 // Workaround for node ^8.6.0, ^9.0.0
@@ -732,7 +734,7 @@ class Server {
   listen(port, hostname, fn) {
     this.hostname = hostname;
 
-    return this.listeningApp.listen(port, hostname, (err) => {
+    const setupCallback = () => {
       this.createSocketServer();
 
       if (this.options.bonjour) {
@@ -740,15 +742,94 @@ class Server {
       }
 
       this.showStatus();
+    };
 
-      if (fn) {
+    // between setupCallback and userCallback should be any other needed handling,
+    // specifically so that things are done in the right order to prevent
+    // backwards compatability issues
+    let userCallbackCalled = false;
+    const userCallback = (err) => {
+      if (fn && !userCallbackCalled) {
+        userCallbackCalled = true;
         fn.call(this.listeningApp, err);
       }
+    };
 
+    const onListeningCallback = () => {
       if (typeof this.options.onListening === 'function') {
         this.options.onListening(this);
       }
-    });
+    };
+
+    const fullCallback = (err) => {
+      setupCallback();
+      userCallback(err);
+      onListeningCallback();
+    };
+
+    // try to follow the Node standard in terms of deciding
+    // whether this is a socket or a port that we will listen on:
+    // https://github.com/nodejs/node/blob/64219741218aa87e259cf8257596073b8e747f0a/lib/net.js#L196
+    if (typeof port === 'string' && tryParseInt(port) === null) {
+      // in this case the "port" argument is actually a socket path
+      const socket = port;
+      // set this so that status helper can identify how the project is being run correctly
+      this.options.socket = socket;
+
+      const chmodSocket = (done) => {
+        // chmod 666 (rw rw rw) - octal
+        const READ_WRITE = 438;
+        fs.chmod(socket, READ_WRITE, done);
+      };
+
+      const startSocket = () => {
+        this.listeningApp.on('error', (err) => {
+          userCallback(err);
+        });
+
+        this.listeningApp.listen(socket, hostname, (err) => {
+          if (err) {
+            fullCallback(err);
+          } else {
+            chmodSocket(fullCallback);
+          }
+        });
+      };
+
+      fs.access(socket, fs.constants.F_OK, (err) => {
+        if (err) {
+          // file does not exist
+          startSocket();
+        } else {
+          // file exists
+
+          const clientSocket = new net.Socket();
+
+          clientSocket.on('error', (err) => {
+            if (err.code === 'ECONNREFUSED' || err.code === 'ENOTSOCK') {
+              // No other server listening on this socket so it can be safely removed
+              fs.unlinkSync(socket);
+
+              startSocket();
+            }
+          });
+
+          clientSocket.connect({ path: socket }, () => {
+            // if a client socket successfully connects to the given socket path,
+            // it means that the socket is in use
+            const err = new Error('This socket is already used');
+            clientSocket.destroy();
+            // do not call onListening or the setup method, since the server
+            // cannot start listening on a used socket
+            userCallback(err);
+          });
+        }
+      });
+    } else {
+      this.listeningApp.listen(port, hostname, fullCallback);
+    }
+
+    return this.listeningApp;
   }
 
   close(cb) {

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -755,16 +755,20 @@ class Server {
       }
     };
 
-    const onListeningCallback = () => {
+    const listenCallback = () => {
       if (typeof this.options.onListening === 'function') {
         this.options.onListening(this);
       }
     };
 
-    const fullCallback = (err) => {
+    const setupAndListenCallback = () => {
       setupCallback();
+      listenCallback();
+    };
+
+    const fullCallback = (err) => {
+      setupAndListenCallback();
       userCallback(err);
-      onListeningCallback();
     };
 
     // try to follow the Node standard in terms of deciding
@@ -776,7 +780,12 @@ class Server {
       // set this so that status helper can identify how the project is being run correctly
       this.options.socket = socket;
 
-      startUnixSocket(this.listeningApp, socket, fullCallback, userCallback);
+      startUnixSocket(
+        this.listeningApp,
+        socket,
+        setupAndListenCallback,
+        userCallback
+      );
     } else {
       this.listeningApp.listen(port, hostname, fullCallback);
     }

--- a/lib/utils/startUnixSocket.js
+++ b/lib/utils/startUnixSocket.js
@@ -3,12 +3,20 @@
 const fs = require('fs');
 const net = require('net');
 
+// userCallback should always be called to indicate that either the server has
+// started listening, or an error was thrown.
+// setupAndListenCallback should only be called if the server starts listening
 function startUnixSocket(
   listeningApp,
   socket,
-  onListeningCallback,
-  errorCallback
+  setupAndListenCallback,
+  userCallback
 ) {
+  const fullCallback = (err) => {
+    setupAndListenCallback();
+    userCallback(err);
+  };
+
   const chmodSocket = (done) => {
     // chmod 666 (rw rw rw) - octal
     const READ_WRITE = 438;
@@ -17,22 +25,22 @@ function startUnixSocket(
 
   const startSocket = () => {
     listeningApp.on('error', (err) => {
-      errorCallback(err);
+      userCallback(err);
     });
 
     // 511 is the default value for the server.listen backlog parameter
     // https://nodejs.org/api/net.html#net_server_listen
     listeningApp.listen(socket, 511, (err) => {
       if (err) {
-        onListeningCallback(err);
+        fullCallback(err);
       } else {
-        chmodSocket(onListeningCallback);
+        chmodSocket(fullCallback);
       }
     });
   };
 
-  fs.access(socket, fs.constants.F_OK, (err) => {
-    if (err) {
+  fs.access(socket, fs.constants.F_OK, (e) => {
+    if (e) {
       // file does not exist
       startSocket();
     } else {
@@ -56,7 +64,7 @@ function startUnixSocket(
         clientSocket.destroy();
         // do not call onListening or the setup method, since the server
         // cannot start listening on a used socket
-        errorCallback(err);
+        userCallback(err);
       });
     }
   });

--- a/lib/utils/startUnixSocket.js
+++ b/lib/utils/startUnixSocket.js
@@ -3,20 +3,7 @@
 const fs = require('fs');
 const net = require('net');
 
-// userCallback should always be called to indicate that either the server has
-// started listening, or an error was thrown.
-// setupAndListenCallback should only be called if the server starts listening
-function startUnixSocket(
-  listeningApp,
-  socket,
-  setupAndListenCallback,
-  userCallback
-) {
-  const fullCallback = (err) => {
-    setupAndListenCallback();
-    userCallback(err);
-  };
-
+function startUnixSocket(listeningApp, socket, cb) {
   const chmodSocket = (done) => {
     // chmod 666 (rw rw rw) - octal
     const READ_WRITE = 438;
@@ -25,16 +12,16 @@ function startUnixSocket(
 
   const startSocket = () => {
     listeningApp.on('error', (err) => {
-      userCallback(err);
+      cb(err);
     });
 
     // 511 is the default value for the server.listen backlog parameter
     // https://nodejs.org/api/net.html#net_server_listen
     listeningApp.listen(socket, 511, (err) => {
       if (err) {
-        fullCallback(err);
+        cb(err);
       } else {
-        chmodSocket(fullCallback);
+        chmodSocket(cb);
       }
     });
   };
@@ -62,9 +49,7 @@ function startUnixSocket(
         // it means that the socket is in use
         const err = new Error('This socket is already used');
         clientSocket.destroy();
-        // do not call onListening or the setup method, since the server
-        // cannot start listening on a used socket
-        userCallback(err);
+        cb(err);
       });
     }
   });

--- a/lib/utils/startUnixSocket.js
+++ b/lib/utils/startUnixSocket.js
@@ -2,8 +2,11 @@
 
 const fs = require('fs');
 const net = require('net');
+const { promisify } = require('util');
 
-function startUnixSocket(listeningApp, socket, cb) {
+const accessAsync = promisify(fs.access);
+
+async function startUnixSocket(listeningApp, socket, cb) {
   const chmodSocket = (done) => {
     // chmod 666 (rw rw rw) - octal
     const READ_WRITE = 438;
@@ -26,32 +29,33 @@ function startUnixSocket(listeningApp, socket, cb) {
     });
   };
 
-  fs.access(socket, fs.constants.F_OK, (e) => {
-    if (e) {
-      // file does not exist
+  try {
+    await accessAsync(socket, fs.constants.F_OK);
+  } catch (e) {
+    // file does not exist
+    startSocket();
+    return;
+  }
+
+  // file exists
+
+  const clientSocket = new net.Socket();
+
+  clientSocket.on('error', (err) => {
+    if (err.code === 'ECONNREFUSED' || err.code === 'ENOTSOCK') {
+      // No other server listening on this socket so it can be safely removed
+      fs.unlinkSync(socket);
+
       startSocket();
-    } else {
-      // file exists
-
-      const clientSocket = new net.Socket();
-
-      clientSocket.on('error', (err) => {
-        if (err.code === 'ECONNREFUSED' || err.code === 'ENOTSOCK') {
-          // No other server listening on this socket so it can be safely removed
-          fs.unlinkSync(socket);
-
-          startSocket();
-        }
-      });
-
-      clientSocket.connect({ path: socket }, () => {
-        // if a client socket successfully connects to the given socket path,
-        // it means that the socket is in use
-        const err = new Error('This socket is already used');
-        clientSocket.destroy();
-        cb(err);
-      });
     }
+  });
+
+  clientSocket.connect({ path: socket }, () => {
+    // if a client socket successfully connects to the given socket path,
+    // it means that the socket is in use
+    const err = new Error('This socket is already used');
+    clientSocket.destroy();
+    cb(err);
   });
 }
 

--- a/lib/utils/startUnixSocket.js
+++ b/lib/utils/startUnixSocket.js
@@ -1,0 +1,65 @@
+'use strict';
+
+const fs = require('fs');
+const net = require('net');
+
+function startUnixSocket(
+  listeningApp,
+  socket,
+  onListeningCallback,
+  errorCallback
+) {
+  const chmodSocket = (done) => {
+    // chmod 666 (rw rw rw) - octal
+    const READ_WRITE = 438;
+    fs.chmod(socket, READ_WRITE, done);
+  };
+
+  const startSocket = () => {
+    listeningApp.on('error', (err) => {
+      errorCallback(err);
+    });
+
+    // 511 is the default value for the server.listen backlog parameter
+    // https://nodejs.org/api/net.html#net_server_listen
+    listeningApp.listen(socket, 511, (err) => {
+      if (err) {
+        onListeningCallback(err);
+      } else {
+        chmodSocket(onListeningCallback);
+      }
+    });
+  };
+
+  fs.access(socket, fs.constants.F_OK, (err) => {
+    if (err) {
+      // file does not exist
+      startSocket();
+    } else {
+      // file exists
+
+      const clientSocket = new net.Socket();
+
+      clientSocket.on('error', (err) => {
+        if (err.code === 'ECONNREFUSED' || err.code === 'ENOTSOCK') {
+          // No other server listening on this socket so it can be safely removed
+          fs.unlinkSync(socket);
+
+          startSocket();
+        }
+      });
+
+      clientSocket.connect({ path: socket }, () => {
+        // if a client socket successfully connects to the given socket path,
+        // it means that the socket is in use
+        const err = new Error('This socket is already used');
+        clientSocket.destroy();
+        // do not call onListening or the setup method, since the server
+        // cannot start listening on a used socket
+        errorCallback(err);
+      });
+    }
+  });
+}
+
+module.exports = startUnixSocket;

--- a/test/helpers/test-unix-socket.js
+++ b/test/helpers/test-unix-socket.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const http = require('http');
+
+const TestUnixSocket = class TestUnixSocket {
+  constructor() {
+    this.server = http.createServer();
+    this.sockets = new Set();
+    this.server.on('connection', (socket) => {
+      this.sockets.add(socket);
+      socket.on('close', () => {
+        this.sockets.delete(socket);
+      });
+    });
+  }
+
+  close(done) {
+    // get rid of connected sockets
+    for (const socket of this.sockets.values()) {
+      socket.destroy();
+    }
+    this.server.close(done);
+  }
+};
+
+module.exports = TestUnixSocket;

--- a/test/helpers/test-unix-socket.js
+++ b/test/helpers/test-unix-socket.js
@@ -15,11 +15,15 @@ const TestUnixSocket = class TestUnixSocket {
   }
 
   close(done) {
-    // get rid of connected sockets
-    for (const socket of this.sockets.values()) {
-      socket.destroy();
+    if (this.server.listening) {
+      // get rid of connected sockets
+      for (const socket of this.sockets.values()) {
+        socket.destroy();
+      }
+      this.server.close(done);
+    } else {
+      done();
     }
-    this.server.close(done);
   }
 };
 

--- a/test/server/onListening-option.test.js
+++ b/test/server/onListening-option.test.js
@@ -1,32 +1,71 @@
 'use strict';
 
+const { unlink } = require('fs');
+const { join } = require('path');
 const testServer = require('../helpers/test-server');
 const config = require('../fixtures/simple-config/webpack.config');
 const port = require('../ports-map')['onListening-option'];
+const { skipTestOnWindows } = require('../helpers/conditional-test');
 
 describe('onListening option', () => {
-  let onListeningIsRunning = false;
+  describe('with host and port', () => {
+    let onListeningIsRunning = false;
 
-  beforeAll((done) => {
-    testServer.start(
-      config,
-      {
-        onListening: (devServer) => {
-          if (!devServer) {
-            throw new Error('webpack-dev-server is not defined');
-          }
+    beforeAll((done) => {
+      testServer.start(
+        config,
+        {
+          onListening: (devServer) => {
+            if (!devServer) {
+              throw new Error('webpack-dev-server is not defined');
+            }
 
-          onListeningIsRunning = true;
+            onListeningIsRunning = true;
+          },
+          port,
         },
-        port,
-      },
-      done
-    );
+        done
+      );
+    });
+
+    afterAll(testServer.close);
+
+    it('should run onListening callback', () => {
+      expect(onListeningIsRunning).toBe(true);
+    });
   });
 
-  afterAll(testServer.close);
+  describe('with Unix socket', () => {
+    if (skipTestOnWindows('Unix sockets are not supported on Windows')) {
+      return;
+    }
 
-  it('should runs onListening callback', () => {
-    expect(onListeningIsRunning).toBe(true);
+    const socketPath = join('.', 'onListening.webpack.sock');
+    let onListeningIsRunning = false;
+
+    beforeAll((done) => {
+      testServer.start(
+        config,
+        {
+          onListening: (devServer) => {
+            if (!devServer) {
+              throw new Error('webpack-dev-server is not defined');
+            }
+
+            onListeningIsRunning = true;
+          },
+          socket: socketPath,
+        },
+        done
+      );
+    });
+
+    afterAll(testServer.close);
+
+    it('should run onListening callback', (done) => {
+      expect(onListeningIsRunning).toBe(true);
+
+      unlink(socketPath, done);
+    });
   });
 });

--- a/test/server/socket-option.test.js
+++ b/test/server/socket-option.test.js
@@ -95,7 +95,7 @@ describe('socket', () => {
       });
     });
 
-    it('should work as Unix socket', (done) => {
+    it('should throw already used error', (done) => {
       server = testServer.start(
         config,
         {

--- a/test/server/socket-option.test.js
+++ b/test/server/socket-option.test.js
@@ -1,0 +1,164 @@
+'use strict';
+
+const http = require('http');
+const net = require('net');
+const fs = require('fs');
+const path = require('path');
+const webpack = require('webpack');
+const testServer = require('../helpers/test-server');
+const config = require('../fixtures/simple-config/webpack.config');
+const Server = require('../../lib/Server');
+const { skipTestOnWindows } = require('../helpers/conditional-test');
+
+describe('socket', () => {
+  const socketPath = path.join('.', 'socket-option.webpack.sock');
+  let server = null;
+
+  describe('path to a non-existent file', () => {
+    let err;
+    beforeAll((done) => {
+      server = testServer.start(
+        config,
+        {
+          socket: socketPath,
+        },
+        (e) => {
+          err = e;
+          done();
+        }
+      );
+    });
+
+    it('should work as Unix socket or error on windows', (done) => {
+      if (process.platform === 'win32') {
+        expect(err.code).toEqual('EACCES');
+        done();
+      } else {
+        const clientSocket = new net.Socket();
+        clientSocket.connect({ path: socketPath }, () => {
+          // this means the connection was made successfully
+          expect(true).toBeTruthy();
+          done();
+        });
+      }
+    });
+
+    afterAll((done) => {
+      testServer.close(() => {
+        fs.unlink(socketPath, done);
+      });
+    });
+  });
+
+  describe('path to existent, unused file', () => {
+    if (skipTestOnWindows('Unix sockets are not supported on Windows')) {
+      return;
+    }
+
+    beforeAll((done) => {
+      fs.writeFileSync(socketPath, '');
+      server = testServer.start(
+        config,
+        {
+          socket: socketPath,
+        },
+        done
+      );
+    });
+
+    it('should work as Unix socket', (done) => {
+      const clientSocket = new net.Socket();
+      clientSocket.connect({ path: socketPath }, () => {
+        // this means the connection was made successfully
+        expect(true).toBeTruthy();
+        done();
+      });
+    });
+
+    afterAll((done) => {
+      testServer.close(() => {
+        fs.unlink(socketPath, done);
+      });
+    });
+  });
+
+  describe('path to existent file with listening server', () => {
+    if (skipTestOnWindows('Unix sockets are not supported on Windows')) {
+      return;
+    }
+
+    let dummyServer;
+    const sockets = new Set();
+    beforeAll((done) => {
+      dummyServer = http.createServer();
+      dummyServer.listen(socketPath, 511, () => {
+        done();
+      });
+      dummyServer.on('connection', (socket) => {
+        sockets.add(socket);
+        socket.on('close', () => {
+          sockets.delete(socket);
+        });
+      });
+    });
+
+    it('should work as Unix socket', (done) => {
+      server = testServer.start(
+        config,
+        {
+          socket: socketPath,
+        },
+        (err) => {
+          expect(err).not.toBeNull();
+          expect(err).not.toBeUndefined();
+          expect(err.message).toEqual('This socket is already used');
+          server.close(done);
+        }
+      );
+    });
+
+    afterAll((done) => {
+      // get rid of connected sockets on the dummyServer
+      for (const socket of sockets.values()) {
+        socket.destroy();
+      }
+      dummyServer.close(() => {
+        fs.unlink(socketPath, done);
+      });
+    });
+  });
+
+  describe('path to existent, unused file', () => {
+    if (skipTestOnWindows('Unix sockets are not supported on Windows')) {
+      return;
+    }
+
+    let devServer;
+    const options = {
+      socket: socketPath,
+    };
+    beforeAll(() => {
+      fs.writeFileSync(socketPath, '');
+    });
+
+    // this test is significant because previously the callback was called
+    // twice if a file at the given socket path already existed, but
+    // could be removed
+    it('should only call server.listen callback once', (done) => {
+      const compiler = webpack(config);
+
+      devServer = new Server(compiler, options);
+      const onListen = jest.fn();
+      // eslint-disable-next-line no-undefined
+      devServer.listen(options.socket, undefined, onListen);
+      setTimeout(() => {
+        expect(onListen).toBeCalledTimes(1);
+        done();
+      }, 10000);
+    });
+
+    afterAll((done) => {
+      devServer.close(done);
+    });
+  });
+});

--- a/test/server/utils/startUnixSocket.test.js
+++ b/test/server/utils/startUnixSocket.test.js
@@ -114,7 +114,7 @@ describe('startUnixSocket', () => {
       setTimeout(() => {
         expect(userCallback).toBeCalledTimes(1);
         done();
-      }, 10000);
+      }, 3000);
     });
 
     afterAll((done) => {

--- a/test/server/utils/startUnixSocket.test.js
+++ b/test/server/utils/startUnixSocket.test.js
@@ -87,7 +87,7 @@ describe('startUnixSocket', () => {
       });
     });
 
-    it('should work as Unix socket', (done) => {
+    it('should throw already used error', (done) => {
       testUnixSocket = new TestUnixSocket();
       startUnixSocket(
         testUnixSocket.server,

--- a/test/server/utils/startUnixSocket.test.js
+++ b/test/server/utils/startUnixSocket.test.js
@@ -15,15 +15,10 @@ describe('startUnixSocket', () => {
     let err;
     beforeAll((done) => {
       testUnixSocket = new TestUnixSocket();
-      startUnixSocket(
-        testUnixSocket.server,
-        socketPath,
-        () => {},
-        (e) => {
-          err = e;
-          done();
-        }
-      );
+      startUnixSocket(testUnixSocket.server, socketPath, (e) => {
+        err = e;
+        done();
+      });
     });
 
     it('should work as Unix socket or error on windows', (done) => {
@@ -55,7 +50,7 @@ describe('startUnixSocket', () => {
     beforeAll((done) => {
       fs.writeFileSync(socketPath, '');
       testUnixSocket = new TestUnixSocket();
-      startUnixSocket(testUnixSocket.server, socketPath, () => {}, done);
+      startUnixSocket(testUnixSocket.server, socketPath, done);
     });
 
     it('should work as Unix socket', (done) => {
@@ -89,17 +84,12 @@ describe('startUnixSocket', () => {
 
     it('should throw already used error', (done) => {
       testUnixSocket = new TestUnixSocket();
-      startUnixSocket(
-        testUnixSocket.server,
-        socketPath,
-        () => {},
-        (err) => {
-          expect(err).not.toBeNull();
-          expect(err).not.toBeUndefined();
-          expect(err.message).toEqual('This socket is already used');
-          testUnixSocket.close(done);
-        }
-      );
+      startUnixSocket(testUnixSocket.server, socketPath, (err) => {
+        expect(err).not.toBeNull();
+        expect(err).not.toBeUndefined();
+        expect(err.message).toEqual('This socket is already used');
+        testUnixSocket.close(done);
+      });
     });
 
     afterAll((done) => {
@@ -120,12 +110,7 @@ describe('startUnixSocket', () => {
     // could be removed
     it('should only call server.listen callback once', (done) => {
       const userCallback = jest.fn();
-      startUnixSocket(
-        testUnixSocket.server,
-        socketPath,
-        () => {},
-        userCallback
-      );
+      startUnixSocket(testUnixSocket.server, socketPath, userCallback);
       setTimeout(() => {
         expect(userCallback).toBeCalledTimes(1);
         done();


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [ ] This is a **bugfix**
- [x] This is a **feature**
- [x] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

Yes

### Motivation / Use-Case

This is the `socket` option handling portion of: https://github.com/webpack/webpack-dev-server/pull/2028. The goal is to move socket handling out of the CLI and into the API `listen` method. 

### Breaking Changes

API users will now get different behavior when they put a socket path in place of `port` in the `server.listen(port, hostname, fn)` method.

### Additional Info

This should be merged before I start work on the `findPort` portion of https://github.com/webpack/webpack-dev-server/pull/2028
