### PR TITLE
test(server/client): make sockjs implementation tests use snapshots

### DIFF
--- a/test/client/clients/SockJSClient.test.js
+++ b/test/client/clients/SockJSClient.test.js
@@ -48,10 +48,7 @@ describe('SockJSClient', () => {
       });
 
       setTimeout(() => {
-        expect(data.length).toEqual(3);
-        expect(data[0]).toEqual('open');
-        expect(data[1]).toEqual('hello world');
-        expect(data[2]).toEqual('close');
+        expect(data).toMatchSnapshot();
         done();
       }, 3000);
     });

--- a/test/client/clients/__snapshots__/SockJSClient.test.js.snap
+++ b/test/client/clients/__snapshots__/SockJSClient.test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SockJSClient client should open, receive message, and close 1`] = `
+Array [
+  "open",
+  "hello world",
+  "close",
+]
+`;

--- a/test/server/servers/SockJSServer.test.js
+++ b/test/server/servers/SockJSServer.test.js
@@ -54,10 +54,7 @@ describe('SockJSServer', () => {
       };
 
       setTimeout(() => {
-        expect(data.length).toEqual(3);
-        expect(data[0]).toEqual('open');
-        expect(data[1]).toEqual('hello world');
-        expect(data[2]).toEqual('close');
+        expect(data).toMatchSnapshot();
         done();
       }, 3000);
     });

--- a/test/server/servers/__snapshots__/SockJSServer.test.js.snap
+++ b/test/server/servers/__snapshots__/SockJSServer.test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SockJSServer server should recieve connection, send message, and close client 1`] = `
+Array [
+  "open",
+  "hello world",
+  "close",
+]
+`;


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [ ] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [x] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

Yes

### Motivation / Use-Case

Simple switch to using snapshots on `SockJSServer` and `SockJSClient` tests.

### Breaking Changes

None

### Additional Info
