### PR TITLE
test(client): added clientMode option test

### DIFF
--- a/test/ports-map.js
+++ b/test/ports-map.js
@@ -39,6 +39,7 @@ const portsList = {
   WebsocketClient: 1,
   WebsocketServer: 1,
   ClientMode: 1,
+  'clientMode-option': 1,
 };
 
 let startPort = 8079;

--- a/test/server/clientMode-option.test.js
+++ b/test/server/clientMode-option.test.js
@@ -1,0 +1,102 @@
+'use strict';
+
+const config = require('../fixtures/simple-config/webpack.config');
+const port = require('../ports-map')['clientMode-option'];
+
+describe('clientMode option', () => {
+  let mockedTestServer;
+  let testServer;
+  let getSocketClientPath;
+
+  const clientModes = [
+    {
+      title: 'as a string ("sockjs")',
+      clientMode: 'sockjs',
+      shouldThrow: false,
+    },
+    {
+      title: 'as a path ("sockjs")',
+      clientMode: require.resolve('../../client-src/clients/SockJSClient'),
+      shouldThrow: false,
+    },
+    {
+      title: 'as a nonexistent path',
+      clientMode: '/bad/path/to/implementation',
+      shouldThrow: true,
+    },
+  ];
+
+  describe('is passed to getSocketClientPath correctly', () => {
+    beforeEach(() => {
+      jest.mock('../../lib/utils/getSocketClientPath');
+      // eslint-disable-next-line global-require
+      getSocketClientPath = require('../../lib/utils/getSocketClientPath');
+    });
+
+    afterEach((done) => {
+      jest.resetAllMocks();
+      jest.resetModules();
+
+      mockedTestServer.close(done);
+    });
+
+    clientModes.forEach((data) => {
+      it(data.title, (done) => {
+        // eslint-disable-next-line global-require
+        mockedTestServer = require('../helpers/test-server');
+        mockedTestServer.start(
+          config,
+          {
+            inline: true,
+            clientMode: data.clientMode,
+            port,
+          },
+          () => {
+            expect(getSocketClientPath.mock.calls.length).toEqual(1);
+            expect(getSocketClientPath.mock.calls[0].length).toEqual(1);
+            expect(getSocketClientPath.mock.calls[0][0].clientMode).toEqual(
+              data.clientMode
+            );
+            done();
+          }
+        );
+      });
+    });
+  });
+
+  describe('passed to server', () => {
+    beforeAll(() => {
+      jest.unmock('../../lib/utils/getSocketClientPath');
+      // eslint-disable-next-line global-require
+      testServer = require('../helpers/test-server');
+    });
+
+    afterEach((done) => {
+      testServer.close(done);
+    });
+
+    clientModes.forEach((data) => {
+      it(`${data.title} ${
+        data.shouldThrow ? 'should throw' : 'should not throw'
+      }`, (done) => {
+        const res = () => {
+          testServer.start(
+            config,
+            {
+              inline: true,
+              clientMode: data.clientMode,
+              port,
+            },
+            done
+          );
+        };
+        if (data.shouldThrow) {
+          expect(res).toThrow(/clientMode must be a string/);
+          done();
+        } else {
+          expect(res).not.toThrow();
+        }
+      });
+    });
+  });
+});


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [ ] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [x] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

Yes

### Motivation / Use-Case

I should have added this earlier, but this simply confirms that the server is passing stuff into the `clientMode` helper correctly, and is throwing with bad `clientMode`.

### Breaking Changes

None

### Additional Info

I will add this mocking method to check `serverMode` helper usage if it looks fine.