### PR TITLE
feat(server): serverMode 'ws' option

### DIFF
--- a/lib/utils/getSocketServerImplementation.js
+++ b/lib/utils/getSocketServerImplementation.js
@@ -9,6 +9,9 @@ function getSocketServerImplementation(options) {
       if (options.serverMode === 'sockjs') {
         // eslint-disable-next-line global-require
         ServerImplementation = require('../servers/SockJSServer');
+      } else if (options.serverMode === 'ws') {
+        // eslint-disable-next-line global-require
+        ServerImplementation = require('../servers/WebsocketServer');
       } else {
         try {
           // eslint-disable-next-line global-require, import/no-dynamic-require
@@ -29,7 +32,7 @@ function getSocketServerImplementation(options) {
 
   if (!serverImplFound) {
     throw new Error(
-      "serverMode must be a string denoting a default implementation (e.g. 'sockjs'), a full path to " +
+      "serverMode must be a string denoting a default implementation (e.g. 'sockjs', 'ws'), a full path to " +
         'a JS file which exports a class extending BaseServer (webpack-dev-server/lib/servers/BaseServer) ' +
         'via require.resolve(...), or the class itself which extends BaseServer'
     );

--- a/test/server/__snapshots__/serverMode-option.test.js.snap
+++ b/test/server/__snapshots__/serverMode-option.test.js.snap
@@ -8,10 +8,84 @@ Array [
 ]
 `;
 
-exports[`serverMode option without a header results in an error 1`] = `
+exports[`serverMode option passed to server without a header results in an error 1`] = `
 Array [
   "open",
   "{\\"type\\":\\"error\\",\\"data\\":\\"Invalid Host/Origin header\\"}",
   "close",
+]
+`;
+
+exports[`serverMode option server should close client with bad headers 1`] = `
+Array [
+  Array [
+    [Function],
+  ],
+]
+`;
+
+exports[`serverMode option server should close client with bad headers 2`] = `
+Array [
+  Array [
+    Object {
+      "foo": "bar",
+    },
+    "{\\"type\\":\\"error\\",\\"data\\":\\"Invalid Host/Origin header\\"}",
+  ],
+]
+`;
+
+exports[`serverMode option server should close client with bad headers 3`] = `
+Array [
+  Array [
+    Object {
+      "foo": "bar",
+    },
+  ],
+]
+`;
+
+exports[`serverMode option server should use server implementation correctly 1`] = `
+Array [
+  Object {
+    "foo": "bar",
+  },
+]
+`;
+
+exports[`serverMode option server should use server implementation correctly 2`] = `
+Array [
+  Array [
+    [Function],
+  ],
+]
+`;
+
+exports[`serverMode option server should use server implementation correctly 3`] = `
+Array [
+  Object {
+    "foo": "bar",
+  },
+  "{\\"type\\":\\"liveReload\\"}",
+]
+`;
+
+exports[`serverMode option server should use server implementation correctly 4`] = `
+Array [
+  Object {
+    "foo": "bar",
+  },
+  "{\\"type\\":\\"ok\\"}",
+]
+`;
+
+exports[`serverMode option server should use server implementation correctly 5`] = `
+Array [
+  Array [
+    Object {
+      "foo": "bar",
+    },
+    [Function],
+  ],
 ]
 `;

--- a/test/server/__snapshots__/serverMode-option.test.js.snap
+++ b/test/server/__snapshots__/serverMode-option.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`serverMode option with a bad host header results in an error 1`] = `
+exports[`serverMode option passed to server with a bad host header results in an error 1`] = `
 Array [
   "open",
   "{\\"type\\":\\"error\\",\\"data\\":\\"Invalid Host/Origin header\\"}",

--- a/test/server/serverMode-option.test.js
+++ b/test/server/serverMode-option.test.js
@@ -229,80 +229,80 @@ describe('serverMode option', () => {
         }).toThrow(/serverMode must be a string/);
       });
     });
-  });
 
-  describe('with a bad host header', () => {
-    beforeAll((done) => {
-      server = testServer.start(
-        config,
-        {
-          port,
-          serverMode: class MySockJSServer extends BaseServer {
-            constructor(serv) {
-              super(serv);
-              this.socket = sockjs.createServer({
-                // Use provided up-to-date sockjs-client
-                sockjs_url: '/__webpack_dev_server__/sockjs.bundle.js',
-                // Limit useless logs
-                log: (severity, line) => {
-                  if (severity === 'error') {
-                    this.server.log.error(line);
-                  } else {
-                    this.server.log.debug(line);
-                  }
-                },
-              });
-
-              this.socket.installHandlers(this.server.listeningApp, {
-                prefix: this.server.sockPath,
-              });
-            }
-
-            send(connection, message) {
-              connection.write(message);
-            }
-
-            close(connection) {
-              connection.close();
-            }
-
-            onConnection(f) {
-              this.socket.on('connection', (connection) => {
-                f(connection, {
-                  host: null,
+    describe('with a bad host header', () => {
+      beforeAll((done) => {
+        server = testServer.start(
+          config,
+          {
+            port,
+            serverMode: class MySockJSServer extends BaseServer {
+              constructor(serv) {
+                super(serv);
+                this.socket = sockjs.createServer({
+                  // Use provided up-to-date sockjs-client
+                  sockjs_url: '/__webpack_dev_server__/sockjs.bundle.js',
+                  // Limit useless logs
+                  log: (severity, line) => {
+                    if (severity === 'error') {
+                      this.server.log.error(line);
+                    } else {
+                      this.server.log.debug(line);
+                    }
+                  },
                 });
-              });
-            }
 
-            onConnectionClose(connection, f) {
-              connection.on('close', f);
-            }
+                this.socket.installHandlers(this.server.listeningApp, {
+                  prefix: this.server.sockPath,
+                });
+              }
+
+              send(connection, message) {
+                connection.write(message);
+              }
+
+              close(connection) {
+                connection.close();
+              }
+
+              onConnection(f) {
+                this.socket.on('connection', (connection) => {
+                  f(connection, {
+                    host: null,
+                  });
+                });
+              }
+
+              onConnectionClose(connection, f) {
+                connection.on('close', f);
+              }
+            },
           },
-        },
-        done
-      );
-    });
+          done
+        );
+      });
 
-    it('results in an error', (done) => {
-      const data = [];
-      const client = new SockJS(`http://localhost:${port}/sockjs-node`);
+      it('results in an error', (done) => {
+        const data = [];
+        const client = new SockJS(`http://localhost:${port}/sockjs-node`);
 
-      client.onopen = () => {
-        data.push('open');
-      };
+        client.onopen = () => {
+          data.push('open');
+        };
 
-      client.onmessage = (e) => {
-        data.push(e.data);
-      };
+        client.onmessage = (e) => {
+          data.push(e.data);
+        };
 
-      client.onclose = () => {
-        data.push('close');
-      };
+        client.onclose = () => {
+          data.push('close');
+        };
 
-      setTimeout(() => {
-        expect(data).toMatchSnapshot();
-        done();
-      }, 5000);
+        setTimeout(() => {
+          expect(data).toMatchSnapshot();
+          done();
+        }, 5000);
+      });
     });
   });
 

--- a/test/server/serverMode-option.test.js
+++ b/test/server/serverMode-option.test.js
@@ -320,6 +320,81 @@ describe('serverMode option', () => {
         }, 5000);
       });
     });
+
+    describe('with a bad host header', () => {
+      beforeAll((done) => {
+        server = testServer.start(
+          config,
+          {
+            port,
+            serverMode: class MySockJSServer extends BaseServer {
+              constructor(serv) {
+                super(serv);
+                this.socket = sockjs.createServer({
+                  // Use provided up-to-date sockjs-client
+                  sockjs_url: '/__webpack_dev_server__/sockjs.bundle.js',
+                  // Limit useless logs
+                  log: (severity, line) => {
+                    if (severity === 'error') {
+                      this.server.log.error(line);
+                    } else {
+                      this.server.log.debug(line);
+                    }
+                  },
+                });
+
+                this.socket.installHandlers(this.server.listeningApp, {
+                  prefix: this.server.sockPath,
+                });
+              }
+
+              send(connection, message) {
+                connection.write(message);
+              }
+
+              close(connection) {
+                connection.close();
+              }
+
+              onConnection(f) {
+                this.socket.on('connection', (connection) => {
+                  f(connection, {
+                    host: null,
+                  });
+                });
+              }
+
+              onConnectionClose(connection, f) {
+                connection.on('close', f);
+              }
+            },
+          },
+          done
+        );
+      });
+
+      it('results in an error', (done) => {
+        const data = [];
+        const client = new SockJS(`http://localhost:${port}/sockjs-node`);
+
+        client.onopen = () => {
+          data.push('open');
+        };
+
+        client.onmessage = (e) => {
+          data.push(e.data);
+        };
+
+        client.onclose = () => {
+          data.push('close');
+        };
+
+        setTimeout(() => {
+          expect(data).toMatchSnapshot();
+          done();
+        }, 5000);
+      });
+    });
   });
 
   describe('server', () => {

--- a/test/server/serverMode-option.test.js
+++ b/test/server/serverMode-option.test.js
@@ -224,7 +224,7 @@ describe('serverMode option', () => {
               serverMode: '/bad/path/to/implementation',
               port,
             },
-            () => { }
+            () => {}
           );
         }).toThrow(/serverMode must be a string/);
       });
@@ -280,7 +280,7 @@ describe('serverMode option', () => {
           done
         );
 
-        mockWarn = jest.spyOn(server.log, 'warn').mockImplementation(() => { });
+        mockWarn = jest.spyOn(server.log, 'warn').mockImplementation(() => {});
       });
 
       it('results in an error', (done) => {
@@ -316,81 +316,6 @@ describe('serverMode option', () => {
 
           expect(foundWarning).toBeTruthy();
 
-          done();
-        }, 5000);
-      });
-    });
-
-    describe('with a bad host header', () => {
-      beforeAll((done) => {
-        server = testServer.start(
-          config,
-          {
-            port,
-            serverMode: class MySockJSServer extends BaseServer {
-              constructor(serv) {
-                super(serv);
-                this.socket = sockjs.createServer({
-                  // Use provided up-to-date sockjs-client
-                  sockjs_url: '/__webpack_dev_server__/sockjs.bundle.js',
-                  // Limit useless logs
-                  log: (severity, line) => {
-                    if (severity === 'error') {
-                      this.server.log.error(line);
-                    } else {
-                      this.server.log.debug(line);
-                    }
-                  },
-                });
-
-                this.socket.installHandlers(this.server.listeningApp, {
-                  prefix: this.server.sockPath,
-                });
-              }
-
-              send(connection, message) {
-                connection.write(message);
-              }
-
-              close(connection) {
-                connection.close();
-              }
-
-              onConnection(f) {
-                this.socket.on('connection', (connection) => {
-                  f(connection, {
-                    host: null,
-                  });
-                });
-              }
-
-              onConnectionClose(connection, f) {
-                connection.on('close', f);
-              }
-            },
-          },
-          done
-        );
-      });
-
-      it('results in an error', (done) => {
-        const data = [];
-        const client = new SockJS(`http://localhost:${port}/sockjs-node`);
-
-        client.onopen = () => {
-          data.push('open');
-        };
-
-        client.onmessage = (e) => {
-          data.push(e.data);
-        };
-
-        client.onclose = () => {
-          data.push('close');
-        };
-
-        setTimeout(() => {
-          expect(data).toMatchSnapshot();
           done();
         }, 5000);
       });

--- a/test/server/utils/getSocketServerImplementation.test.js
+++ b/test/server/utils/getSocketServerImplementation.test.js
@@ -2,9 +2,10 @@
 
 const getSocketServerImplementation = require('../../../lib/utils/getSocketServerImplementation');
 const SockJSServer = require('../../../lib/servers/SockJSServer');
+const WebsocketServer = require('../../../lib/servers/WebsocketServer');
 
 describe('getSocketServerImplementation util', () => {
-  it("should works with string serverMode ('sockjs')", () => {
+  it("should work with string serverMode ('sockjs')", () => {
     let result;
 
     expect(() => {
@@ -16,7 +17,7 @@ describe('getSocketServerImplementation util', () => {
     expect(result).toEqual(SockJSServer);
   });
 
-  it('should works with serverMode (SockJSServer class)', () => {
+  it('should work with serverMode (SockJSServer class)', () => {
     let result;
 
     expect(() => {
@@ -40,7 +41,43 @@ describe('getSocketServerImplementation util', () => {
     expect(result).toEqual(SockJSServer);
   });
 
-  it('should throws with serverMode (bad path)', () => {
+  it("should work with string serverMode ('ws')", () => {
+    let result;
+
+    expect(() => {
+      result = getSocketServerImplementation({
+        serverMode: 'ws',
+      });
+    }).not.toThrow();
+
+    expect(result).toEqual(WebsocketServer);
+  });
+
+  it('should work with serverMode (WebsocketServer class)', () => {
+    let result;
+
+    expect(() => {
+      result = getSocketServerImplementation({
+        serverMode: WebsocketServer,
+      });
+    }).not.toThrow();
+
+    expect(result).toEqual(WebsocketServer);
+  });
+
+  it('should work with serverMode (WebsocketServer full path)', () => {
+    let result;
+
+    expect(() => {
+      result = getSocketServerImplementation({
+        serverMode: require.resolve('../../../lib/servers/WebsocketServer'),
+      });
+    }).not.toThrow();
+
+    expect(result).toEqual(WebsocketServer);
+  });
+
+  it('should throw with serverMode (bad path)', () => {
     expect(() => {
       getSocketServerImplementation({
         serverMode: '/bad/path/to/implementation',


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [ ] This is a **bugfix**
- [x] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

<!-- Please note that we won't approve your changes if you don't add tests. -->
Yes

### Motivation / Use-Case

Adds the option `serverMode: 'ws'`. Please review and merge https://github.com/webpack/webpack-dev-server/pull/2077 before this. 

I still want to work on `serverMode-option.test.js` further such that it tests to see that `Server.js` interacts with a socket server implementation correctly. Currently, it only checks that `Server.js` calls the constructor of the server implementation. I will work on this later.

### Breaking Changes

None

### Additional Info
