### PR TITLE
fix(server): stricter headers security check

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -685,7 +685,14 @@ class Server {
         return;
       }
 
-      if (headers && (!this.checkHost(headers) || !this.checkOrigin(headers))) {
+      if (!headers) {
+        this.log.warn(
+          'serverMode implementation must pass headers to the callback of onConnection(f) ' +
+            'via f(connection, headers) in order for clients to pass a headers security check'
+        );
+      }
+
+      if (!headers || !this.checkHost(headers) || !this.checkOrigin(headers)) {
         this.sockWrite([connection], 'error', 'Invalid Host/Origin header');
 
         this.socketServer.close(connection);

--- a/lib/servers/SockJSServer.js
+++ b/lib/servers/SockJSServer.js
@@ -57,7 +57,7 @@ module.exports = class SockJSServer extends BaseServer {
     connection.close();
   }
 
-  // f should return the resulting connection and, optionally, the connection headers
+  // f should be passed the resulting connection and the connection headers
   onConnection(f) {
     this.socket.on('connection', (connection) => {
       f(connection, connection.headers);

--- a/lib/servers/WebsocketServer.js
+++ b/lib/servers/WebsocketServer.js
@@ -27,7 +27,7 @@ module.exports = class WebsocketServer extends BaseServer {
     connection.close();
   }
 
-  // f should return the resulting connection
+  // f should be passed the resulting connection and the connection headers
   onConnection(f) {
     this.wsServer.on('connection', (connection, req) => {
       f(connection, req.headers);

--- a/test/server/__snapshots__/serverMode-option.test.js.snap
+++ b/test/server/__snapshots__/serverMode-option.test.js.snap
@@ -7,3 +7,11 @@ Array [
   "close",
 ]
 `;
+
+exports[`serverMode option without a header results in an error 1`] = `
+Array [
+  "open",
+  "{\\"type\\":\\"error\\",\\"data\\":\\"Invalid Host/Origin header\\"}",
+  "close",
+]
+`;


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [x] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

Yes

### Motivation / Use-Case

Headers security check for connecting clients should not allow a connection without headers: https://github.com/webpack/webpack-dev-server/pull/2077

### Breaking Changes

Changes the socket server implementation requirements such that headers must be passed to `onConnection` callback.

### Additional Info
