### PR TITLE
refactor(server): move publicPath configuration from CLI to API

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -32,6 +32,7 @@ const createDomain = require('./utils/createDomain');
 const runBonjour = require('./utils/runBonjour');
 const routes = require('./utils/routes');
 const getSocketServerImplementation = require('./utils/getSocketServerImplementation');
+const setPublicPath = require('./utils/setPublicPath');
 const schema = require('./options.json');
 
 // Workaround for node ^8.6.0, ^9.0.0
@@ -57,6 +58,8 @@ class Server {
 
     this.compiler = compiler;
     this.options = options;
+
+    setPublicPath(compiler, options);
 
     // Setup default value
     this.options.contentBase =

--- a/lib/utils/createConfig.js
+++ b/lib/utils/createConfig.js
@@ -59,19 +59,6 @@ function createConfig(config, argv, { port }) {
     options.overlay = argv.overlay;
   }
 
-  if (!options.publicPath) {
-    // eslint-disable-next-line
-    options.publicPath =
-      (firstWpOpt.output && firstWpOpt.output.publicPath) || '';
-
-    if (
-      !isAbsoluteUrl(String(options.publicPath)) &&
-      options.publicPath[0] !== '/'
-    ) {
-      options.publicPath = `/${options.publicPath}`;
-    }
-  }
-
   if (!options.filename && firstWpOpt.output && firstWpOpt.output.filename) {
     options.filename = firstWpOpt.output && firstWpOpt.output.filename;
   }

--- a/lib/utils/setPublicPath.js
+++ b/lib/utils/setPublicPath.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const isAbsoluteUrl = require('is-absolute-url');
+
+function setPublicPath(compiler, options) {
+  const firstWpOpt = compiler.compilers
+    ? compiler.compilers[0].options
+    : compiler.options;
+
+  if (!options.publicPath) {
+    // eslint-disable-next-line
+    options.publicPath =
+      (firstWpOpt.output && firstWpOpt.output.publicPath) || '';
+
+    if (
+      !isAbsoluteUrl(String(options.publicPath)) &&
+      options.publicPath[0] !== '/'
+    ) {
+      options.publicPath = `/${options.publicPath}`;
+    }
+  }
+}
+
+module.exports = setPublicPath;


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [ ] This is a **bugfix**
- [ ] This is a **feature**
- [x] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

Not yet

### Motivation / Use-Case

This is part of the effort to move configuration changes out of the CLI and into the API. The goal here is to set the `publicPath` option in the API if it is not already set.

### Breaking Changes

No breaking changes on CLI.

On API, if a user was not specifying a `publicPath` in the past, it would not be set. Now, it will be set based on `compiler.options.output.publicPath`, if it exists. Should this PR be on `next` for this reason?

### Additional Info
