### PR TITLE
fix(examples): make examples webpack-dev-server npm script work on Windows

### DIFF
--- a/examples/run-example.js
+++ b/examples/run-example.js
@@ -1,0 +1,9 @@
+'use strict';
+
+const { spawn } = require('child_process');
+
+const cwd = process.env.INIT_CWD;
+spawn('node', ['../../../bin/webpack-dev-server.js'], {
+  cwd,
+  stdio: 'inherit',
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -3572,6 +3572,15 @@
         "sha.js": "^2.4.8"
       }
     },
+    "cross-env": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.2.0.tgz",
+      "integrity": "sha512-jtdNFfFW1hB7sMhr/H6rW1Z45LFqyI431m3qU6bFXcQ3Eh7LtBuG3h74o7ohHZ3crrRkkqHlo4jYHFPcjroANg==",
+      "requires": {
+        "cross-spawn": "^6.0.5",
+        "is-windows": "^1.0.0"
+      }
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3572,15 +3572,6 @@
         "sha.js": "^2.4.8"
       }
     },
-    "cross-env": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.2.0.tgz",
-      "integrity": "sha512-jtdNFfFW1hB7sMhr/H6rW1Z45LFqyI431m3qU6bFXcQ3Eh7LtBuG3h74o7ohHZ3crrRkkqHlo4jYHFPcjroANg==",
-      "requires": {
-        "cross-spawn": "^6.0.5",
-        "is-windows": "^1.0.0"
-      }
-    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "chokidar": "^2.1.6",
     "compression": "^1.7.4",
     "connect-history-api-fallback": "^1.6.0",
-    "cross-env": "^5.2.0",
     "debug": "^4.1.1",
     "del": "^4.1.1",
     "express": "^4.17.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "build:client:live": "webpack ./client-src/live/index.js -o client/live.bundle.js --color --config client-src/live/webpack.config.js",
     "build:client:sockjs": "webpack ./client-src/sockjs/index.js -o client/sockjs.bundle.js --color --config client-src/sockjs/webpack.config.js",
     "build:client": "rimraf ./client/* && npm-run-all -s -l -p \"build:client:**\"",
-    "webpack-dev-server": "cd $INIT_CWD && node ../../../bin/webpack-dev-server.js",
+    "webpack-dev-server": "node examples/run-example.js",
     "release": "standard-version"
   },
   "dependencies": {
@@ -40,6 +40,7 @@
     "chokidar": "^2.1.6",
     "compression": "^1.7.4",
     "connect-history-api-fallback": "^1.6.0",
+    "cross-env": "^5.2.0",
     "debug": "^4.1.1",
     "del": "^4.1.1",
     "express": "^4.17.1",


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [x] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

No

### Motivation / Use-Case

As described here: https://github.com/webpack/webpack-dev-server/pull/2100#discussion_r300542619, `$INIT_CWD` does not work on Windows. I tried solving with `cross-env` but it did not work, so here is an alternative.

### Breaking Changes

None

### Additional Info
