### PR TITLE
fix: check for name of HotModuleReplacementPlugin to avoid RangeError

### DIFF
--- a/lib/utils/addEntries.js
+++ b/lib/utils/addEntries.js
@@ -93,8 +93,9 @@ function addEntries(config, options, server) {
         config.plugins = config.plugins || [];
         if (
           !config.plugins.find(
-            (plugin) =>
-              plugin.constructor === webpack.HotModuleReplacementPlugin
+            // Check for the name rather than the constructor reference in case
+            // there are multiple copies of webpack installed
+            (plugin) => plugin.constructor.name === 'HotModuleReplacementPlugin'
           )
         ) {
           config.plugins.push(new webpack.HotModuleReplacementPlugin());

--- a/test/server/utils/addEntries.test.js
+++ b/test/server/utils/addEntries.test.js
@@ -246,6 +246,26 @@ describe('addEntries util', () => {
     ]);
   });
 
+  it("should not add the HMR plugin again if it's already there from a different webpack", () => {
+    const existingPlugin = new webpack.BannerPlugin('bruce');
+
+    // Simulate the inclusion of another webpack's HotModuleReplacementPlugin
+    class HotModuleReplacementPlugin {}
+
+    const webpackOptions = Object.assign({}, config, {
+      plugins: [new HotModuleReplacementPlugin(), existingPlugin],
+    });
+    const devServerOptions = { hot: true };
+
+    addEntries(webpackOptions, devServerOptions);
+
+    expect(webpackOptions.plugins).toEqual([
+      // Nothing should be injected
+      new HotModuleReplacementPlugin(),
+      existingPlugin,
+    ]);
+  });
+
   it('should can prevent duplicate entries from successive calls', () => {
     const webpackOptions = Object.assign({}, config);
     const devServerOptions = { hot: true };


### PR DESCRIPTION
- [x] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

Yes

### Motivation / Use-Case

Fixes #87, a long-standing subtle bug which seems to have tripped up a lot of people historically.

### Breaking Changes

No breaking changes.

### Additional Info

See my comment on the issue: https://github.com/webpack/webpack-dev-server/issues/87#issuecomment-514381082. The only way I can see this solution being a problem is if we're worried about configs that are using `--hot` and also have a plugin that *isn't* `HotModuleReplacementPlugin` but has the same name. In that case, we'd no longer inject the real HMR plugin. I'm not sure how likely this is and I seem to remember seeing other webpack plugins that check the name string rather than relying on the constructor reference (probably for this same reason).

However, if we are concerned and if there's a property we can additionally check on the instances of the plugin, that would potentially be more robust. Ideally it'd be a property that's existing on the `HotModuleReplacementPlugin` for a while to make it as backward-compatible as possible.