### PR TITLE
test(server): increase port mapping base number

### DIFF
--- a/test/ports-map.js
+++ b/test/ports-map.js
@@ -46,7 +46,7 @@ const portsList = {
   Iframe: 1,
 };
 
-let startPort = 8079;
+let startPort = 8089;
 const ports = {};
 
 Object.keys(portsList).forEach((key) => {

--- a/test/server/__snapshots__/Server.test.js.snap
+++ b/test/server/__snapshots__/Server.test.js.snap
@@ -5,7 +5,7 @@ Array [
   Array [
     "client",
     "index.js?http:",
-    "localhost:8090",
+    "localhost:8100",
   ],
   Array [
     "node_modules",
@@ -35,7 +35,7 @@ Array [
   Array [
     "client",
     "index.js?http:",
-    "localhost:8090",
+    "localhost:8100",
   ],
   Array [
     "node_modules",

--- a/test/server/open-option.test.js
+++ b/test/server/open-option.test.js
@@ -27,7 +27,7 @@ describe('open option', () => {
       server.close(() => {
         expect(open.mock.calls[0]).toMatchInlineSnapshot(`
           Array [
-            "http://localhost:8110/",
+            "http://localhost:8120/",
             Object {
               "wait": false,
             },

--- a/test/server/servers/__snapshots__/SockJSServer.test.js.snap
+++ b/test/server/servers/__snapshots__/SockJSServer.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SockJSServer server should recieve connection, send message, and close client 1`] = `"localhost:8083"`;
+exports[`SockJSServer server should recieve connection, send message, and close client 1`] = `"localhost:8093"`;
 
 exports[`SockJSServer server should recieve connection, send message, and close client 2`] = `
 Array [

--- a/test/server/servers/__snapshots__/WebsocketServer.test.js.snap
+++ b/test/server/servers/__snapshots__/WebsocketServer.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`WebsocketServer server should recieve connection, send message, and close client 1`] = `"localhost:8121"`;
+exports[`WebsocketServer server should recieve connection, send message, and close client 1`] = `"localhost:8131"`;
 
 exports[`WebsocketServer server should recieve connection, send message, and close client 2`] = `
 Array [


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [ ] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [x] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

N/A

### Motivation / Use-Case

As mentioned in https://github.com/webpack/webpack-dev-server/pull/2143, if we need to test CLI default port selection, which will use ports 8080, 8081, 8082... we should make sure the hard port mapping does not use these ports near port 8080. We just need to provide enough room for this default port assignment so that there will never be collisions.

### Breaking Changes

None

### Additional Info
