### PR TITLE
fix(server): fix setupExitSignals usage

### DIFF
--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -19,8 +19,11 @@ const getVersions = require('../lib/utils/getVersions');
 const options = require('./options');
 
 let server;
+const serverData = {
+  server: null,
+};
 
-setupExitSignals(server);
+setupExitSignals(serverData);
 
 // Prefer the local installation of webpack-dev-server
 if (importLocal(__filename)) {
@@ -98,6 +101,7 @@ function startDevServer(config, options) {
 
   try {
     server = new Server(compiler, options, log);
+    serverData.server = server;
   } catch (err) {
     if (err.name === 'ValidationError') {
       log.error(colors.error(options.stats.colors, err.message));

--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -22,7 +22,10 @@ let server;
 const serverData = {
   server: null,
 };
-
+// we must pass an object that contains the server object as a property so that
+// we can update this server property later, and setupExitSignals will be able to 
+// recognize that the server has been instantiated, because we will set
+// serverData.server to the new server object.
 setupExitSignals(serverData);
 
 // Prefer the local installation of webpack-dev-server

--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -23,7 +23,7 @@ const serverData = {
   server: null,
 };
 // we must pass an object that contains the server object as a property so that
-// we can update this server property later, and setupExitSignals will be able to 
+// we can update this server property later, and setupExitSignals will be able to
 // recognize that the server has been instantiated, because we will set
 // serverData.server to the new server object.
 setupExitSignals(serverData);

--- a/lib/utils/setupExitSignals.js
+++ b/lib/utils/setupExitSignals.js
@@ -2,11 +2,11 @@
 
 const signals = ['SIGINT', 'SIGTERM'];
 
-function setupExitSignals(server) {
+function setupExitSignals(serverData) {
   signals.forEach((signal) => {
     process.on(signal, () => {
-      if (server) {
-        server.close(() => {
+      if (serverData.server) {
+        serverData.server.close(() => {
           // eslint-disable-next-line no-process-exit
           process.exit();
         });

--- a/test/server/utils/setupExitSignals.test.js
+++ b/test/server/utils/setupExitSignals.test.js
@@ -1,0 +1,57 @@
+'use strict';
+
+const setupExitSignals = require('../../../lib/utils/setupExitSignals');
+
+describe('setupExitSignals', () => {
+  let server;
+  let exitSpy;
+  const signals = ['SIGINT', 'SIGTERM'];
+
+  beforeAll(() => {
+    exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => { });
+    server = {
+      close: jest.fn((callback) => {
+        callback();
+      }),
+    };
+  });
+
+  afterEach(() => {
+    exitSpy.mockReset();
+    server.close.mockClear();
+    signals.forEach((signal) => {
+      process.removeAllListeners(signal);
+    });
+  });
+
+  signals.forEach((signal) => {
+    it(`should exit process (${signal}, server never defined)`, (done) => {
+      setupExitSignals({
+        server: null,
+      });
+      process.emit(signal);
+      setTimeout(() => {
+        expect(exitSpy.mock.calls.length).toEqual(1);
+        done();
+      }, 1000);
+    });
+
+    it(`should close server, then exit process (${signal}, server defined before signal)`, (done) => {
+      const serverData = {
+        server: null,
+      };
+      setupExitSignals(serverData);
+  
+      setTimeout(() => {
+        serverData.server = server;
+        process.emit(signal);
+      }, 500);
+  
+      setTimeout(() => {
+        expect(server.close.mock.calls.length).toEqual(1);
+        expect(exitSpy.mock.calls.length).toEqual(1);
+        done();
+      }, 1500);
+    });
+  });
+});

--- a/test/server/utils/setupExitSignals.test.js
+++ b/test/server/utils/setupExitSignals.test.js
@@ -8,7 +8,7 @@ describe('setupExitSignals', () => {
   const signals = ['SIGINT', 'SIGTERM'];
 
   beforeAll(() => {
-    exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => { });
+    exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {});
     server = {
       close: jest.fn((callback) => {
         callback();
@@ -41,12 +41,12 @@ describe('setupExitSignals', () => {
         server: null,
       };
       setupExitSignals(serverData);
-  
+
       setTimeout(() => {
         serverData.server = server;
         process.emit(signal);
       }, 500);
-  
+
       setTimeout(() => {
         expect(server.close.mock.calls.length).toEqual(1);
         expect(exitSpy.mock.calls.length).toEqual(1);


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [x] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

No, should I add tests for `setupExitSignals`?

### Motivation / Use-Case

Fixes problem with `setupExitSignals` mentioned in: https://github.com/webpack/webpack-dev-server/issues/1479

An alternative to this approach is simply to get rid of `setupExitSignals`, but I think it's better to keep the helper and just change the function a bit.

### Breaking Changes

Altered `setupExitSignals` function API.

### Additional Info
