### PR TITLE
feat(server): add stdin option to API

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -33,6 +33,7 @@ const createDomain = require('./utils/createDomain');
 const runBonjour = require('./utils/runBonjour');
 const routes = require('./utils/routes');
 const getSocketServerImplementation = require('./utils/getSocketServerImplementation');
+const handleStdin = require('./utils/handleStdin');
 const schema = require('./options.json');
 
 // Workaround for node ^8.6.0, ^9.0.0
@@ -74,6 +75,8 @@ class Server {
     }
 
     normalizeOptions(this.compiler, this.options);
+
+    handleStdin(this.options);
 
     updateCompiler(this.compiler, this.options);
 

--- a/lib/options.json
+++ b/lib/options.json
@@ -355,6 +355,9 @@
         }
       ]
     },
+    "stdin": {
+      "type": "boolean"
+    },
     "useLocalIp": {
       "type": "boolean"
     },
@@ -438,6 +441,7 @@
       "socket": "should be {String} (https://webpack.js.org/configuration/dev-server/#devserversocket)",
       "staticOptions": "should be {Object} (https://webpack.js.org/configuration/dev-server/#devserverstaticoptions)",
       "stats": "should be {Object|Boolean} (https://webpack.js.org/configuration/dev-server/#devserverstats-)",
+      "stdin": "should be {Boolean} (https://webpack.js.org/configuration/dev-server/#devserverstdin)",
       "useLocalIp": "should be {Boolean} (https://webpack.js.org/configuration/dev-server/#devserveruselocalip)",
       "warn": "should be {Function}",
       "watchContentBase": "should be {Boolean} (https://webpack.js.org/configuration/dev-server/#devserverwatchcontentbase)",

--- a/lib/utils/createConfig.js
+++ b/lib/utils/createConfig.js
@@ -81,12 +81,7 @@ function createConfig(config, argv, { port }) {
   }
 
   if (argv.stdin) {
-    process.stdin.on('end', () => {
-      // eslint-disable-next-line no-process-exit
-      process.exit(0);
-    });
-
-    process.stdin.resume();
+    options.stdin = true;
   }
 
   // TODO https://github.com/webpack/webpack-dev-server/issues/616 (v4)

--- a/lib/utils/handleStdin.js
+++ b/lib/utils/handleStdin.js
@@ -1,0 +1,16 @@
+'use strict';
+
+function handleStdin(options) {
+  if (options.stdin) {
+    // listening for this event only once makes testing easier,
+    // since it prevents event listeners from hanging open
+    process.stdin.once('end', () => {
+      // eslint-disable-next-line no-process-exit
+      process.exit(0);
+    });
+
+    process.stdin.resume();
+  }
+}
+
+module.exports = handleStdin;

--- a/test/cli/cli.test.js
+++ b/test/cli/cli.test.js
@@ -107,7 +107,7 @@ describe('CLI', () => {
     });
   });
 
-  it('--stdin, with "end" event should exit without time out', (done) => {
+  it('--stdin, with "end" event should exit without time out', async () => {
     const configPath = resolve(
       __dirname,
       '../fixtures/simple-config/webpack.config.js'
@@ -119,15 +119,10 @@ describe('CLI', () => {
       childProcess.stdin.pause();
     }, 500);
 
-    childProcess
-      .then((output) => {
-        childProcess.stdin.removeAllListeners('end');
-        expect(output.code).toEqual(0);
-        expect(output.timedOut).toBeFalsy();
-        expect(output.killed).toBeFalsy();
-        done();
-      })
-      .catch(done);
+    const { exitCode, timedOut, killed } = await childProcess;
+    expect(exitCode).toEqual(0);
+    expect(timedOut).toBeFalsy();
+    expect(killed).toBeFalsy();
   });
 
   it('should accept the promise function of webpack.config.js', async () => {

--- a/test/cli/cli.test.js
+++ b/test/cli/cli.test.js
@@ -83,6 +83,53 @@ describe('CLI', () => {
     }
   });
 
+  it('without --stdin, with stdin "end" event should time out', (done) => {
+    const configPath = resolve(
+      __dirname,
+      '../fixtures/simple-config/webpack.config.js'
+    );
+    const childProcess = testBin(false, configPath, true);
+
+    setTimeout(() => {
+      // this is meant to confirm that it does not have any effect on the running process
+      // since options.stdin is not enabled
+      childProcess.stdin.emit('end');
+      childProcess.stdin.pause();
+    }, 500);
+
+    setTimeout(() => {
+      childProcess.kill();
+    }, 1000);
+
+    childProcess.once('exit', () => {
+      expect(childProcess.killed).toBeTruthy();
+      done();
+    });
+  });
+
+  it('--stdin, with "end" event should exit without time out', (done) => {
+    const configPath = resolve(
+      __dirname,
+      '../fixtures/simple-config/webpack.config.js'
+    );
+    const childProcess = testBin('--stdin', configPath);
+
+    setTimeout(() => {
+      childProcess.stdin.emit('end');
+      childProcess.stdin.pause();
+    }, 500);
+
+    childProcess
+      .then((output) => {
+        childProcess.stdin.removeAllListeners('end');
+        expect(output.code).toEqual(0);
+        expect(output.timedOut).toBeFalsy();
+        expect(output.killed).toBeFalsy();
+        done();
+      })
+      .catch(done);
+  });
+
   it('should accept the promise function of webpack.config.js', async () => {
     try {
       const { exitCode } = await testBin(

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -331,6 +331,10 @@ describe('options', () => {
         ],
         failure: ['whoops!', null],
       },
+      stdin: {
+        success: [false],
+        failure: [''],
+      },
       useLocalIp: {
         success: [false],
         failure: [''],

--- a/test/ports-map.js
+++ b/test/ports-map.js
@@ -44,6 +44,7 @@ const portsList = {
   'progress-option': 1,
   'profile-option': 1,
   Iframe: 1,
+  'stdin-option': 1,
 };
 
 let startPort = 8089;

--- a/test/server/stdin-option.test.js
+++ b/test/server/stdin-option.test.js
@@ -2,6 +2,7 @@
 
 const config = require('../fixtures/simple-config/webpack.config');
 const testServer = require('../helpers/test-server');
+const timer = require('../helpers/timer');
 const port = require('../ports-map')['stdin-option'];
 
 describe('stdin', () => {
@@ -32,13 +33,11 @@ describe('stdin', () => {
       );
     });
 
-    it('should exit process', (done) => {
+    it('should exit process', async () => {
       process.stdin.emit('end');
-      setTimeout(() => {
-        process.stdin.pause();
-        expect(exitSpy.mock.calls[0]).toEqual([0]);
-        done();
-      }, 1000);
+      await timer(1000);
+      process.stdin.pause();
+      expect(exitSpy.mock.calls[0]).toEqual([0]);
     });
   });
 
@@ -53,13 +52,11 @@ describe('stdin', () => {
       );
     });
 
-    it('should not exit process', (done) => {
+    it('should not exit process', async () => {
       process.stdin.emit('end');
-      setTimeout(() => {
-        process.stdin.pause();
-        expect(exitSpy.mock.calls.length).toEqual(0);
-        done();
-      }, 1000);
+      await timer(1000);
+      process.stdin.pause();
+      expect(exitSpy.mock.calls.length).toEqual(0);
     });
   });
 });

--- a/test/server/stdin-option.test.js
+++ b/test/server/stdin-option.test.js
@@ -1,0 +1,65 @@
+'use strict';
+
+const config = require('../fixtures/simple-config/webpack.config');
+const testServer = require('../helpers/test-server');
+const port = require('../ports-map')['stdin-option'];
+
+describe('stdin', () => {
+  // eslint-disable-next-line no-unused-vars
+  let server;
+  let exitSpy;
+
+  beforeAll(() => {
+    exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {});
+  });
+
+  afterEach((done) => {
+    server = null;
+    exitSpy.mockReset();
+    process.stdin.removeAllListeners('end');
+    testServer.close(done);
+  });
+
+  describe('enabled', () => {
+    beforeAll((done) => {
+      server = testServer.start(
+        config,
+        {
+          port,
+          stdin: true,
+        },
+        done
+      );
+    });
+
+    it('should exit process', (done) => {
+      process.stdin.emit('end');
+      setTimeout(() => {
+        process.stdin.pause();
+        expect(exitSpy.mock.calls[0]).toEqual([0]);
+        done();
+      }, 1000);
+    });
+  });
+
+  describe('disabled (default)', () => {
+    beforeAll((done) => {
+      server = testServer.start(
+        config,
+        {
+          port,
+        },
+        done
+      );
+    });
+
+    it('should not exit process', (done) => {
+      process.stdin.emit('end');
+      setTimeout(() => {
+        process.stdin.pause();
+        expect(exitSpy.mock.calls.length).toEqual(0);
+        done();
+      }, 1000);
+    });
+  });
+});

--- a/test/server/utils/handleStdin.test.js
+++ b/test/server/utils/handleStdin.test.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const handleStdin = require('../../../lib/utils/handleStdin');
+
+describe('handleStdin', () => {
+  let exitSpy;
+
+  beforeAll(() => {
+    exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    process.stdin.removeAllListeners('end');
+    exitSpy.mockReset();
+  });
+
+  describe('enabled', () => {
+    it('should exit process', (done) => {
+      handleStdin({
+        stdin: true,
+      });
+      process.stdin.emit('end');
+      setTimeout(() => {
+        process.stdin.pause();
+        expect(exitSpy.mock.calls[0]).toEqual([0]);
+        done();
+      }, 1000);
+    });
+  });
+
+  describe('disabled (default)', () => {
+    it('should not exit process', (done) => {
+      handleStdin({});
+      process.stdin.emit('end');
+      setTimeout(() => {
+        process.stdin.pause();
+        expect(exitSpy.mock.calls.length).toEqual(0);
+        done();
+      }, 1000);
+    });
+  });
+});

--- a/test/server/utils/handleStdin.test.js
+++ b/test/server/utils/handleStdin.test.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const timer = require('../../helpers/timer');
 const handleStdin = require('../../../lib/utils/handleStdin');
 
 describe('handleStdin', () => {
@@ -15,28 +16,26 @@ describe('handleStdin', () => {
   });
 
   describe('enabled', () => {
-    it('should exit process', (done) => {
+    it('should exit process', async () => {
       handleStdin({
         stdin: true,
       });
       process.stdin.emit('end');
-      setTimeout(() => {
-        process.stdin.pause();
-        expect(exitSpy.mock.calls[0]).toEqual([0]);
-        done();
-      }, 1000);
+
+      await timer(1000);
+      process.stdin.pause();
+      expect(exitSpy.mock.calls[0]).toEqual([0]);
     });
   });
 
   describe('disabled (default)', () => {
-    it('should not exit process', (done) => {
+    it('should not exit process', async () => {
       handleStdin({});
       process.stdin.emit('end');
-      setTimeout(() => {
-        process.stdin.pause();
-        expect(exitSpy.mock.calls.length).toEqual(0);
-        done();
-      }, 1000);
+
+      await timer(1000);
+      process.stdin.pause();
+      expect(exitSpy.mock.calls.length).toEqual(0);
     });
   });
 });


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [ ] This is a **bugfix**
- [x] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

Yes

### Motivation / Use-Case

This makes stdin an option for both CLI and API, and helps in moving configuration changes out of the CLI for CLI refactor.

Same PR as https://github.com/webpack/webpack-dev-server/pull/2106, but moved to `next`. It was faster to do this than an ugly rebase.

### Breaking Changes

None, `stdin` will work the same as it did before on CLI.

### Additional Info
