### PR TITLE
chore(deps): add webpack-cli to peers

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,8 @@
     "webpack-cli": "^3.3.6"
   },
   "peerDependencies": {
-    "webpack": "^4.0.0"
+    "webpack": "^4.0.0",
+    "webpack-cli": "^3.0.0"
   },
   "author": "Tobias Koppers @sokra",
   "bugs": "https://github.com/webpack/webpack-dev-server/issues",


### PR DESCRIPTION
- [x] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

Can publish a package with this PR and see if it actually works but these kind of fixes have been done multiple times to make yarn v2 happy. Considering `webpack-dev-server` throws at runtime anyway if `webpack-cli` is missing this shouldn't bother anyone

### Motivation / Use-Case

yarn v2 throws currently with 

```
Error: A package is trying to access another package without the second one being listed as a dependency of the first one

Required package: webpack-cli (via "webpack-cli/bin/config-yargs")
Required by: webpack-dev-server@virtual:836be30d0802b4899b9a78ca9d744f43f038cccf96d6b8307cbd938d17151f1ac108d2e64290515733c51d0949e0c6d87f9a7c9e245dfe628e5c4ef98f22d752#npm:3.8.0 
```

### Breaking Changes

I guess this new warning might be annoying if you don't run the `webpack-dev-server` cli. If this is a blocker I can try and see if https://github.com/yarnpkg/rfcs/blob/master/accepted/0000-optional-peer-dependencies.md works for yarn v2.

### Additional Info
