### PR TITLE
fix: fatal error when current JS is not inside script tag

### DIFF
--- a/client-src/default/utils/createSocketUrl.js
+++ b/client-src/default/utils/createSocketUrl.js
@@ -16,8 +16,10 @@ function createSocketUrl(resourceQuery) {
     // Else, get the url from the <script> this file was called with.
     let scriptHost = getCurrentScriptSource();
 
-    // eslint-disable-next-line no-useless-escape
-    scriptHost = scriptHost.replace(/\/[^\/]+$/, '');
+    if (scriptHost) {
+      // eslint-disable-next-line no-useless-escape
+      scriptHost = scriptHost.replace(/\/[^\/]+$/, '');
+    }
     urlParts = url.parse(scriptHost || '/', false, true);
   }
 

--- a/test/client/utils/createSocketUrl.test.js
+++ b/test/client/utils/createSocketUrl.test.js
@@ -13,6 +13,8 @@ describe('createSocketUrl', () => {
     // TODO: comment out after the major release
     // https://github.com/webpack/webpack-dev-server/pull/1954#issuecomment-498043376
     // 'file://filename',
+    // eslint-disable-next-line no-undefined
+    undefined,
   ];
 
   samples.forEach((url) => {


### PR DESCRIPTION
* for example when html-webpack-inline-source-plugin is used, the JS is inlined in HTML in script tag. So in this case document.currentScript.getAttribute('src') is undefined
* undefined cannot be used as string with method replace. This cause a fatal error and crash app

- [ ] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

<!-- Please note that we won't approve your changes if you don't add tests. -->

### Motivation / Use-Case

<!--
  What existing problem does the pull request solve?

  Please explain the motivation or use-case for making this change.
  If this Pull Request addresses an issue, please link to the issue.
-->

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  potential migration path for existing applications.
-->

### Additional Info
