### PR TITLE
test(cli): use ports map for quiet logging test

### DIFF
--- a/test/cli/cli.test.js
+++ b/test/cli/cli.test.js
@@ -4,6 +4,7 @@ const { unlink } = require('fs');
 const { join, resolve } = require('path');
 const execa = require('execa');
 const testBin = require('../helpers/test-bin');
+const port1 = require('../ports-map').cli[0];
 
 const httpsCertificateDirectory = resolve(
   __dirname,
@@ -30,11 +31,11 @@ describe('CLI', () => {
   });
 
   it('--quiet', async (done) => {
-    const output = await testBin('--quiet');
+    const output = await testBin(`--quiet --port ${port1}`);
     expect(output.code).toEqual(0);
     expect(output.stdout.split('\n').length === 3).toBe(true);
     expect(
-      output.stdout.includes('Project is running at http://localhost:8080/')
+      output.stdout.includes(`Project is running at http://localhost:${port1}/`)
     ).toBe(true);
     expect(output.stdout.includes('webpack output is served from /')).toBe(
       true


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [ ] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [x] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

N/A

### Motivation / Use-Case

Use ports map instead of hard-coded port 8080. Note that the `cli` ports-map value already existed, just wasn't being used.

### Breaking Changes

N/A

### Additional Info
