### PR TITLE
fix: add hostname and port to bonjour name to prevent name collisions

### DIFF
--- a/lib/utils/runBonjour.js
+++ b/lib/utils/runBonjour.js
@@ -2,9 +2,10 @@
 
 function runBonjour({ port }) {
   const bonjour = require('bonjour')();
+  const os = require('os');
 
   bonjour.publish({
-    name: 'Webpack Dev Server',
+    name: `Webpack Dev Server ${os.hostname()}:${port}`,
     port,
     type: 'http',
     subtypes: ['webpack'],

--- a/test/server/utils/__snapshots__/runBonjour.test.js.snap
+++ b/test/server/utils/__snapshots__/runBonjour.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`runBonjour should call bonjour.publish 1`] = `
 Object {
-  "name": "Webpack Dev Server",
+  "name": "Webpack Dev Server hostname:1111",
   "port": 1111,
   "subtypes": Array [
     "webpack",

--- a/test/server/utils/runBonjour.test.js
+++ b/test/server/utils/runBonjour.test.js
@@ -2,6 +2,12 @@
 
 const runBonjour = require('../../../lib/utils/runBonjour');
 
+jest.mock('os', () => {
+  return {
+    hostname: () => 'hostname',
+  };
+});
+
 describe('runBonjour', () => {
   let mock;
   let publish = jest.fn();
@@ -31,5 +37,18 @@ describe('runBonjour', () => {
     });
 
     expect(publish.mock.calls[0][0]).toMatchSnapshot();
+  });
+
+  it('should call bonjour.publish with different name for different ports', () => {
+    runBonjour({
+      port: 1111,
+    });
+    runBonjour({
+      port: 2222,
+    });
+
+    const calls = publish.mock.calls;
+
+    expect(calls[0][0].name).not.toEqual(calls[1][0].name);
   });
 });


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [x] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [x] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

Yes

### Motivation / Use-Case

It was impossible to run mutliple instances of webpack-dev-server if they all had `bonjour` because of 'name already in use' error.

### Breaking Changes

No

### Additional Info
