### PR TITLE
fix(client): don't override protocol for socket connection to 127.0.0.1

### DIFF
--- a/client-src/default/utils/createSocketUrl.js
+++ b/client-src/default/utils/createSocketUrl.js
@@ -46,6 +46,7 @@ function createSocketUrl(resourceQuery) {
   // because the browser doesn't accept non-secure websockets.
   if (
     hostname &&
+    hostname !== '127.0.0.1' &&
     (self.location.protocol === 'https:' || urlParts.hostname === '0.0.0.0')
   ) {
     protocol = self.location.protocol;

--- a/test/client/utils/__snapshots__/createSocketUrl.test.js.snap
+++ b/test/client/utils/__snapshots__/createSocketUrl.test.js.snap
@@ -4,6 +4,8 @@ exports[`createSocketUrl should return the url when __resourceQuery is ?test 1`]
 
 exports[`createSocketUrl should return the url when __resourceQuery is http://0.0.0.0 1`] = `"http://localhost/sockjs-node"`;
 
+exports[`createSocketUrl should return the url when __resourceQuery is http://127.0.0.1 1`] = `"http://127.0.0.1/sockjs-node"`;
+
 exports[`createSocketUrl should return the url when __resourceQuery is http://user:pass@[::]:8080 1`] = `"http://user:pass@localhost:8080/sockjs-node"`;
 
 exports[`createSocketUrl should return the url when __resourceQuery is http://user:password@localhost/ 1`] = `"http://user:password@localhost/sockjs-node"`;
@@ -21,6 +23,8 @@ exports[`createSocketUrl should return the url when __resourceQuery is undefined
 exports[`createSocketUrl should return the url when the current script source is ?test 1`] = `"/sockjs-node"`;
 
 exports[`createSocketUrl should return the url when the current script source is http://0.0.0.0 1`] = `"http://localhost/sockjs-node"`;
+
+exports[`createSocketUrl should return the url when the current script source is http://127.0.0.1 1`] = `"http://127.0.0.1/sockjs-node"`;
 
 exports[`createSocketUrl should return the url when the current script source is http://user:pass@[::]:8080 1`] = `"http://user:pass@localhost:8080/sockjs-node"`;
 

--- a/test/client/utils/createSocketUrl.test.js
+++ b/test/client/utils/createSocketUrl.test.js
@@ -10,6 +10,7 @@ describe('createSocketUrl', () => {
     'http://0.0.0.0',
     'https://localhost:123',
     'http://user:pass@[::]:8080',
+    'http://127.0.0.1',
     // TODO: comment out after the major release
     // https://github.com/webpack/webpack-dev-server/pull/1954#issuecomment-498043376
     // 'file://filename',


### PR DESCRIPTION
Chrome and Firefox accept `http://`/`ws://` mixed-content connection to
`127.0.0.1` even when the actual website is loaded via `https://`.

Fixes #2302 

- [X] This is a **bugfix**
- [X] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

I'm not sure if the [current tests](https://github.com/webpack/webpack-dev-server/blob/master/test/client/utils/__snapshots__/createSocketUrl.test.js.snap) actually contain correct assertions.

### Motivation / Use-Case

described in https://github.com/webpack/webpack-dev-server/issues/2302

### Breaking Changes

nope

### Additional Info
