### PR TITLE
fix(Server): don't use `spdy` on `node >= v10.0.0` (#1451)

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -7,6 +7,7 @@ const fs = require('fs');
 const http = require('http');
 const path = require('path');
 const url = require('url');
+const https = require('https');
 const chokidar = require('chokidar');
 const compress = require('compression');
 const del = require('del');
@@ -497,7 +498,20 @@ function Server(compiler, options) {
       };
     }
 
-    this.listeningApp = spdy.createServer(options.https, app);
+    // `spdy` is effectively unmaintained, and as a consequence of an
+    // implementation that extensively relies on Node’s non-public APIs, broken
+    // on Node 10 and above. In those cases, only https will be used for now.
+    // Once express supports Node's built-in HTTP/2 support, migrating over to
+    // that should be the best way to go.
+    // The relevant issues are:
+    // - https://github.com/nodejs/node/issues/21665
+    // - https://github.com/webpack/webpack-dev-server/issues/1449
+    // - https://github.com/expressjs/express/issues/3388
+    if (+process.version.match(/^v(\d+)/)[1] >= 10) {
+      this.listeningApp = https.createServer(options.https, app);
+    } else {
+      this.listeningApp = spdy.createServer(options.https, app);
+    }
   } else {
     this.listeningApp = http.createServer(app);
   }

--- a/test/Https.test.js
+++ b/test/Https.test.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const path = require('path');
+const request = require('supertest');
+const helper = require('./helper');
+const config = require('./fixtures/contentbase-config/webpack.config');
+require('mocha-sinon');
+
+const contentBasePublic = path.join(__dirname, 'fixtures/contentbase-config/public');
+
+describe('HTTPS', function testHttps() {
+  let server;
+  let req;
+  afterEach(helper.close);
+
+  // Increase the timeout to 20 seconds to allow time for key generation.
+  this.timeout(20000);
+
+  describe('to directory', () => {
+    before((done) => {
+      server = helper.start(config, {
+        contentBase: contentBasePublic,
+        https: true
+      }, done);
+      req = request(server.app);
+    });
+
+    it('Request to index', (done) => {
+      req.get('/')
+        .expect(200, /Heyo/, done);
+    });
+  });
+});


### PR DESCRIPTION
Cherry-picked by https://github.com/webpack/webpack-dev-server/pull/1451
to support webpack 3 with nodejs version 10

Now, spdy is not working properly in nodejs 10

<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [ ] This is a **bugfix**

### For Bugs and Features; did you add new tests?

Yes

<!-- Please note that we won't approve your changes if you don't add tests. -->

### Motivation / Use-Case

Webpack3 is working with webapck-dev-server 2.x.x, not 3.x.x

This cherry-pick will resolve the spdy issue in nodejs 10 in webpack3 by using https, not spdy

