### PR TITLE
fix(client): fix tests for createSocketUrl

### DIFF
--- a/client-src/default/utils/createSocketUrl.js
+++ b/client-src/default/utils/createSocketUrl.js
@@ -11,15 +11,11 @@ function createSocketUrl(resourceQuery) {
 
   if (typeof resourceQuery === 'string' && resourceQuery !== '') {
     // If this bundle is inlined, use the resource query to get the correct url.
+    // strip leading `?` from query string
     urlParts = url.parse(resourceQuery.substr(1));
   } else {
     // Else, get the url from the <script> this file was called with.
-    let scriptHost = getCurrentScriptSource();
-
-    if (scriptHost) {
-      // eslint-disable-next-line no-useless-escape
-      scriptHost = scriptHost.replace(/\/[^\/]+$/, '');
-    }
+    const scriptHost = getCurrentScriptSource();
     urlParts = url.parse(scriptHost || '/', false, true);
   }
 

--- a/test/client/utils/__snapshots__/createSocketUrl.test.js.snap
+++ b/test/client/utils/__snapshots__/createSocketUrl.test.js.snap
@@ -4,34 +4,34 @@ exports[`createSocketUrl should return the url when __resourceQuery is ?test 1`]
 
 exports[`createSocketUrl should return the url when __resourceQuery is http://0.0.0.0 1`] = `"http://localhost/sockjs-node"`;
 
-exports[`createSocketUrl should return the url when __resourceQuery is http://user:pass@[::]:8080 1`] = `"ttp:user:pass@localhost:8080/sockjs-node"`;
+exports[`createSocketUrl should return the url when __resourceQuery is http://user:pass@[::]:8080 1`] = `"http://user:pass@localhost:8080/sockjs-node"`;
 
-exports[`createSocketUrl should return the url when __resourceQuery is http://user:password@localhost/ 1`] = `"ttp:user:password@localhost/sockjs-node"`;
+exports[`createSocketUrl should return the url when __resourceQuery is http://user:password@localhost/ 1`] = `"http://user:password@localhost/sockjs-node"`;
 
-exports[`createSocketUrl should return the url when __resourceQuery is https://example.com 1`] = `"ttps:example.com/sockjs-node"`;
+exports[`createSocketUrl should return the url when __resourceQuery is https://example.com 1`] = `"https://example.com/sockjs-node"`;
 
-exports[`createSocketUrl should return the url when __resourceQuery is https://example.com/path 1`] = `"ttps:example.com/sockjs-node"`;
+exports[`createSocketUrl should return the url when __resourceQuery is https://example.com/path 1`] = `"https://example.com/sockjs-node"`;
 
-exports[`createSocketUrl should return the url when __resourceQuery is https://example.com/path/foo.js 1`] = `"ttps:example.com/sockjs-node"`;
+exports[`createSocketUrl should return the url when __resourceQuery is https://example.com/path/foo.js 1`] = `"https://example.com/sockjs-node"`;
 
-exports[`createSocketUrl should return the url when __resourceQuery is https://localhost:123 1`] = `"ttps:localhost:123/sockjs-node"`;
+exports[`createSocketUrl should return the url when __resourceQuery is https://localhost:123 1`] = `"https://localhost:123/sockjs-node"`;
 
 exports[`createSocketUrl should return the url when __resourceQuery is undefined 1`] = `"/sockjs-node"`;
 
 exports[`createSocketUrl should return the url when the current script source is ?test 1`] = `"/sockjs-node"`;
 
-exports[`createSocketUrl should return the url when the current script source is http://0.0.0.0 1`] = `"http:/sockjs-node"`;
+exports[`createSocketUrl should return the url when the current script source is http://0.0.0.0 1`] = `"http://localhost/sockjs-node"`;
 
-exports[`createSocketUrl should return the url when the current script source is http://user:pass@[::]:8080 1`] = `"http:/sockjs-node"`;
+exports[`createSocketUrl should return the url when the current script source is http://user:pass@[::]:8080 1`] = `"http://user:pass@localhost:8080/sockjs-node"`;
 
 exports[`createSocketUrl should return the url when the current script source is http://user:password@localhost/ 1`] = `"http://user:password@localhost/sockjs-node"`;
 
-exports[`createSocketUrl should return the url when the current script source is https://example.com 1`] = `"https:/sockjs-node"`;
+exports[`createSocketUrl should return the url when the current script source is https://example.com 1`] = `"https://example.com/sockjs-node"`;
 
 exports[`createSocketUrl should return the url when the current script source is https://example.com/path 1`] = `"https://example.com/sockjs-node"`;
 
 exports[`createSocketUrl should return the url when the current script source is https://example.com/path/foo.js 1`] = `"https://example.com/sockjs-node"`;
 
-exports[`createSocketUrl should return the url when the current script source is https://localhost:123 1`] = `"https:/sockjs-node"`;
+exports[`createSocketUrl should return the url when the current script source is https://localhost:123 1`] = `"https://localhost:123/sockjs-node"`;
 
 exports[`createSocketUrl should return the url when the current script source is undefined 1`] = `"/sockjs-node"`;

--- a/test/client/utils/createSocketUrl.test.js
+++ b/test/client/utils/createSocketUrl.test.js
@@ -26,7 +26,8 @@ describe('createSocketUrl', () => {
     const createSocketUrl = require('../../../client-src/default/utils/createSocketUrl');
 
     test(`should return the url when __resourceQuery is ${url}`, () => {
-      expect(createSocketUrl(url)).toMatchSnapshot();
+      const query = url ? url.querystring : url;
+      expect(createSocketUrl(query)).toMatchSnapshot();
     });
 
     test(`should return the url when the current script source is ${url}`, () => {


### PR DESCRIPTION
- [ ] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [X] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### Motivation / Use-Case

follow up of https://github.com/webpack/webpack-dev-server/pull/2303 

1) the tests are incorrect because they did not prepend the `?` to the url. The parameter format should be like `?http://0.0.0.0:8096&sockPort=8097&sockHost=localhost`

2) replacing two `//` with one `/` looks wrong an unused as mentioned in https://github.com/webpack/webpack-dev-server/pull/2303