### PR TITLE
feat(client): allow sock port to use browser location's port

### DIFF
--- a/client-src/default/utils/createSocketUrl.js
+++ b/client-src/default/utils/createSocketUrl.js
@@ -76,7 +76,11 @@ function getSocketUrl(urlParts, loc) {
   // they are not provided
   const sockHost = query.sockHost || hostname;
   const sockPath = query.sockPath || '/sockjs-node';
-  const sockPort = query.sockPort || port;
+  let sockPort = query.sockPort || port;
+
+  if (sockPort === 'location') {
+    sockPort = loc.port;
+  }
 
   return url.format({
     protocol,

--- a/test/client/utils/createSocketUrl.test.js
+++ b/test/client/utils/createSocketUrl.test.js
@@ -141,6 +141,16 @@ describe('createSocketUrl', () => {
       'http://localhost',
       'http://localhost:8097/sockjs-node',
     ],
+    [
+      '?http://example.com:8096&sockPort=location',
+      'http://something.com',
+      'http://example.com/sockjs-node',
+    ],
+    [
+      '?http://0.0.0.0:8096&sockPort=location',
+      'http://localhost:3000',
+      'http://localhost:3000/sockjs-node',
+    ],
   ];
   samples3.forEach(([scriptSrc, loc, expected]) => {
     test(`should return socket ${expected} for query ${scriptSrc} and location ${loc}`, () => {


### PR DESCRIPTION
Add the ability to set `sockPort: 'location'` to make the sock port dynamic.

This change would allow the port to be specified by an individual proxy, e.g. if different team members have their environments configured differently.

<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [ ] This is a **bugfix**
- [x] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

<!-- Please note that we won't approve your changes if you don't add tests. -->

I added the scenario to an existing test.

### Motivation / Use-Case

<!--
  What existing problem does the pull request solve?

  Please explain the motivation or use-case for making this change.
  If this Pull Request addresses an issue, please link to the issue.
-->

Related to #1664 which was semi-addressed by #1792 and then reverted by #1838.

This change provides a way for the sock port to use the browser location's port which may or may not be known at build time. For example,
* one team member hits webpack-dev-server directly at http://localhost:3000
* another uses a Docker container that proxies it via http://localhost.example.com
* a third uses Nginx to proxy through SSL with https://dev.example.com

For all three to be able to use it the way they want they would have to modify their local copy of webpack.config.js to set the `sockPort` to either 3000, 80, or 443 and then remember to never check in their change. Alternatively a "magic" value (in this case `"location"`) would be set and the client JS would swap in the browser's port number and all three developers would happily use their current setup.

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  potential migration path for existing applications.
-->

No breaking changes (additive only).

### Additional Info

N/A