### PR TITLE
feat(server): proxyconfig callback args

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -289,7 +289,7 @@ class Server {
 
       this.app.use((req, res, next) => {
         if (typeof proxyConfigOrCallback === 'function') {
-          const newProxyConfig = proxyConfigOrCallback();
+          const newProxyConfig = proxyConfigOrCallback(req, res, next);
 
           if (newProxyConfig !== proxyConfig) {
             proxyConfig = newProxyConfig;

--- a/test/server/proxy-option.test.js
+++ b/test/server/proxy-option.test.js
@@ -45,11 +45,12 @@ const proxyOption = {
 
 const proxyOptionOfArray = [
   { context: '/proxy1', target: proxyOption.target },
-  function proxy() {
+  function proxy(req) {
     return {
       context: '/api/proxy2',
       target: `http://localhost:${port2}`,
       pathRewrite: { '^/api': '' },
+      bypass: () => (req.query.foo ? false : null),
     };
   },
 ];
@@ -200,6 +201,10 @@ describe('proxy option', () => {
     });
 
     it('respects a proxy option of function', (done) => {
+      req.get('/api/proxy2').expect(200, 'from proxy2', done);
+    });
+
+    it('should allow for behavior configured by req', (done) => {
       req.get('/api/proxy2').expect(200, 'from proxy2', done);
     });
   });

--- a/test/server/proxy-option.test.js
+++ b/test/server/proxy-option.test.js
@@ -205,7 +205,7 @@ describe('proxy option', () => {
     });
 
     it('should allow for behavior configured by req', (done) => {
-      req.get('/api/proxy2').expect(200, 'from proxy2', done);
+      req.get('/api/proxy2?foo=true').expect(200, 'from proxy2', done);
     });
   });
 

--- a/test/server/proxy-option.test.js
+++ b/test/server/proxy-option.test.js
@@ -205,7 +205,7 @@ describe('proxy option', () => {
     });
 
     it('should allow for behavior configured by req', (done) => {
-      req.get('/api/proxy2?foo=true').expect(200, 'from proxy2', done);
+      req.get('/api/proxy2?foo=true').expect(404, done);
     });
   });
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [ ] This is a **bugfix**
- [x] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

yes

### Motivation / Use-Case

This allows configuration of the proxy to be dynamic based off the Express `req`, `res`, and `next` args.

https://github.com/webpack/webpack-dev-server/issues/2360#issue-539948540

### Breaking Changes

None
