### PR TITLE
fix(server): fallthrough non `GET` and `HEAD` request to routes defined in after option

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -390,13 +390,27 @@ class Server {
 
     if (Array.isArray(contentBase)) {
       contentBase.forEach((item) => {
-        this.app.use(contentBasePublicPath, serveIndex(item));
+        this.app.use(contentBasePublicPath, (req, res, next) => {
+          // serve-index doesn't fallthrough non-get/head request to next middleware
+          if (req.method !== 'GET' && req.method !== 'HEAD') {
+            return next();
+          }
+
+          serveIndex(item)(req, res, next);
+        });
       });
     } else if (
       typeof contentBase !== 'number' &&
       !isAbsoluteUrl(String(contentBase))
     ) {
-      this.app.use(contentBasePublicPath, serveIndex(contentBase));
+      this.app.use(contentBasePublicPath, (req, res, next) => {
+        // serve-index doesn't fallthrough non-get/head request to next middleware
+        if (req.method !== 'GET' && req.method !== 'HEAD') {
+          return next();
+        }
+
+        serveIndex(contentBase)(req, res, next);
+      });
     }
   }
 

--- a/test/server/after-option.test.js
+++ b/test/server/after-option.test.js
@@ -29,6 +29,10 @@ describe('after option', () => {
           appArg.get('/after/some/path', (_, response) => {
             response.send('after');
           });
+
+          appArg.post('/after/some/path', (_, response) => {
+            response.send('after POST');
+          });
         },
         port,
       },
@@ -46,6 +50,16 @@ describe('after option', () => {
       .expect(200)
       .then((response) => {
         expect(response.text).toBe('after');
+      });
+  });
+
+  it('should handle POST requests to after route', () => {
+    return req
+      .post('/after/some/path')
+      .expect('Content-Type', 'text/html; charset=utf-8')
+      .expect(200)
+      .then((response) => {
+        expect(response.text).toBe('after POST');
       });
   });
 });

--- a/test/server/contentBasePublicPath-option.test.js
+++ b/test/server/contentBasePublicPath-option.test.js
@@ -277,19 +277,19 @@ describe('contentBasePublicPath option', () => {
     });
 
     it('POST request', (done) => {
-      req.post(`${contentBasePublicPath}/`).expect(405, done);
+      req.post(`${contentBasePublicPath}/`).expect(404, done);
     });
 
     it('PUT request', (done) => {
-      req.put(`${contentBasePublicPath}/`).expect(405, done);
+      req.put(`${contentBasePublicPath}/`).expect(404, done);
     });
 
     it('DELETE request', (done) => {
-      req.delete(`${contentBasePublicPath}/`).expect(405, done);
+      req.delete(`${contentBasePublicPath}/`).expect(404, done);
     });
 
     it('PATCH request', (done) => {
-      req.patch(`${contentBasePublicPath}/`).expect(405, done);
+      req.patch(`${contentBasePublicPath}/`).expect(404, done);
     });
   });
 });


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [x] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

Yes

### Motivation / Use-Case

Before #2150, non-GET request where forwarded to any middleware defined in the after option, since #2150, they are handled by `serve-index` instead that always reply with a 405 error.

This fix issue #2370.

### Breaking Changes

No

### Additional Info

Closes #2370