### PR TITLE
feat(server): forward logger to dev-middleware

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -114,7 +114,7 @@ class Server {
     this.setupHooks();
     this.setupApp();
     this.setupCheckHostRoute();
-    this.setupDevMiddleware();
+    this.setupDevMiddleware(_log);
 
     // set express routes
     routes(this.app, this.middleware, this.options);
@@ -197,11 +197,16 @@ class Server {
     });
   }
 
-  setupDevMiddleware() {
+  setupDevMiddleware(_log) {
     // middleware for serving webpack bundle
+    const logOptions = { logLevel: this.log.options.level };
+    if (_log !== undefined) {
+      logOptions.logger = _log;
+    }
+
     this.middleware = webpackDevMiddleware(
       this.compiler,
-      Object.assign({}, this.options, { logLevel: this.log.options.level })
+      Object.assign({}, this.options, logOptions)
     );
   }
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [ ] This is a **bugfix**
- [x] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

<!-- Please note that we won't approve your changes if you don't add tests. -->

### Motivation / Use-Case

<!--
  What existing problem does the pull request solve?

  Please explain the motivation or use-case for making this change.
  If this Pull Request addresses an issue, please link to the issue.
-->

This is to help reading the output of the webpack-dev-middleware when using a single compiler and multiple servers. Currently, the logs are not very useful, since they just prefix everything with `[wdm]` because the logger isn't forwarded via options, and we can't pass it via `options` since it's not part of the schema.

I attached a screenshot that explains why it's a bit hard to read the logs.

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  potential migration path for existing applications.
-->

I don't believe this can break anything

### Additional Info

Current logs:
![Screen Shot 2020-01-08 at 17 41 26](https://user-images.githubusercontent.com/3650621/71997502-41b58e00-323e-11ea-8d4c-944b2ff69c11.png)

