### PR TITLE
Adds an optional peer dependency on webpack-cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,6 +116,11 @@
   "peerDependencies": {
     "webpack": "^4.0.0 || ^5.0.0"
   },
+  "peerDependenciesMeta": {
+    "webpack-cli": {
+      "optional": true
+    }
+  },
   "author": "Tobias Koppers @sokra",
   "bugs": "https://github.com/webpack/webpack-dev-server/issues",
   "homepage": "https://github.com/webpack/webpack-dev-server#readme",


### PR DESCRIPTION
- [x] This is a **bugfix**
- [x] This is a **metadata update**

### For Bugs and Features; did you add new tests?

Can publish a package with this PR and see if it actually works but these kind of fixes have been done multiple times to make Yarn 2 happy. Considering `webpack-dev-server` throws at runtime anyway if `webpack-cli` is missing this shouldn't bother anyone

### Motivation / Use-Case

Yarn 2 currently throws when using `webpack-dev-server` due to it trying to require `webpack-cli` without declaring it anywhere in its dependencies:

```
Error: A package is trying to access another package without the second one being listed as a dependency of the first one

Required package: webpack-cli (via "webpack-cli/bin/config-yargs")
Required by: webpack-dev-server@virtual:836be30d0802b4899b9a78ca9d744f43f038cccf96d6b8307cbd938d17151f1ac108d2e64290515733c51d0949e0c6d87f9a7c9e245dfe628e5c4ef98f22d752#npm:3.8.0 
```

### Breaking Changes

There is no breaking change for anyone - not even a warning for older package managers. This is a completely safe bugfix that will only impact Yarn users.

### Additional Info

Supercedes: https://github.com/webpack/webpack-dev-server/pull/2191

Documentation: https://next.yarnpkg.com/configuration/manifest#peerDependenciesMeta.optional