### PR TITLE
Refactor https options

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -639,6 +639,7 @@ class Server {
             'HTTP/2 is currently unsupported for Node 10.0.0 and above, but will be supported once Express supports it'
           );
         }
+
         this.listeningApp = https.createServer(this.options.https, this.app);
       } else {
         // The relevant issues are:

--- a/lib/options.json
+++ b/lib/options.json
@@ -16,26 +16,6 @@
     "bonjour": {
       "type": "boolean"
     },
-    "ca": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "instanceof": "Buffer"
-        }
-      ]
-    },
-    "cert": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "instanceof": "Buffer"
-        }
-      ]
-    },
     "clientLogLevel": {
       "enum": ["info", "warn", "error", "debug", "trace", "silent"]
     },
@@ -156,16 +136,6 @@
     "inline": {
       "type": "boolean"
     },
-    "key": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "instanceof": "Buffer"
-        }
-      ]
-    },
     "lazy": {
       "type": "boolean"
     },
@@ -229,19 +199,6 @@
         }
       ]
     },
-    "pfx": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "instanceof": "Buffer"
-        }
-      ]
-    },
-    "pfxPassphrase": {
-      "type": "string"
-    },
     "port": {
       "anyOf": [
         {
@@ -293,9 +250,6 @@
     },
     "reporter": {
       "instanceof": "Function"
-    },
-    "requestCert": {
-      "type": "boolean"
     },
     "serveIndex": {
       "type": "boolean"
@@ -403,8 +357,6 @@
       "allowedHosts": "should be {Array} (https://webpack.js.org/configuration/dev-server/#devserverallowedhosts)",
       "before": "should be {Function} (https://webpack.js.org/configuration/dev-server/#devserverbefore)",
       "bonjour": "should be {Boolean} (https://webpack.js.org/configuration/dev-server/#devserverbonjour)",
-      "ca": "should be {String|Buffer}",
-      "cert": "should be {String|Buffer}",
       "clientLogLevel": "should be {String} and equal to one of the allowed values\n\n [ 'silent', 'info', 'debug', 'trace', 'error', 'warn' ]\n\n (https://webpack.js.org/configuration/dev-server/#devserverclientloglevel)",
       "compress": "should be {Boolean} (https://webpack.js.org/configuration/dev-server/#devservercompress)",
       "contentBase": "should be {Number|String|Array} (https://webpack.js.org/configuration/dev-server/#devservercontentbase)",
@@ -421,7 +373,6 @@
       "injectClient": "should be {Boolean|Function} (https://webpack.js.org/configuration/dev-server/#devserverinjectclient)",
       "injectHot": "should be {Boolean|Function} (https://webpack.js.org/configuration/dev-server/#devserverinjecthot)",
       "inline": "should be {Boolean} (https://webpack.js.org/configuration/dev-server/#devserverinline)",
-      "key": "should be {String|Buffer}",
       "lazy": "should be {Boolean} (https://webpack.js.org/configuration/dev-server/#devserverlazy-)",
       "liveReload": "should be {Boolean} (https://webpack.js.org/configuration/dev-server/#devserverlivereload-)",
       "log": "should be {Function}",
@@ -432,8 +383,6 @@
       "open": "should be {String|Boolean} (https://webpack.js.org/configuration/dev-server/#devserveropen)",
       "openPage": "should be {String|Array} (https://webpack.js.org/configuration/dev-server/#devserveropenpage)",
       "overlay": "should be {Boolean|Object} (https://webpack.js.org/configuration/dev-server/#devserveroverlay)",
-      "pfx": "should be {String|Buffer} (https://webpack.js.org/configuration/dev-server/#devserverpfx)",
-      "pfxPassphrase": "should be {String} (https://webpack.js.org/configuration/dev-server/#devserverpfxpassphrase)",
       "port": "should be {Number|String|Null} (https://webpack.js.org/configuration/dev-server/#devserverport)",
       "profile": "should be {Boolean} (https://webpack.js.org/configuration/dev-server/#devserverprofile)",
       "progress": "should be {Boolean} (https://webpack.js.org/configuration/dev-server/#devserverprogress---cli-only)",
@@ -442,7 +391,6 @@
       "publicPath": "should be {String} (https://webpack.js.org/configuration/dev-server/#devserverpublicpath-)",
       "quiet": "should be {Boolean} (https://webpack.js.org/configuration/dev-server/#devserverquiet-)",
       "reporter": "should be {Function} (https://github.com/webpack/webpack-dev-middleware#reporter)",
-      "requestCert": "should be {Boolean}",
       "contentBasePublicPath": "should be {String} (https://webpack.js.org/configuration/dev-server/#devservercontentbasepublicpath)",
       "serveIndex": "should be {Boolean} (https://webpack.js.org/configuration/dev-server/#devserverserveindex)",
       "serverSideRender": "should be {Boolean} (https://github.com/webpack/webpack-dev-middleware#serversiderender)",

--- a/lib/utils/createConfig.js
+++ b/lib/utils/createConfig.js
@@ -142,31 +142,34 @@ function createConfig(config, argv, { port }) {
   }
 
   if (argv.https) {
-    options.https = true;
+    options.https =
+      argv.cacert || argv.pfx || argv.key || argv.cert || argv.pfxPassphrase
+        ? {}
+        : true;
+
+    if (argv.cacert) {
+      options.https.ca = argv.cacert;
+    }
+
+    if (argv.pfx) {
+      options.https.pfx = argv.pfx;
+    }
+
+    if (argv.key) {
+      options.https.key = argv.key;
+    }
+
+    if (argv.cert) {
+      options.https.cert = argv.cert;
+    }
+
+    if (argv.pfxPassphrase) {
+      options.https.passphrase = argv.pfxPassphrase;
+    }
   }
 
   if (argv.http2) {
     options.http2 = true;
-  }
-
-  if (argv.key) {
-    options.key = argv.key;
-  }
-
-  if (argv.cert) {
-    options.cert = argv.cert;
-  }
-
-  if (argv.cacert) {
-    options.ca = argv.cacert;
-  }
-
-  if (argv.pfx) {
-    options.pfx = argv.pfx;
-  }
-
-  if (argv.pfxPassphrase) {
-    options.pfxPassphrase = argv.pfxPassphrase;
   }
 
   if (argv.inline === false) {

--- a/test/__snapshots__/validate-options.test.js.snap
+++ b/test/__snapshots__/validate-options.test.js.snap
@@ -26,24 +26,6 @@ exports[`options should throw an error on the "bonjour" option with "" value 1`]
  - options.bonjour should be a boolean."
 `;
 
-exports[`options should throw an error on the "ca" option with "false" value 1`] = `
-"Invalid options object. Dev Server has been initialized using an options object that does not match the API schema.
- - options.ca should be one of these:
-   string | Buffer
-   Details:
-    * options.ca should be a string.
-    * options.ca should be an instance of Buffer."
-`;
-
-exports[`options should throw an error on the "cert" option with "false" value 1`] = `
-"Invalid options object. Dev Server has been initialized using an options object that does not match the API schema.
- - options.cert should be one of these:
-   string | Buffer
-   Details:
-    * options.cert should be a string.
-    * options.cert should be an instance of Buffer."
-`;
-
 exports[`options should throw an error on the "clientLogLevel" option with "none" value 1`] = `
 "Invalid options object. Dev Server has been initialized using an options object that does not match the API schema.
  - options.clientLogLevel should be one of these:
@@ -175,15 +157,6 @@ exports[`options should throw an error on the "inline" option with "" value 1`] 
  - options.inline should be a boolean."
 `;
 
-exports[`options should throw an error on the "key" option with "false" value 1`] = `
-"Invalid options object. Dev Server has been initialized using an options object that does not match the API schema.
- - options.key should be one of these:
-   string | Buffer
-   Details:
-    * options.key should be a string.
-    * options.key should be an instance of Buffer."
-`;
-
 exports[`options should throw an error on the "lazy" option with "" value 1`] = `
 "Invalid options object. Dev Server has been initialized using an options object that does not match the API schema.
  - options.lazy should be a boolean."
@@ -255,20 +228,6 @@ exports[`options should throw an error on the "overlay" option with "{"warnings"
  - options.overlay.warnings should be a boolean."
 `;
 
-exports[`options should throw an error on the "pfx" option with "false" value 1`] = `
-"Invalid options object. Dev Server has been initialized using an options object that does not match the API schema.
- - options.pfx should be one of these:
-   string | Buffer
-   Details:
-    * options.pfx should be a string.
-    * options.pfx should be an instance of Buffer."
-`;
-
-exports[`options should throw an error on the "pfxPassphrase" option with "false" value 1`] = `
-"Invalid options object. Dev Server has been initialized using an options object that does not match the API schema.
- - options.pfxPassphrase should be a string."
-`;
-
 exports[`options should throw an error on the "port" option with "false" value 1`] = `
 "Invalid options object. Dev Server has been initialized using an options object that does not match the API schema.
  - options.port should be one of these:
@@ -334,11 +293,6 @@ exports[`options should throw an error on the "quiet" option with "" value 1`] =
 exports[`options should throw an error on the "reporter" option with "" value 1`] = `
 "Invalid options object. Dev Server has been initialized using an options object that does not match the API schema.
  - options.reporter should be an instance of function."
-`;
-
-exports[`options should throw an error on the "requestCert" option with "" value 1`] = `
-"Invalid options object. Dev Server has been initialized using an options object that does not match the API schema.
- - options.requestCert should be a boolean."
 `;
 
 exports[`options should throw an error on the "serveIndex" option with "" value 1`] = `

--- a/test/fixtures/schema/webpack.config.no-dev-stats.js
+++ b/test/fixtures/schema/webpack.config.no-dev-stats.js
@@ -19,7 +19,6 @@ module.exports = {
     lazy: '_lazy',
     quiet: '_quiet',
     https: '_https',
-    pfxPassphrase: '_pfxPassphrase',
     inline: '_inline',
     historyApiFallback: '_historyApiFallback',
     compress: '_compress',

--- a/test/server/utils/__snapshots__/createConfig.test.js.snap
+++ b/test/server/utils/__snapshots__/createConfig.test.js.snap
@@ -74,9 +74,10 @@ Object {
 
 exports[`createConfig cacert option 1`] = `
 Object {
-  "ca": "/path/to/ca.pem",
   "hot": true,
-  "https": true,
+  "https": Object {
+    "ca": "/path/to/ca.pem",
+  },
   "port": 8080,
   "publicPath": "/",
   "stats": Object {
@@ -102,9 +103,10 @@ Object {
 
 exports[`createConfig cert option 1`] = `
 Object {
-  "cert": "/path/to/server.crt",
   "hot": true,
-  "https": true,
+  "https": Object {
+    "cert": "/path/to/server.crt",
+  },
   "port": 8080,
   "publicPath": "/",
   "stats": Object {
@@ -558,8 +560,9 @@ Object {
 exports[`createConfig key option 1`] = `
 Object {
   "hot": true,
-  "https": true,
-  "key": "/path/to/server.key",
+  "https": Object {
+    "key": "/path/to/server.key",
+  },
   "port": 8080,
   "publicPath": "/",
   "stats": Object {
@@ -790,8 +793,9 @@ Object {
 exports[`createConfig pfx option 1`] = `
 Object {
   "hot": true,
-  "https": true,
-  "pfx": "/path/to/file.pfx",
+  "https": Object {
+    "pfx": "/path/to/file.pfx",
+  },
   "port": 8080,
   "publicPath": "/",
   "stats": Object {
@@ -804,7 +808,6 @@ Object {
 exports[`createConfig pfxPassphrase option 1`] = `
 Object {
   "hot": true,
-  "pfxPassphrase": "passphrase",
   "port": 8080,
   "publicPath": "/",
   "stats": Object {
@@ -1150,7 +1153,6 @@ Object {
   "lazy": "_lazy",
   "open": "_open",
   "openPage": "_openPage",
-  "pfxPassphrase": "_pfxPassphrase",
   "port": "_port",
   "progress": "_progress",
   "public": "_public",
@@ -1181,7 +1183,6 @@ Object {
     "lazy": "_lazy",
     "open": "_open",
     "openPage": "_openPage",
-    "pfxPassphrase": "_pfxPassphrase",
     "port": "_port",
     "progress": "_progress",
     "public": "_public",

--- a/test/validate-options.test.js
+++ b/test/validate-options.test.js
@@ -43,14 +43,6 @@ describe('options', () => {
       success: [false],
       failure: [''],
     },
-    ca: {
-      success: ['', Buffer.from('')],
-      failure: [false],
-    },
-    cert: {
-      success: ['', Buffer.from('')],
-      failure: [false],
-    },
     clientLogLevel: {
       success: ['silent', 'info', 'error', 'warn', 'trace', 'debug'],
       failure: ['whoops!', 'none', 'warning'],
@@ -115,10 +107,6 @@ describe('options', () => {
       success: [true],
       failure: [''],
     },
-    key: {
-      success: ['', Buffer.from('')],
-      failure: [false],
-    },
     lazy: {
       success: [true],
       failure: [''],
@@ -167,14 +155,6 @@ describe('options', () => {
         { warnings: 'test' },
       ],
     },
-    pfx: {
-      success: ['', Buffer.from('')],
-      failure: [false],
-    },
-    pfxPassphrase: {
-      success: [''],
-      failure: [false],
-    },
     port: {
       success: ['', 0, null],
       failure: [false],
@@ -211,10 +191,6 @@ describe('options', () => {
     },
     reporter: {
       success: [() => {}],
-      failure: [''],
-    },
-    requestCert: {
-      success: [true],
       failure: [''],
     },
     serveIndex: {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [ ] This is a **bugfix**
- [ ] This is a **feature**
- [x] This is a **code refactor**
- [x] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

Existing tests

### Motivation / Use-Case

We already support `https: { ca: 'value', key: 'value' ...otherHttpsValues }` so the ability to configure in two options can be misleading, so let's remove it

### Breaking Changes

Yes

### Additional Info

No