### PR TITLE
refactor: the `contentBase` option now accepts only paths

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -23,7 +23,6 @@ const serveIndex = require('serve-index');
 const webpack = require('webpack');
 const webpackDevMiddleware = require('webpack-dev-middleware');
 const validateOptions = require('schema-utils');
-const isAbsoluteUrl = require('is-absolute-url');
 const normalizeOptions = require('./utils/normalizeOptions');
 const updateCompiler = require('./utils/updateCompiler');
 const createLogger = require('./utils/createLogger');
@@ -328,50 +327,13 @@ class Server {
   }
 
   setupStaticFeature() {
-    const contentBase = this.options.contentBase;
-    const contentBasePublicPath = this.options.contentBasePublicPath;
+    const { contentBase, contentBasePublicPath } = this.options;
 
     if (Array.isArray(contentBase)) {
       contentBase.forEach((item) => {
         this.app.use(contentBasePublicPath, express.static(item));
       });
-    } else if (isAbsoluteUrl(String(contentBase))) {
-      this.log.warn(
-        'Using a URL as contentBase is deprecated and will be removed in the next major version. Please use the proxy option instead.'
-      );
-
-      this.log.warn(
-        'proxy: {\n\t"*": "<your current contentBase configuration>"\n}'
-      );
-
-      // Redirect every request to contentBase
-      this.app.get('*', (req, res) => {
-        res.writeHead(302, {
-          Location: contentBase + req.path + (req._parsedUrl.search || ''),
-        });
-
-        res.end();
-      });
-    } else if (typeof contentBase === 'number') {
-      this.log.warn(
-        'Using a number as contentBase is deprecated and will be removed in the next major version. Please use the proxy option instead.'
-      );
-
-      this.log.warn(
-        'proxy: {\n\t"*": "//localhost:<your current contentBase configuration>"\n}'
-      );
-
-      // Redirect every request to the port contentBase
-      this.app.get('*', (req, res) => {
-        res.writeHead(302, {
-          Location: `//localhost:${contentBase}${req.path}${req._parsedUrl
-            .search || ''}`,
-        });
-
-        res.end();
-      });
     } else {
-      // route content request
       this.app.use(
         contentBasePublicPath,
         express.static(contentBase, this.options.staticOptions)
@@ -380,8 +342,7 @@ class Server {
   }
 
   setupServeIndexFeature() {
-    const contentBase = this.options.contentBase;
-    const contentBasePublicPath = this.options.contentBasePublicPath;
+    const { contentBase, contentBasePublicPath } = this.options;
 
     if (Array.isArray(contentBase)) {
       contentBase.forEach((item) => {
@@ -394,10 +355,7 @@ class Server {
           serveIndex(item)(req, res, next);
         });
       });
-    } else if (
-      typeof contentBase !== 'number' &&
-      !isAbsoluteUrl(String(contentBase))
-    ) {
+    } else {
       this.app.use(contentBasePublicPath, (req, res, next) => {
         // serve-index doesn't fallthrough non-get/head request to next middleware
         if (req.method !== 'GET' && req.method !== 'HEAD') {
@@ -410,15 +368,10 @@ class Server {
   }
 
   setupWatchStaticFeature() {
-    const contentBase = this.options.contentBase;
+    const { contentBase } = this.options;
 
-    if (isAbsoluteUrl(String(contentBase)) || typeof contentBase === 'number') {
-      throw new Error('Watching remote files is not supported.');
-    } else if (Array.isArray(contentBase)) {
+    if (Array.isArray(contentBase)) {
       contentBase.forEach((item) => {
-        if (isAbsoluteUrl(String(item)) || typeof item === 'number') {
-          throw new Error('Watching remote files is not supported.');
-        }
         this._watch(item);
       });
     } else {
@@ -1012,12 +965,14 @@ class Server {
     };
 
     const watcher = chokidar.watch(watchPath, watchOptions);
-    // disabling refreshing on changing the content
+
+    // Disabling refreshing on changing the content
     if (this.options.liveReload !== false) {
       watcher.on('change', () => {
         this.sockWrite(this.sockets, 'content-changed');
       });
     }
+
     this.contentBaseWatchers.push(watcher);
   }
 

--- a/lib/options.json
+++ b/lib/options.json
@@ -51,9 +51,6 @@
           "enum": [false]
         },
         {
-          "type": "number"
-        },
-        {
           "type": "string"
         },
         {
@@ -407,7 +404,7 @@
       "cert": "should be {String|Buffer}",
       "clientLogLevel": "should be {String} and equal to one of the allowed values\n\n [ 'silent', 'info', 'debug', 'trace', 'error', 'warn' ]\n\n (https://webpack.js.org/configuration/dev-server/#devserverclientloglevel)",
       "compress": "should be {Boolean} (https://webpack.js.org/configuration/dev-server/#devservercompress)",
-      "contentBase": "should be {Number|String|Array} (https://webpack.js.org/configuration/dev-server/#devservercontentbase)",
+      "contentBase": "should be {String|Array} (https://webpack.js.org/configuration/dev-server/#devservercontentbase)",
       "disableHostCheck": "should be {Boolean} (https://webpack.js.org/configuration/dev-server/#devserverdisablehostcheck)",
       "filename": "should be {String|RegExp|Function} (https://webpack.js.org/configuration/dev-server/#devserverfilename-)",
       "fs": "should be {Object} (https://github.com/webpack/webpack-dev-middleware#fs)",

--- a/lib/utils/createConfig.js
+++ b/lib/utils/createConfig.js
@@ -101,9 +101,7 @@ function createConfig(config, argv, { port }) {
 
     if (Array.isArray(options.contentBase)) {
       options.contentBase = options.contentBase.map((p) => path.resolve(p));
-    } else if (/^[0-9]$/.test(options.contentBase)) {
-      options.contentBase = +options.contentBase;
-    } else if (!isAbsoluteUrl(String(options.contentBase))) {
+    } else {
       options.contentBase = path.resolve(options.contentBase);
     }
   }

--- a/test/server/contentBase-option.test.js
+++ b/test/server/contentBase-option.test.js
@@ -196,99 +196,13 @@ describe('contentBase option', () => {
     });
   });
 
-  describe('to port', () => {
-    beforeAll((done) => {
-      server = testServer.start(
-        config,
-        {
-          contentBase: 9099999,
-          port,
-        },
-        done
-      );
-      req = request(server.app);
-    });
-
-    afterAll((done) => {
-      testServer.close(done);
-    });
-
-    it('Request to page', async () => {
-      await req
-        .get('/other.html')
-        .expect('Location', '//localhost:9099999/other.html')
-        .expect(302);
-    });
-  });
-
-  describe('to external url', () => {
-    beforeAll((done) => {
-      server = testServer.start(
-        config,
-        {
-          contentBase: 'http://example.com/',
-          port,
-        },
-        done
-      );
-      req = request(server.app);
-    });
-
-    afterAll((done) => {
-      testServer.close(done);
-    });
-
-    it('Request to page', async () => {
-      await req
-        .get('/foo.html')
-        // TODO: hmm, two slashes seems to be a bug?
-        .expect('Location', 'http://example.com//foo.html')
-        .expect(302);
-    });
-
-    it('Request to page with search params', async () => {
-      await req
-        .get('/foo.html?space=ship')
-        // TODO: hmm, two slashes seems to be a bug?
-        .expect('Location', 'http://example.com//foo.html?space=ship')
-        .expect(302);
-    });
-  });
-
   describe('testing single & multiple external paths', () => {
     afterEach((done) => {
       testServer.close(() => {
         done();
       });
     });
-    it('Should throw exception (string)', (done) => {
-      try {
-        // eslint-disable-next-line no-unused-vars
-        server = testServer.start(config, {
-          contentBase: 'https://example.com/',
-          watchContentBase: true,
-        });
 
-        expect(true).toBe(false);
-      } catch (e) {
-        expect(e.message).toBe('Watching remote files is not supported.');
-        done();
-      }
-    });
-    it('Should throw exception (number)', (done) => {
-      try {
-        // eslint-disable-next-line no-unused-vars
-        server = testServer.start(config, {
-          contentBase: 2,
-          watchContentBase: true,
-        });
-
-        expect(true).toBe(false);
-      } catch (e) {
-        expect(e.message).toBe('Watching remote files is not supported.');
-        done();
-      }
-    });
     it('Should not throw exception (local path with lower case first character)', (done) => {
       testServer.start(
         config,
@@ -302,6 +216,7 @@ describe('contentBase option', () => {
         done
       );
     });
+
     it("Should not throw exception (local path with lower case first character & has '-')", (done) => {
       testServer.start(
         config,
@@ -313,6 +228,7 @@ describe('contentBase option', () => {
         done
       );
     });
+
     it("Should not throw exception (local path with upper case first character & has '-')", (done) => {
       testServer.start(
         config,
@@ -323,21 +239,6 @@ describe('contentBase option', () => {
         },
         done
       );
-    });
-
-    it('Should throw exception (array)', (done) => {
-      try {
-        // eslint-disable-next-line no-unused-vars
-        server = testServer.start(config, {
-          contentBase: [contentBasePublic, 'https://example.com/'],
-          watchContentBase: true,
-        });
-
-        expect(true).toBe(false);
-      } catch (e) {
-        expect(e.message).toBe('Watching remote files is not supported.');
-        done();
-      }
     });
   });
 

--- a/test/validate-options.test.js
+++ b/test/validate-options.test.js
@@ -60,7 +60,7 @@ describe('options', () => {
       failure: [''],
     },
     contentBase: {
-      success: [0, '.', false],
+      success: ['./directory', false, ['./directory', './other-directory']],
       failure: [[1], [false]],
     },
     disableHostCheck: {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [ ] This is a **bugfix**
- [ ] This is a **feature**
- [x] This is a **code refactor**
- [x] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

Change existing

### Motivation / Use-Case

Drop support number and absolute urls for `contentBase`

### Breaking Changes

Yes

### Additional Info

We need improve schema-utils, to catch problems with invalid paths before run, I put it in todo and will send a PR in future