### PR TITLE
Fix MaxListenersExceededWarning when having more than 10 proxies

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -131,9 +131,11 @@ class Server {
 
     // Proxy websockets without the initial http request
     // https://github.com/chimurai/http-proxy-middleware#external-websocket-upgrade
-    this.websocketProxies.forEach(function(wsProxy) {
-      this.listeningApp.on('upgrade', wsProxy.upgrade);
-    }, this);
+    this.listeningApp.on('upgrade', (event) => {
+      this.websocketProxies.forEach((wsProxy) => {
+        wsProxy.upgrade(event);
+      });
+    });
   }
 
   setupProgressPlugin() {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [x] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

<!-- Please note that we won't approve your changes if you don't add tests. -->

I am not sure how to test this change. Would be glad if someone has an idea.

### Motivation / Use-Case

<!--
  What existing problem does the pull request solve?

  Please explain the motivation or use-case for making this change.
  If this Pull Request addresses an issue, please link to the issue.
-->

Node.js issues a warning of having more than 10 event listeners on start when there are more than 10 proxies in the configuration:

```
(node:3044) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 upgrade listeners added. Use emitter.setMaxListeners() to increase limit
```

This happens, because an event handler is created for each proxy.
With this change, only one event listener is created and it triggers all proxy handlers when an event occurs.

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  potential migration path for existing applications.
-->

### Additional Info
