### PR TITLE
fix(server): don't crash on setupExitSignals(undefined)

### DIFF
--- a/lib/utils/setupExitSignals.js
+++ b/lib/utils/setupExitSignals.js
@@ -5,7 +5,7 @@ const signals = ['SIGINT', 'SIGTERM'];
 function setupExitSignals(serverData) {
   signals.forEach((signal) => {
     process.on(signal, () => {
-      if (serverData.server) {
+      if (serverData && serverData.server) {
         serverData.server.close(() => {
           // eslint-disable-next-line no-process-exit
           process.exit();

--- a/test/server/utils/setupExitSignals.test.js
+++ b/test/server/utils/setupExitSignals.test.js
@@ -25,6 +25,16 @@ describe('setupExitSignals', () => {
   });
 
   signals.forEach((signal) => {
+    it(`should exit process (${signal}, serverData never defined`, (done) => {
+      // eslint-disable-next-line no-undefined
+      setupExitSignals(undefined);
+      process.emit(signal);
+      setTimeout(() => {
+        expect(exitSpy.mock.calls.length).toEqual(1);
+        done();
+      }, 1000);
+    });
+
     it(`should exit process (${signal}, server never defined)`, (done) => {
       setupExitSignals({
         server: null,


### PR DESCRIPTION
- [x] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

Yes.

### Motivation / Use-Case

Someone observed this line crash:
https://github.com/webpack/webpack-dev-server/issues/1479#issuecomment-549824098

This is the fix suggested by @evilebottnawi — please review.

### Breaking Changes

none.

### Additional Info

I don't see how that crash was possible, all callers (1 real + few tests) pass an object (and weren't touched since #2181 introduced `serverData`.  But I also can't argue with a stacktrace :-)

Feel free to reject.
