### PR TITLE
Update internal-ip version

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "html-entities": "^1.2.1",
     "http-proxy-middleware": "0.19.1",
     "import-local": "^2.0.0",
-    "internal-ip": "^4.3.0",
+    "internal-ip": "^6.0.0",
     "ip": "^1.1.5",
     "is-absolute-url": "^3.0.3",
     "killable": "^1.0.1",


### PR DESCRIPTION
To solve https://github.com/sindresorhus/execa/pull/182 

which is now a security vulnerability so internal-ip version should be latest, 

`internal-ip > default-gateway > execa`