### PR TITLE
fix(run-open): introduce open instead of opn

### DIFF
--- a/lib/utils/runOpen.js
+++ b/lib/utils/runOpen.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const open = require('opn');
+const open = require('open');
 const isAbsoluteUrl = require('is-absolute-url');
 
 function runOpen(uri, options, log) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9589,6 +9589,11 @@
       "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
       "dev": true
     },
+    "is-docker": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.0.0.tgz",
+      "integrity": "sha512-pJEdRugimx4fBMra5z2/5iRdZ63OhYV0vr0Dwm5+xtW4D1FvRkB8hamMIhnWfyJeDdyr/aa7BDyNbtG38VxgoQ=="
+    },
     "is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
@@ -9771,7 +9776,8 @@
     "is-wsl": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
-      "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
+      "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
+      "dev": true
     },
     "is2": {
       "version": "2.0.1",
@@ -12817,19 +12823,27 @@
         "mimic-fn": "^2.1.0"
       }
     },
+    "open": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.0.3.tgz",
+      "integrity": "sha512-sP2ru2v0P290WFfv49Ap8MF6PkzGNnGlAwHweB4WR4mr5d2d0woiCluUeJ218w7/+PmoBy9JmYgD5A4mLcWOFA==",
+      "requires": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "dependencies": {
+        "is-wsl": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.1.1.tgz",
+          "integrity": "sha512-umZHcSrwlDHo2TGMXv0DZ8dIUGunZ2Iv68YZnrmCiBPkZ4aaOhtv7pXJKeki9k3qJ3RJr0cDyitcl5wEH3AYog=="
+        }
+      }
+    },
     "opencollective-postinstall": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz",
       "integrity": "sha512-pVOEP16TrAO2/fjej1IdOyupJY8KDUM1CvsaScRbw6oddvpQoOfGk4ywha0HKKVAD6RkW4x6Q+tNBwhf3Bgpuw==",
       "dev": true
-    },
-    "opn": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/opn/-/opn-5.5.0.tgz",
-      "integrity": "sha512-PqHpggC9bLV0VeWcdKhkpxY+3JTzetLSqTCWL/z/tFIbI6G8JCjondXklT1JinczLz2Xib62sSp0T/gKT4KksA==",
-      "requires": {
-        "is-wsl": "^1.1.0"
-      }
     },
     "optimist": {
       "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "is-absolute-url": "^3.0.3",
     "killable": "^1.0.1",
     "loglevel": "^1.6.8",
-    "opn": "^5.5.0",
+    "open": "^7.0.3",
     "p-retry": "^3.0.1",
     "portfinder": "^1.0.25",
     "schema-utils": "^1.0.0",

--- a/test/server/open-option.test.js
+++ b/test/server/open-option.test.js
@@ -1,9 +1,9 @@
 'use strict';
 
-jest.mock('opn');
+jest.mock('open');
 
 const webpack = require('webpack');
-const open = require('opn');
+const open = require('open');
 const Server = require('../../lib/Server');
 const config = require('../fixtures/simple-config/webpack.config');
 const port = require('../ports-map')['open-option'];

--- a/test/server/utils/runOpen.test.js
+++ b/test/server/utils/runOpen.test.js
@@ -1,25 +1,25 @@
 'use strict';
 
-const opn = require('opn');
+const open = require('open');
 const runOpen = require('../../../lib/utils/runOpen');
 
-jest.mock('opn');
+jest.mock('open');
 
 describe('runOpen util', () => {
   afterEach(() => {
-    opn.mockClear();
+    open.mockClear();
   });
 
   describe('should open browser', () => {
     beforeEach(() => {
-      opn.mockImplementation(() => Promise.resolve());
+      open.mockImplementation(() => Promise.resolve());
     });
 
     it('on specify URL', () => {
       return runOpen('https://example.com', {}, console).then(() => {
-        expect(opn).toBeCalledWith('https://example.com', { wait: false });
+        expect(open).toBeCalledWith('https://example.com', { wait: false });
 
-        expect(opn.mock.calls[0]).toMatchInlineSnapshot(`
+        expect(open.mock.calls[0]).toMatchInlineSnapshot(`
           Array [
             "https://example.com",
             Object {
@@ -36,11 +36,11 @@ describe('runOpen util', () => {
         { openPage: '/index.html' },
         console
       ).then(() => {
-        expect(opn).toBeCalledWith('https://example.com/index.html', {
+        expect(open).toBeCalledWith('https://example.com/index.html', {
           wait: false,
         });
 
-        expect(opn.mock.calls[0]).toMatchInlineSnapshot(`
+        expect(open.mock.calls[0]).toMatchInlineSnapshot(`
           Array [
             "https://example.com/index.html",
             Object {
@@ -57,11 +57,11 @@ describe('runOpen util', () => {
         { openPage: ['/index.html'] },
         console
       ).then(() => {
-        expect(opn).toBeCalledWith('https://example.com/index.html', {
+        expect(open).toBeCalledWith('https://example.com/index.html', {
           wait: false,
         });
 
-        expect(opn.mock.calls[0]).toMatchSnapshot();
+        expect(open.mock.calls[0]).toMatchSnapshot();
       });
     });
 
@@ -71,15 +71,15 @@ describe('runOpen util', () => {
         { openPage: ['/index.html', '/index2.html'] },
         console
       ).then(() => {
-        expect(opn).toBeCalledWith('https://example.com/index.html', {
+        expect(open).toBeCalledWith('https://example.com/index.html', {
           wait: false,
         });
-        expect(opn).toBeCalledWith('https://example.com/index2.html', {
+        expect(open).toBeCalledWith('https://example.com/index2.html', {
           wait: false,
         });
 
-        expect(opn.mock.calls[0]).toMatchSnapshot();
-        expect(opn.mock.calls[1]).toMatchSnapshot();
+        expect(open.mock.calls[0]).toMatchSnapshot();
+        expect(open.mock.calls[1]).toMatchSnapshot();
       });
     });
 
@@ -89,12 +89,12 @@ describe('runOpen util', () => {
         { open: 'Google Chrome' },
         console
       ).then(() => {
-        expect(opn).toBeCalledWith('https://example.com', {
+        expect(open).toBeCalledWith('https://example.com', {
           app: 'Google Chrome',
           wait: false,
         });
 
-        expect(opn.mock.calls[0]).toMatchInlineSnapshot(`
+        expect(open.mock.calls[0]).toMatchInlineSnapshot(`
           Array [
             "https://example.com",
             Object {
@@ -112,12 +112,12 @@ describe('runOpen util', () => {
         { open: 'Google Chrome', openPage: '/index.html' },
         console
       ).then(() => {
-        expect(opn).toBeCalledWith('https://example.com/index.html', {
+        expect(open).toBeCalledWith('https://example.com/index.html', {
           app: 'Google Chrome',
           wait: false,
         });
 
-        expect(opn.mock.calls[0]).toMatchInlineSnapshot(`
+        expect(open.mock.calls[0]).toMatchInlineSnapshot(`
           Array [
             "https://example.com/index.html",
             Object {
@@ -135,12 +135,12 @@ describe('runOpen util', () => {
         { open: 'Google Chrome', openPage: 'https://example2.com' },
         console
       ).then(() => {
-        expect(opn).toBeCalledWith('https://example2.com', {
+        expect(open).toBeCalledWith('https://example2.com', {
           app: 'Google Chrome',
           wait: false,
         });
 
-        expect(opn.mock.calls[0]).toMatchInlineSnapshot(`
+        expect(open.mock.calls[0]).toMatchInlineSnapshot(`
           Array [
             "https://example2.com",
             Object {
@@ -158,11 +158,11 @@ describe('runOpen util', () => {
         { open: 'Google Chrome', openPage: 'http://example2.com' },
         console
       ).then(() => {
-        expect(opn).toBeCalledWith('http://example2.com', {
+        expect(open).toBeCalledWith('http://example2.com', {
           app: 'Google Chrome',
           wait: false,
         });
-        expect(opn.mock.calls[0]).toMatchInlineSnapshot(`
+        expect(open.mock.calls[0]).toMatchInlineSnapshot(`
           Array [
             "http://example2.com",
             Object {
@@ -184,16 +184,16 @@ describe('runOpen util', () => {
       },
       console
     ).then(() => {
-      expect(opn).toBeCalledWith('https://example2.com', {
+      expect(open).toBeCalledWith('https://example2.com', {
         app: 'Google Chrome',
         wait: false,
       });
-      expect(opn).toBeCalledWith('https://example3.com', {
+      expect(open).toBeCalledWith('https://example3.com', {
         app: 'Google Chrome',
         wait: false,
       });
-      expect(opn.mock.calls[0]).toMatchSnapshot();
-      expect(opn.mock.calls[1]).toMatchSnapshot();
+      expect(open.mock.calls[0]).toMatchSnapshot();
+      expect(open.mock.calls[1]).toMatchSnapshot();
     });
   });
 
@@ -206,17 +206,17 @@ describe('runOpen util', () => {
       },
       console
     ).then(() => {
-      expect(opn).toBeCalledWith('https://example.com/index.html', {
+      expect(open).toBeCalledWith('https://example.com/index.html', {
         app: 'Google Chrome',
         wait: false,
       });
-      expect(opn).toBeCalledWith('https://example2.com', {
+      expect(open).toBeCalledWith('https://example2.com', {
         app: 'Google Chrome',
         wait: false,
       });
 
-      expect(opn.mock.calls[0]).toMatchSnapshot();
-      expect(opn.mock.calls[1]).toMatchSnapshot();
+      expect(open.mock.calls[0]).toMatchSnapshot();
+      expect(open.mock.calls[1]).toMatchSnapshot();
     });
   });
 
@@ -224,7 +224,7 @@ describe('runOpen util', () => {
     const logMock = { warn: jest.fn() };
 
     beforeEach(() => {
-      opn.mockImplementation(() => Promise.reject());
+      open.mockImplementation(() => Promise.reject());
     });
 
     afterEach(() => {
@@ -236,9 +236,9 @@ describe('runOpen util', () => {
         expect(logMock.warn.mock.calls[0][0]).toMatchInlineSnapshot(
           `"Unable to open \\"https://example.com\\" in browser. If you are running in a headless environment, please do not use the --open flag"`
         );
-        expect(opn).toBeCalledWith('https://example.com', { wait: false });
+        expect(open).toBeCalledWith('https://example.com', { wait: false });
 
-        expect(opn.mock.calls[0]).toMatchInlineSnapshot(`
+        expect(open.mock.calls[0]).toMatchInlineSnapshot(`
           Array [
             "https://example.com",
             Object {
@@ -258,11 +258,11 @@ describe('runOpen util', () => {
         expect(logMock.warn.mock.calls[0][0]).toMatchInlineSnapshot(
           `"Unable to open \\"https://example.com/index.html\\" in browser. If you are running in a headless environment, please do not use the --open flag"`
         );
-        expect(opn).toBeCalledWith('https://example.com/index.html', {
+        expect(open).toBeCalledWith('https://example.com/index.html', {
           wait: false,
         });
 
-        expect(opn.mock.calls[0]).toMatchInlineSnapshot(`
+        expect(open.mock.calls[0]).toMatchInlineSnapshot(`
           Array [
             "https://example.com/index.html",
             Object {
@@ -282,12 +282,12 @@ describe('runOpen util', () => {
         expect(logMock.warn.mock.calls[0][0]).toMatchInlineSnapshot(
           `"Unable to open \\"https://example.com\\" in browser: \\"Google Chrome\\". If you are running in a headless environment, please do not use the --open flag"`
         );
-        expect(opn).toBeCalledWith('https://example.com', {
+        expect(open).toBeCalledWith('https://example.com', {
           app: 'Google Chrome',
           wait: false,
         });
 
-        expect(opn.mock.calls[0]).toMatchInlineSnapshot(`
+        expect(open.mock.calls[0]).toMatchInlineSnapshot(`
           Array [
             "https://example.com",
             Object {
@@ -308,12 +308,12 @@ describe('runOpen util', () => {
         expect(logMock.warn.mock.calls[0][0]).toMatchInlineSnapshot(
           `"Unable to open \\"https://example.com/index.html\\" in browser: \\"Google Chrome\\". If you are running in a headless environment, please do not use the --open flag"`
         );
-        expect(opn).toBeCalledWith('https://example.com/index.html', {
+        expect(open).toBeCalledWith('https://example.com/index.html', {
           app: 'Google Chrome',
           wait: false,
         });
 
-        expect(opn.mock.calls[0]).toMatchInlineSnapshot(`
+        expect(open.mock.calls[0]).toMatchInlineSnapshot(`
           Array [
             "https://example.com/index.html",
             Object {
@@ -334,11 +334,11 @@ describe('runOpen util', () => {
         },
         logMock
       ).then(() => {
-        expect(opn).toBeCalledWith('https://example.com/index.html', {
+        expect(open).toBeCalledWith('https://example.com/index.html', {
           app: ['Google Chrome', '--incognito'],
         });
 
-        expect(opn.mock.calls[0]).toMatchInlineSnapshot(`
+        expect(open.mock.calls[0]).toMatchInlineSnapshot(`
           Array [
             "https://example.com/index.html",
             Object {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [ ] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

modified

<!-- Please note that we won't approve your changes if you don't add tests. -->

### Motivation / Use-Case

opn is deprecated.

<!--
  What existing problem does the pull request solve?

  Please explain the motivation or use-case for making this change.
  If this Pull Request addresses an issue, please link to the issue.
-->

### Breaking Changes

yes because open doesn't support Node6.

<!--
  If this PR introduces a breaking change, please describe the impact and a
  potential migration path for existing applications.
-->

### Additional Info
