### PR TITLE
fix: add prefix for invalidate endpoint

### DIFF
--- a/lib/utils/routes.js
+++ b/lib/utils/routes.js
@@ -22,7 +22,7 @@ function routes(server) {
     createReadStream(join(clientBasePath, 'default/index.bundle.js')).pipe(res);
   });
 
-  app.get('/invalidate', (_req, res) => {
+  app.get('/webpack-dev-server/invalidate', (_req, res) => {
     server.invalidate();
     res.end();
   });

--- a/test/server/utils/routes.test.js
+++ b/test/server/utils/routes.test.js
@@ -48,8 +48,12 @@ describe('routes util', () => {
     });
   });
 
-  it('GET request to invalidate endpoint', (done) => {
-    req.get('/invalidate').expect(200, done);
+  it('should handles GET request to invalidate endpoint', (done) => {
+    req.get('/webpack-dev-server/invalidate').then(({ res }) => {
+      expect(res.headers['content-type']).not.toEqual('text/html');
+      expect(res.statusCode).toEqual(200);
+      done();
+    });
   });
 
   it('should handles GET request to live html', (done) => {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [x] This is a **bugfix**
- [x] This is a **feature**
- [ ] This is a **code refactor**
- [x] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?
Yes
<!-- Please note that we won't approve your changes if you don't add tests. -->

### Motivation / Use-Case
as @sokra suggested : https://github.com/webpack/webpack-dev-server/pull/2493#pullrequestreview-405542308
<!--
  What existing problem does the pull request solve?

  Please explain the motivation or use-case for making this change.
  If this Pull Request addresses an issue, please link to the issue.
-->

### Breaking Changes
a change in the endpoint from `/invalidate` to `/webpack-dev-server/invalidate`.

<!--
  If this PR introduces a breaking change, please describe the impact and a
  potential migration path for existing applications.
-->

### Additional Info
