### PR TITLE
fix: invalidate route

### DIFF
--- a/lib/utils/routes.js
+++ b/lib/utils/routes.js
@@ -28,15 +28,15 @@ function routes(server) {
     createReadStream(join(clientBasePath, 'index.bundle.js')).pipe(res);
   });
 
+  app.get('/webpack-dev-server/invalidate', (_req, res) => {
+    server.invalidate();
+    res.end();
+  });
+
   app.get('/webpack-dev-server/*', (req, res) => {
     res.setHeader('Content-Type', 'text/html');
 
     createReadStream(join(clientBasePath, 'live.html')).pipe(res);
-  });
-
-  app.get('/webpack-dev-server/invalidate', (_req, res) => {
-    server.invalidate();
-    res.end();
   });
 
   app.get('/webpack-dev-server', (req, res) => {

--- a/lib/utils/routes.js
+++ b/lib/utils/routes.js
@@ -34,7 +34,7 @@ function routes(server) {
     createReadStream(join(clientBasePath, 'live.html')).pipe(res);
   });
 
-  app.get('/invalidate', (_req, res) => {
+  app.get('/webpack-dev-server/invalidate', (_req, res) => {
     server.invalidate();
     res.end();
   });

--- a/test/server/utils/routes.test.js
+++ b/test/server/utils/routes.test.js
@@ -64,8 +64,12 @@ describe('routes util', () => {
     });
   });
 
-  it('GET request to invalidate endpoint', (done) => {
-    req.get('/invalidate').expect(200, done);
+  it('should handles GET request to invalidate endpoint', (done) => {
+    req.get('/webpack-dev-server/invalidate').then(({ res }) => {
+      expect(res.headers['content-type']).not.toEqual('text/html');
+      expect(res.statusCode).toEqual(200);
+      done();
+    });
   });
 
   it('should handles GET request to live html', (done) => {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [x] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [x] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

Update existing tests

### Motivation / Use-Case

Backport from v4, because `invalidate` is not release yet, let's fix it before release `3.11.0`

### Breaking Changes

No, because `invalidate` doesn't exists in `3.10` version

### Additional Info

No
