### PR TITLE
Update package.json - version bump internal-ip

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "html-entities": "^1.3.1",
     "http-proxy-middleware": "0.19.1",
     "import-local": "^2.0.0",
-    "internal-ip": "^4.3.0",
+    "internal-ip": "^6.0.0",
     "ip": "^1.1.5",
     "is-absolute-url": "^3.0.3",
     "killable": "^1.0.1",


### PR DESCRIPTION
Updating to 6.0.0 resolves a security defect coming from internal-ip 4.3.0

<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [ ] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

<!-- Please note that we won't approve your changes if you don't add tests. -->

### Motivation / Use-Case

<!--
  What existing problem does the pull request solve?
security bug coming from internal-ip 4.3.0, this is simply a version bump to the most current version. 
  
Please explain the motivation or use-case for making this change.
  If this Pull Request addresses an issue, please link to the issue.
-->
The security bug is coming from execa. 

Here is what the resolved trace looks like:
internalip@1.0.0 /home/alan/Desktop/internalip
└─┬ internal-ip@6.0.0
  └─┬ default-gateway@6.0.1
    └── execa@4.0.2 

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  potential migration path for existing applications.
-->

### Additional Info
