### PR TITLE
fix(client): run babel on whole client dependency tree via webpack bundle

### DIFF
--- a/client-src/clients/SockJSClient.js
+++ b/client-src/clients/SockJSClient.js
@@ -9,6 +9,8 @@ const BaseClient = require('./BaseClient');
 module.exports = class SockJSClient extends BaseClient {
   constructor(url) {
     super();
+    // we require the logger in here because otherwise
+    // webpack@5 polyfills do not get applied to it
     const { log } = require('../default/utils/log');
 
     this.sock = new SockJS(url);

--- a/client-src/clients/SockJSClient.js
+++ b/client-src/clients/SockJSClient.js
@@ -4,12 +4,13 @@
   no-unused-vars
 */
 const SockJS = require('sockjs-client/dist/sockjs');
-const { log } = require('../default/utils/log');
 const BaseClient = require('./BaseClient');
 
 module.exports = class SockJSClient extends BaseClient {
   constructor(url) {
     super();
+    const { log } = require('../default/utils/log');
+
     this.sock = new SockJS(url);
 
     this.sock.onerror = (err) => {

--- a/client-src/clients/WebsocketClient.js
+++ b/client-src/clients/WebsocketClient.js
@@ -5,12 +5,14 @@
 /* eslint-disable
   no-unused-vars
 */
-const { log } = require('../default/utils/log');
+
 const BaseClient = require('./BaseClient');
 
 module.exports = class WebsocketClient extends BaseClient {
   constructor(url) {
     super();
+    const { log } = require('../default/utils/log');
+
     this.client = new WebSocket(url.replace(/^http/, 'ws'));
 
     this.client.onerror = (err) => {

--- a/client-src/clients/WebsocketClient.js
+++ b/client-src/clients/WebsocketClient.js
@@ -11,6 +11,8 @@ const BaseClient = require('./BaseClient');
 module.exports = class WebsocketClient extends BaseClient {
   constructor(url) {
     super();
+    // we require the logger in here because otherwise
+    // webpack@5 polyfills do not get applied to it
     const { log } = require('../default/utils/log');
 
     this.client = new WebSocket(url.replace(/^http/, 'ws'));

--- a/client-src/default/index.js
+++ b/client-src/default/index.js
@@ -15,7 +15,7 @@ const sendMessage = require('./utils/sendMessage');
 const reloadApp = require('./utils/reloadApp');
 const createSocketUrl = require('./utils/createSocketUrl');
 
-function init(resourceQuery, hotEmitter) {
+function init(resourceQuery, hotEmitter, clientClass) {
   const status = {
     isUnloading: false,
     currentHash: '',
@@ -151,7 +151,7 @@ function init(resourceQuery, hotEmitter) {
     },
   };
 
-  socket(socketUrl, onSocketMessage);
+  socket(socketUrl, onSocketMessage, clientClass);
 }
 
 module.exports = init;

--- a/client-src/default/index.js
+++ b/client-src/default/index.js
@@ -5,7 +5,7 @@ window.global = window.global || window;
 window.process = window.process || {};
 window.process.env = window.process.env || {};
 
-/* global __resourceQuery WorkerGlobalScope self */
+/* global WorkerGlobalScope self */
 /* eslint prefer-destructuring: off */
 const stripAnsi = require('strip-ansi');
 const socket = require('./socket');
@@ -15,139 +15,141 @@ const sendMessage = require('./utils/sendMessage');
 const reloadApp = require('./utils/reloadApp');
 const createSocketUrl = require('./utils/createSocketUrl');
 
-const status = {
-  isUnloading: false,
-  currentHash: '',
-};
-const options = {
-  hot: false,
-  hotReload: true,
-  liveReload: false,
-  initial: true,
-  useWarningOverlay: false,
-  useErrorOverlay: false,
-  useProgress: false,
-};
-const socketUrl = createSocketUrl(__resourceQuery);
+function init(resourceQuery) {
+  const status = {
+    isUnloading: false,
+    currentHash: '',
+  };
+  const options = {
+    hot: false,
+    hotReload: true,
+    liveReload: false,
+    initial: true,
+    useWarningOverlay: false,
+    useErrorOverlay: false,
+    useProgress: false,
+  };
+  const socketUrl = createSocketUrl(resourceQuery);
 
-self.addEventListener('beforeunload', () => {
-  status.isUnloading = true;
-});
+  self.addEventListener('beforeunload', () => {
+    status.isUnloading = true;
+  });
 
-if (typeof window !== 'undefined') {
-  const qs = window.location.search.toLowerCase();
-  options.hotReload = qs.indexOf('hotreload=false') === -1;
+  if (typeof window !== 'undefined') {
+    const qs = window.location.search.toLowerCase();
+    options.hotReload = qs.indexOf('hotreload=false') === -1;
+  }
+
+  const onSocketMessage = {
+    hot() {
+      options.hot = true;
+      log.info('Hot Module Replacement enabled.');
+    },
+    liveReload() {
+      options.liveReload = true;
+      log.info('Live Reloading enabled.');
+    },
+    invalid() {
+      log.info('App updated. Recompiling...');
+      // fixes #1042. overlay doesn't clear if errors are fixed but warnings remain.
+      if (options.useWarningOverlay || options.useErrorOverlay) {
+        overlay.clear();
+      }
+      sendMessage('Invalid');
+    },
+    hash(hash) {
+      status.currentHash = hash;
+    },
+    'still-ok': function stillOk() {
+      log.info('Nothing changed.');
+      if (options.useWarningOverlay || options.useErrorOverlay) {
+        overlay.clear();
+      }
+      sendMessage('StillOk');
+    },
+    logging: function logging(level) {
+      // this is needed because the HMR logger operate separately from
+      // dev server logger
+      const hotCtx = require.context('webpack/hot', false, /^\.\/log$/);
+      if (hotCtx.keys().indexOf('./log') !== -1) {
+        hotCtx('./log').setLogLevel(level);
+      }
+  
+      setLogLevel(level);
+    },
+    overlay(value) {
+      if (typeof document !== 'undefined') {
+        if (typeof value === 'boolean') {
+          options.useWarningOverlay = false;
+          options.useErrorOverlay = value;
+        } else if (value) {
+          options.useWarningOverlay = value.warnings;
+          options.useErrorOverlay = value.errors;
+        }
+      }
+    },
+    progress(progress) {
+      if (typeof document !== 'undefined') {
+        options.useProgress = progress;
+      }
+    },
+    'progress-update': function progressUpdate(data) {
+      if (options.useProgress) {
+        log.info(`${data.percent}% - ${data.msg}.`);
+      }
+      sendMessage('Progress', data);
+    },
+    ok() {
+      sendMessage('Ok');
+      if (options.useWarningOverlay || options.useErrorOverlay) {
+        overlay.clear();
+      }
+      if (options.initial) {
+        return (options.initial = false);
+      } // eslint-disable-line no-return-assign
+      reloadApp(options, status);
+    },
+    'content-changed': function contentChanged() {
+      log.info('Content base changed. Reloading...');
+      self.location.reload();
+    },
+    warnings(warnings) {
+      log.warn('Warnings while compiling.');
+      const strippedWarnings = warnings.map((warning) => stripAnsi(warning));
+      sendMessage('Warnings', strippedWarnings);
+      for (let i = 0; i < strippedWarnings.length; i++) {
+        log.warn(strippedWarnings[i]);
+      }
+      if (options.useWarningOverlay) {
+        overlay.showMessage(warnings);
+      }
+  
+      if (options.initial) {
+        return (options.initial = false);
+      } // eslint-disable-line no-return-assign
+      reloadApp(options, status);
+    },
+    errors(errors) {
+      log.error('Errors while compiling. Reload prevented.');
+      const strippedErrors = errors.map((error) => stripAnsi(error));
+      sendMessage('Errors', strippedErrors);
+      for (let i = 0; i < strippedErrors.length; i++) {
+        log.error(strippedErrors[i]);
+      }
+      if (options.useErrorOverlay) {
+        overlay.showMessage(errors);
+      }
+      options.initial = false;
+    },
+    error(error) {
+      log.error(error);
+    },
+    close() {
+      log.error('Disconnected!');
+    },
+  };
+
+  socket(socketUrl, onSocketMessage);
 }
 
-const onSocketMessage = {
-  hot() {
-    options.hot = true;
-    log.info('Hot Module Replacement enabled.');
-  },
-  liveReload() {
-    options.liveReload = true;
-    log.info('Live Reloading enabled.');
-  },
-  invalid() {
-    log.info('App updated. Recompiling...');
-    // fixes #1042. overlay doesn't clear if errors are fixed but warnings remain.
-    if (options.useWarningOverlay || options.useErrorOverlay) {
-      overlay.clear();
-    }
-    sendMessage('Invalid');
-  },
-  hash(hash) {
-    status.currentHash = hash;
-  },
-  'still-ok': function stillOk() {
-    log.info('Nothing changed.');
-    if (options.useWarningOverlay || options.useErrorOverlay) {
-      overlay.clear();
-    }
-    sendMessage('StillOk');
-  },
-  logging: function logging(level) {
-    // this is needed because the HMR logger operate separately from
-    // dev server logger
-    const hotCtx = require.context('webpack/hot', false, /^\.\/log$/);
-    if (hotCtx.keys().indexOf('./log') !== -1) {
-      hotCtx('./log').setLogLevel(level);
-    }
-
-    setLogLevel(level);
-  },
-  overlay(value) {
-    if (typeof document !== 'undefined') {
-      if (typeof value === 'boolean') {
-        options.useWarningOverlay = false;
-        options.useErrorOverlay = value;
-      } else if (value) {
-        options.useWarningOverlay = value.warnings;
-        options.useErrorOverlay = value.errors;
-      }
-    }
-  },
-  progress(progress) {
-    if (typeof document !== 'undefined') {
-      options.useProgress = progress;
-    }
-  },
-  'progress-update': function progressUpdate(data) {
-    if (options.useProgress) {
-      log.info(`${data.percent}% - ${data.msg}.`);
-    }
-    sendMessage('Progress', data);
-  },
-  ok() {
-    sendMessage('Ok');
-    if (options.useWarningOverlay || options.useErrorOverlay) {
-      overlay.clear();
-    }
-    if (options.initial) {
-      return (options.initial = false);
-    } // eslint-disable-line no-return-assign
-    reloadApp(options, status);
-  },
-  'content-changed': function contentChanged() {
-    log.info('Content base changed. Reloading...');
-    self.location.reload();
-  },
-  warnings(warnings) {
-    log.warn('Warnings while compiling.');
-    const strippedWarnings = warnings.map((warning) => stripAnsi(warning));
-    sendMessage('Warnings', strippedWarnings);
-    for (let i = 0; i < strippedWarnings.length; i++) {
-      log.warn(strippedWarnings[i]);
-    }
-    if (options.useWarningOverlay) {
-      overlay.showMessage(warnings);
-    }
-
-    if (options.initial) {
-      return (options.initial = false);
-    } // eslint-disable-line no-return-assign
-    reloadApp(options, status);
-  },
-  errors(errors) {
-    log.error('Errors while compiling. Reload prevented.');
-    const strippedErrors = errors.map((error) => stripAnsi(error));
-    sendMessage('Errors', strippedErrors);
-    for (let i = 0; i < strippedErrors.length; i++) {
-      log.error(strippedErrors[i]);
-    }
-    if (options.useErrorOverlay) {
-      overlay.showMessage(errors);
-    }
-    options.initial = false;
-  },
-  error(error) {
-    log.error(error);
-  },
-  close() {
-    log.error('Disconnected!');
-
-    sendMessage('Close');
-  },
-};
-
-socket(socketUrl, onSocketMessage);
+module.exports = init;

--- a/client-src/default/index.js
+++ b/client-src/default/index.js
@@ -146,6 +146,8 @@ function init(resourceQuery, hotEmitter) {
     },
     close() {
       log.error('Disconnected!');
+
+      sendMessage('Close');
     },
   };
 

--- a/client-src/default/index.js
+++ b/client-src/default/index.js
@@ -15,7 +15,7 @@ const sendMessage = require('./utils/sendMessage');
 const reloadApp = require('./utils/reloadApp');
 const createSocketUrl = require('./utils/createSocketUrl');
 
-function init(resourceQuery) {
+function init(resourceQuery, hotEmitter) {
   const status = {
     isUnloading: false,
     currentHash: '',
@@ -107,7 +107,7 @@ function init(resourceQuery) {
       if (options.initial) {
         return (options.initial = false);
       } // eslint-disable-line no-return-assign
-      reloadApp(options, status);
+      reloadApp(options, status, hotEmitter);
     },
     'content-changed': function contentChanged() {
       log.info('Content base changed. Reloading...');
@@ -127,7 +127,7 @@ function init(resourceQuery) {
       if (options.initial) {
         return (options.initial = false);
       } // eslint-disable-line no-return-assign
-      reloadApp(options, status);
+      reloadApp(options, status, hotEmitter);
     },
     errors(errors) {
       log.error('Errors while compiling. Reload prevented.');

--- a/client-src/default/index.js
+++ b/client-src/default/index.js
@@ -74,7 +74,7 @@ function init(resourceQuery) {
       if (hotCtx.keys().indexOf('./log') !== -1) {
         hotCtx('./log').setLogLevel(level);
       }
-  
+
       setLogLevel(level);
     },
     overlay(value) {
@@ -123,7 +123,7 @@ function init(resourceQuery) {
       if (options.useWarningOverlay) {
         overlay.showMessage(warnings);
       }
-  
+
       if (options.initial) {
         return (options.initial = false);
       } // eslint-disable-line no-return-assign

--- a/client-src/default/socket.js
+++ b/client-src/default/socket.js
@@ -30,7 +30,7 @@ const socket = function initSocket(url, handlers, clientClass) {
       retries += 1;
 
       setTimeout(() => {
-        socket(url, handlers);
+        socket(url, handlers, clientClass);
       }, retryInMs);
     }
   });

--- a/client-src/default/socket.js
+++ b/client-src/default/socket.js
@@ -1,22 +1,12 @@
 'use strict';
 
-/* global __webpack_dev_server_client__ */
-/* eslint-disable
-  camelcase
-*/
-
-// this WebsocketClient is here as a default fallback,
-//  in case the client is not injected
-const Client =
-  typeof __webpack_dev_server_client__ !== 'undefined'
-    ? __webpack_dev_server_client__
-    : // eslint-disable-next-line import/no-unresolved
-      require('../clients/WebsocketClient');
-
 let retries = 0;
 let client = null;
 
-const socket = function initSocket(url, handlers) {
+const socket = function initSocket(url, handlers, clientClass) {
+  // this WebsocketClient is here as a default fallback,
+  // in case the client is not injected
+  const Client = clientClass || require('../clients/WebsocketClient');
   client = new Client(url);
 
   client.onOpen(() => {

--- a/client-src/default/utils/reloadApp.js
+++ b/client-src/default/utils/reloadApp.js
@@ -1,6 +1,9 @@
 'use strict';
 
 /* global WorkerGlobalScope self */
+/* eslint-disable
+  camelcase
+*/
 
 const { log } = require('./log');
 
@@ -13,7 +16,12 @@ function reloadApp(
   }
   if (hot) {
     log.info('App hot update...');
-    const hotEmitter = require('webpack/hot/emitter');
+    const hotEmitter =
+      typeof __webpack_hot_emitter__ !== 'undefined'
+        ? // eslint-disable-next-line no-undef
+          __webpack_hot_emitter__
+        : // eslint-disable-next-line import/no-unresolved
+          require('webpack/hot/emitter');
     hotEmitter.emit('webpackHotUpdate', currentHash);
     if (typeof self !== 'undefined' && self.window) {
       // broadcast update to window

--- a/client-src/default/utils/reloadApp.js
+++ b/client-src/default/utils/reloadApp.js
@@ -1,27 +1,20 @@
 'use strict';
 
 /* global WorkerGlobalScope self */
-/* eslint-disable
-  camelcase
-*/
 
 const { log } = require('./log');
 
 function reloadApp(
   { hotReload, hot, liveReload },
-  { isUnloading, currentHash }
+  { isUnloading, currentHash },
+  hotEmitter
 ) {
   if (isUnloading || !hotReload) {
     return;
   }
   if (hot) {
     log.info('App hot update...');
-    const hotEmitter =
-      typeof __webpack_hot_emitter__ !== 'undefined'
-        ? // eslint-disable-next-line no-undef
-          __webpack_hot_emitter__
-        : // eslint-disable-next-line import/no-unresolved
-          require('webpack/hot/emitter');
+    hotEmitter = hotEmitter || require('webpack/hot/emitter');
     hotEmitter.emit('webpackHotUpdate', currentHash);
     if (typeof self !== 'undefined' && self.window) {
       // broadcast update to window

--- a/client-src/default/webpack.config.js
+++ b/client-src/default/webpack.config.js
@@ -3,7 +3,7 @@
 const path = require('path');
 
 module.exports = {
-  mode: 'production',
+  mode: 'development',
   entry: path.join(__dirname, 'index.js'),
   output: {
     path: path.resolve(__dirname, '../../client/entry'),

--- a/client-src/default/webpack.config.js
+++ b/client-src/default/webpack.config.js
@@ -6,8 +6,9 @@ module.exports = {
   mode: 'production',
   entry: path.join(__dirname, 'index.js'),
   output: {
-    path: path.resolve(__dirname, '../../client/default'),
-    filename: 'index.bundle.js',
+    path: path.resolve(__dirname, '../../client/entry'),
+    filename: 'bundle.js',
+    libraryTarget: 'commonjs2',
   },
   module: {
     rules: [

--- a/client-src/default/webpack.config.js
+++ b/client-src/default/webpack.config.js
@@ -3,7 +3,7 @@
 const path = require('path');
 
 module.exports = {
-  mode: 'development',
+  mode: 'production',
   entry: path.join(__dirname, 'index.js'),
   output: {
     path: path.resolve(__dirname, '../../client/entry'),

--- a/client-src/entry/bundle.js
+++ b/client-src/entry/bundle.js
@@ -1,0 +1,5 @@
+'use strict';
+
+// this is a placeholder for the bundle that is exported in the build phase
+// this file is ignored by babel
+module.exports = require('../default');

--- a/client-src/entry/index.js
+++ b/client-src/entry/index.js
@@ -4,4 +4,6 @@
 
 const init = require('../default');
 
+// this is needed to pass along the resource query to the client bundle
+// that is compiled with webpack and babel-loader
 init(__resourceQuery);

--- a/client-src/entry/index.js
+++ b/client-src/entry/index.js
@@ -1,0 +1,7 @@
+'use strict';
+
+/* global __resourceQuery */
+
+const init = require('../default');
+
+init(__resourceQuery);

--- a/client-src/entry/index.js
+++ b/client-src/entry/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-/* global __resourceQuery __webpack_hot_emitter__ */
+/* global __resourceQuery __webpack_hot_emitter__ __webpack_dev_server_client__ */
 /* eslint-disable
   camelcase
 */
@@ -11,6 +11,12 @@ const hotEmitter =
   typeof __webpack_hot_emitter__ === 'undefined'
     ? null
     : __webpack_hot_emitter__;
+
+const clientClass =
+  typeof __webpack_dev_server_client__ === 'undefined'
+    ? null
+    : __webpack_dev_server_client__;
+
 // this is needed to pass along the resource query to the client bundle
 // that is compiled with webpack and babel-loader
-init(__resourceQuery, hotEmitter);
+init(__resourceQuery, hotEmitter, clientClass);

--- a/client-src/entry/index.js
+++ b/client-src/entry/index.js
@@ -2,7 +2,7 @@
 
 /* global __resourceQuery */
 
-const init = require('../default');
+const init = require('./bundle');
 
 // this is needed to pass along the resource query to the client bundle
 // that is compiled with webpack and babel-loader

--- a/client-src/entry/index.js
+++ b/client-src/entry/index.js
@@ -1,9 +1,16 @@
 'use strict';
 
-/* global __resourceQuery */
+/* global __resourceQuery __webpack_hot_emitter__ */
+/* eslint-disable
+  camelcase
+*/
 
 const init = require('./bundle');
 
+const hotEmitter =
+  typeof __webpack_hot_emitter__ === 'undefined'
+    ? null
+    : __webpack_hot_emitter__;
 // this is needed to pass along the resource query to the client bundle
 // that is compiled with webpack and babel-loader
-init(__resourceQuery);
+init(__resourceQuery, hotEmitter);

--- a/lib/utils/addEntries.js
+++ b/lib/utils/addEntries.js
@@ -50,7 +50,7 @@ function addEntries(config, options, server) {
       : '';
   /** @type {string} */
   const clientEntry = `${require.resolve(
-    '../../client/default/'
+    '../../client/entry/'
   )}?${domain}${host}${path}${port}`;
 
   /** @type {(string[] | string)} */

--- a/lib/utils/routes.js
+++ b/lib/utils/routes.js
@@ -19,7 +19,7 @@ function routes(server) {
   app.get('/webpack-dev-server.js', (req, res) => {
     res.setHeader('Content-Type', 'application/javascript');
 
-    createReadStream(join(clientBasePath, 'default/index.bundle.js')).pipe(res);
+    createReadStream(join(clientBasePath, 'entry/bundle.js')).pipe(res);
   });
 
   app.get('/webpack-dev-server/invalidate', (_req, res) => {

--- a/lib/utils/updateCompiler.js
+++ b/lib/utils/updateCompiler.js
@@ -51,6 +51,7 @@ function updateCompiler(compiler, options) {
 
     const providePlugin = new webpack.ProvidePlugin({
       __webpack_dev_server_client__: getSocketClientPath(options),
+      __webpack_hot_emitter__: 'webpack/hot/emitter',
     });
     providePlugin.apply(compiler);
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -4076,9 +4076,9 @@
       }
     },
     "acorn": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.2.0.tgz",
-      "integrity": "sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.3.1.tgz",
+      "integrity": "sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA==",
       "dev": true
     },
     "acorn-globals": {

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "@commitlint/cli": "^8.3.5",
     "@commitlint/config-conventional": "^8.3.4",
     "@jest/test-sequencer": "^26.0.1",
+    "acorn": "^7.3.1",
     "babel-jest": "^26.0.1",
     "babel-loader": "^8.1.0",
     "body-parser": "^1.19.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "pretest": "npm run lint",
     "prepare": "rimraf ./ssl/*.pem && npm run build:client",
     "build:client:default": "babel client-src/default --out-dir client/default --ignore \"./client-src/default/*.config.js\"",
+    "build:client:entry": "babel client-src/entry --out-dir client/entry --ignore \"./client-src/entry/bundle.js\"",
     "build:client:clients": "babel client-src/clients --out-dir client/clients",
     "build:client:index": "webpack --color --config client-src/default/webpack.config.js",
     "build:client:sockjs": "webpack --color --config client-src/sockjs/webpack.config.js",

--- a/test/client/__snapshots__/index.test.js.snap
+++ b/test/client/__snapshots__/index.test.js.snap
@@ -43,15 +43,22 @@ exports[`index should run onSocketMessage.liveReload 1`] = `"Live Reloading enab
 exports[`index should run onSocketMessage.ok 1`] = `"Ok"`;
 
 exports[`index should run onSocketMessage.ok 2`] = `
-Object {
-  "hot": false,
-  "hotReload": true,
-  "initial": false,
-  "liveReload": false,
-  "useErrorOverlay": false,
-  "useProgress": false,
-  "useWarningOverlay": false,
-}
+Array [
+  Object {
+    "hot": false,
+    "hotReload": true,
+    "initial": false,
+    "liveReload": false,
+    "useErrorOverlay": false,
+    "useProgress": false,
+    "useWarningOverlay": false,
+  },
+  Object {
+    "currentHash": "mock-hash",
+    "isUnloading": false,
+  },
+  "bar",
+]
 `;
 
 exports[`index should run onSocketMessage.progress and onSocketMessage['progress-update'] 1`] = `"Progress"`;

--- a/test/client/__snapshots__/index.test.js.snap
+++ b/test/client/__snapshots__/index.test.js.snap
@@ -57,7 +57,7 @@ Array [
     "currentHash": "mock-hash",
     "isUnloading": false,
   },
-  "bar",
+  "hotEmitter",
 ]
 `;
 
@@ -109,5 +109,6 @@ Array [
     "still-ok": [Function],
     "warnings": [Function],
   },
+  "clientClass",
 ]
 `;

--- a/test/client/__snapshots__/socket-helper.test.js.snap
+++ b/test/client/__snapshots__/socket-helper.test.js.snap
@@ -1,12 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`socket should default to WebsocketClient when no __webpack_dev_server_client__ set 1`] = `
+exports[`socket should default to WebsocketClient when no clientClass provided 1`] = `
 Array [
   "my.url",
 ]
 `;
 
-exports[`socket should default to WebsocketClient when no __webpack_dev_server_client__ set 2`] = `
+exports[`socket should default to WebsocketClient when no clientClass provided 2`] = `
 Array [
   Array [
     [Function],
@@ -14,7 +14,7 @@ Array [
 ]
 `;
 
-exports[`socket should default to WebsocketClient when no __webpack_dev_server_client__ set 3`] = `
+exports[`socket should default to WebsocketClient when no clientClass provided 3`] = `
 Array [
   Array [
     [Function],
@@ -22,7 +22,7 @@ Array [
 ]
 `;
 
-exports[`socket should default to WebsocketClient when no __webpack_dev_server_client__ set 4`] = `
+exports[`socket should default to WebsocketClient when no clientClass provided 4`] = `
 Array [
   Array [
     [Function],
@@ -30,7 +30,7 @@ Array [
 ]
 `;
 
-exports[`socket should default to WebsocketClient when no __webpack_dev_server_client__ set 5`] = `
+exports[`socket should default to WebsocketClient when no clientClass provided 5`] = `
 Array [
   Array [
     "hello world",
@@ -38,13 +38,13 @@ Array [
 ]
 `;
 
-exports[`socket should use __webpack_dev_server_client__ when set 1`] = `
+exports[`socket should use clientClass when passed in 1`] = `
 Array [
   "my.url",
 ]
 `;
 
-exports[`socket should use __webpack_dev_server_client__ when set 2`] = `
+exports[`socket should use clientClass when passed in 2`] = `
 Array [
   Array [
     [Function],
@@ -52,7 +52,7 @@ Array [
 ]
 `;
 
-exports[`socket should use __webpack_dev_server_client__ when set 3`] = `
+exports[`socket should use clientClass when passed in 3`] = `
 Array [
   Array [
     [Function],
@@ -60,7 +60,7 @@ Array [
 ]
 `;
 
-exports[`socket should use __webpack_dev_server_client__ when set 4`] = `
+exports[`socket should use clientClass when passed in 4`] = `
 Array [
   Array [
     [Function],
@@ -68,7 +68,7 @@ Array [
 ]
 `;
 
-exports[`socket should use __webpack_dev_server_client__ when set 5`] = `
+exports[`socket should use clientClass when passed in 5`] = `
 Array [
   Array [
     "hello world",

--- a/test/client/entry/entry.test.js
+++ b/test/client/entry/entry.test.js
@@ -1,21 +1,33 @@
 'use strict';
 
+jest.setMock('../../../client-src/default/index.js', jest.fn());
 jest.setMock('../../../client/entry/bundle.js', jest.fn());
+
+global.__resourceQuery = 'test1';
+global.__webpack_hot_emitter__ = 'test2';
 
 const acorn = require('acorn');
 const request = require('supertest');
 const testServer = require('../../helpers/test-server');
 const config = require('../../fixtures/simple-config/webpack.config');
 const port = require('../../ports-map').entry;
+const init = require('../../../client-src/default');
 const bundle = require('../../../client/entry/bundle');
 
 describe('entry', () => {
   describe('module', () => {
-    it('should pass resource query to bundle', () => {
-      global.__resourceQuery = 'test';
+    it('should pass resource query and emitter to bundle', () => {
       require('../../../client/entry');
       expect(bundle.mock.calls.length).toEqual(1);
-      expect(bundle.mock.calls[0][0]).toEqual('test');
+      expect(bundle.mock.calls[0]).toEqual(['test1', 'test2']);
+    });
+  });
+
+  describe('bundle placeholder', () => {
+    it('should call unbundled init function', () => {
+      require('../../../client-src/entry');
+      expect(init.mock.calls.length).toEqual(1);
+      expect(init.mock.calls[0]).toEqual(['test1', 'test2']);
     });
   });
 

--- a/test/client/entry/entry.test.js
+++ b/test/client/entry/entry.test.js
@@ -2,6 +2,7 @@
 
 jest.setMock('../../../client/entry/bundle.js', jest.fn());
 
+const acorn = require('acorn');
 const request = require('supertest');
 const testServer = require('../../helpers/test-server');
 const config = require('../../fixtures/simple-config/webpack.config');
@@ -35,7 +36,11 @@ describe('entry', () => {
         .expect('Content-Type', 'application/javascript; charset=UTF-8')
         .expect(200);
 
-      expect(text).not.toContain('const ');
+      expect(() => {
+        acorn.parse(text, {
+          ecmaVersion: 5,
+        });
+      }).not.toThrow();
     });
   });
 });

--- a/test/client/entry/entry.test.js
+++ b/test/client/entry/entry.test.js
@@ -30,7 +30,7 @@ describe('entry', () => {
 
     afterAll(testServer.close);
 
-    it('should not include const', async () => {
+    it('should get full user bundle and parse with ES5', async () => {
       const { text } = await req
         .get('/main.js')
         .expect('Content-Type', 'application/javascript; charset=UTF-8')

--- a/test/client/entry/entry.test.js
+++ b/test/client/entry/entry.test.js
@@ -14,8 +14,13 @@ const config = require('../../fixtures/simple-config/webpack.config');
 const port = require('../../ports-map').entry;
 const init = require('../../../client-src/default');
 const bundle = require('../../../client/entry/bundle');
+const isWebpack5 = require('../../helpers/isWebpack5');
 
 describe('entry', () => {
+  // the ES5 check test for the bundle will not work on webpack@5,
+  // because webpack@5 bundle output uses some ES6 syntax
+  const runBundledOutputTest = isWebpack5 ? describe.skip : describe;
+
   describe('module', () => {
     it('should pass resource query and emitter to bundle', () => {
       require('../../../client/entry');
@@ -32,7 +37,7 @@ describe('entry', () => {
     });
   });
 
-  describe('bundled output', () => {
+  runBundledOutputTest('bundled output', () => {
     let server;
     let req;
 

--- a/test/client/entry/entry.test.js
+++ b/test/client/entry/entry.test.js
@@ -5,6 +5,7 @@ jest.setMock('../../../client/entry/bundle.js', jest.fn());
 
 global.__resourceQuery = 'test1';
 global.__webpack_hot_emitter__ = 'test2';
+global.__webpack_dev_server_client__ = 'test3';
 
 const acorn = require('acorn');
 const request = require('supertest');
@@ -19,7 +20,7 @@ describe('entry', () => {
     it('should pass resource query and emitter to bundle', () => {
       require('../../../client/entry');
       expect(bundle.mock.calls.length).toEqual(1);
-      expect(bundle.mock.calls[0]).toEqual(['test1', 'test2']);
+      expect(bundle.mock.calls[0]).toEqual(['test1', 'test2', 'test3']);
     });
   });
 
@@ -27,7 +28,7 @@ describe('entry', () => {
     it('should call unbundled init function', () => {
       require('../../../client-src/entry');
       expect(init.mock.calls.length).toEqual(1);
-      expect(init.mock.calls[0]).toEqual(['test1', 'test2']);
+      expect(init.mock.calls[0]).toEqual(['test1', 'test2', 'test3']);
     });
   });
 

--- a/test/client/entry/entry.test.js
+++ b/test/client/entry/entry.test.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const request = require('supertest');
+const testServer = require('../../helpers/test-server');
+const config = require('../../fixtures/simple-config/webpack.config');
+const port = require('../../ports-map').entry;
+
+describe('entry', () => {
+  describe('bundled output', () => {
+    let server;
+    let req;
+
+    beforeAll((done) => {
+      server = testServer.start(config, { port }, done);
+      req = request(server.app);
+    });
+
+    afterAll(testServer.close);
+
+    it('should not include const', async () => {
+      const { text } = await req
+        .get('/main.js')
+        .expect('Content-Type', 'application/javascript; charset=UTF-8')
+        .expect(200);
+
+      expect(text).not.toContain('const ');
+    });
+  });
+});

--- a/test/client/entry/entry.test.js
+++ b/test/client/entry/entry.test.js
@@ -1,11 +1,23 @@
 'use strict';
 
+jest.setMock('../../../client/entry/bundle.js', jest.fn());
+
 const request = require('supertest');
 const testServer = require('../../helpers/test-server');
 const config = require('../../fixtures/simple-config/webpack.config');
 const port = require('../../ports-map').entry;
+const bundle = require('../../../client/entry/bundle');
 
 describe('entry', () => {
+  describe('module', () => {
+    it('should pass resource query to bundle', () => {
+      global.__resourceQuery = 'test';
+      require('../../../client/entry');
+      expect(bundle.mock.calls.length).toEqual(1);
+      expect(bundle.mock.calls[0][0]).toEqual('test');
+    });
+  });
+
   describe('bundled output', () => {
     let server;
     let req;

--- a/test/client/entry/no-emitter-and-client.test.js
+++ b/test/client/entry/no-emitter-and-client.test.js
@@ -12,6 +12,6 @@ describe('entry without emitter', () => {
   it('should pass resource query to bundle without emitter', () => {
     require('../../../client/entry');
     expect(bundle.mock.calls.length).toEqual(1);
-    expect(bundle.mock.calls[0]).toEqual(['test1', null]);
+    expect(bundle.mock.calls[0]).toEqual(['test1', null, null]);
   });
 });

--- a/test/client/entry/no-emitter.test.js
+++ b/test/client/entry/no-emitter.test.js
@@ -9,11 +9,9 @@ global.__resourceQuery = 'test1';
 const bundle = require('../../../client/entry/bundle');
 
 describe('entry without emitter', () => {
-  describe('module', () => {
-    it('should pass resource query to bundle without emitter', () => {
-      require('../../../client/entry');
-      expect(bundle.mock.calls.length).toEqual(1);
-      expect(bundle.mock.calls[0]).toEqual(['test1', null]);
-    });
+  it('should pass resource query to bundle without emitter', () => {
+    require('../../../client/entry');
+    expect(bundle.mock.calls.length).toEqual(1);
+    expect(bundle.mock.calls[0]).toEqual(['test1', null]);
   });
 });

--- a/test/client/entry/no-emitter.test.js
+++ b/test/client/entry/no-emitter.test.js
@@ -1,0 +1,19 @@
+'use strict';
+
+jest.setMock('../../../client/entry/bundle.js', jest.fn());
+
+// this test file is separate from entry.test.js because it is
+// difficult to set new globals or delete globals with jest
+global.__resourceQuery = 'test1';
+
+const bundle = require('../../../client/entry/bundle');
+
+describe('entry without emitter', () => {
+  describe('module', () => {
+    it('should pass resource query to bundle without emitter', () => {
+      require('../../../client/entry');
+      expect(bundle.mock.calls.length).toEqual(1);
+      expect(bundle.mock.calls[0]).toEqual(['test1', null]);
+    });
+  });
+});

--- a/test/client/index.test.js
+++ b/test/client/index.test.js
@@ -16,6 +16,7 @@ describe('index', () => {
 
   beforeEach(() => {
     const resourceQuery = 'foo';
+    const hotEmitter = 'bar';
 
     // log
     jest.setMock('../../client-src/default/utils/log.js', {
@@ -60,7 +61,7 @@ describe('index', () => {
     };
 
     const init = require('../../client-src/default');
-    init(resourceQuery);
+    init(resourceQuery, hotEmitter);
 
     onSocketMessage = socket.mock.calls[0][1];
   });

--- a/test/client/index.test.js
+++ b/test/client/index.test.js
@@ -157,7 +157,7 @@ describe('index', () => {
 
       const res = onSocketMessage.ok();
       expect(reloadApp).toBeCalled();
-      expect(reloadApp.mock.calls[0][0]).toMatchSnapshot();
+      expect(reloadApp.mock.calls[0]).toMatchSnapshot();
       expect(res).toEqual(undefined);
     }
   });

--- a/test/client/index.test.js
+++ b/test/client/index.test.js
@@ -13,10 +13,9 @@ describe('index', () => {
   let sendMessage;
   let onSocketMessage;
   const locationValue = self.location;
-  const resourceQueryValue = global.__resourceQuery;
 
   beforeEach(() => {
-    global.__resourceQuery = 'foo';
+    const resourceQuery = 'foo';
 
     // log
     jest.setMock('../../client-src/default/utils/log.js', {
@@ -60,12 +59,13 @@ describe('index', () => {
       reload: jest.fn(),
     };
 
-    require('../../client-src/default');
+    const init = require('../../client-src/default');
+    init(resourceQuery);
+
     onSocketMessage = socket.mock.calls[0][1];
   });
 
   afterEach(() => {
-    global.__resourceQuery = resourceQueryValue;
     Object.assign(self, locationValue);
     jest.resetAllMocks();
     jest.resetModules();

--- a/test/client/index.test.js
+++ b/test/client/index.test.js
@@ -16,7 +16,8 @@ describe('index', () => {
 
   beforeEach(() => {
     const resourceQuery = 'foo';
-    const hotEmitter = 'bar';
+    const hotEmitter = 'hotEmitter';
+    const clientClass = 'clientClass';
 
     // log
     jest.setMock('../../client-src/default/utils/log.js', {
@@ -61,7 +62,7 @@ describe('index', () => {
     };
 
     const init = require('../../client-src/default');
-    init(resourceQuery, hotEmitter);
+    init(resourceQuery, hotEmitter, clientClass);
 
     onSocketMessage = socket.mock.calls[0][1];
   });

--- a/test/client/utils/__snapshots__/reloadApp.test.js.snap
+++ b/test/client/utils/__snapshots__/reloadApp.test.js.snap
@@ -1,10 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`reloadApp should run hot 1`] = `"App hot update..."`;
+exports[`reloadApp should run hot if emitter not passed in 1`] = `"App hot update..."`;
 
-exports[`reloadApp should run hot 2`] = `"webpackHotUpdate"`;
+exports[`reloadApp should run hot if emitter not passed in 2`] = `"webpackHotUpdate"`;
 
-exports[`reloadApp should run hot 3`] = `
+exports[`reloadApp should run hot if emitter not passed in 3`] = `
+Array [
+  "webpackHotUpdatehash",
+  "*",
+]
+`;
+
+exports[`reloadApp should run hot if emitter passed in 1`] = `"App hot update..."`;
+
+exports[`reloadApp should run hot if emitter passed in 2`] = `"webpackHotUpdate"`;
+
+exports[`reloadApp should run hot if emitter passed in 3`] = `
 Array [
   "webpackHotUpdatehash",
   "*",

--- a/test/client/utils/reloadApp.test.js
+++ b/test/client/utils/reloadApp.test.js
@@ -45,19 +45,43 @@ describe('reloadApp', () => {
     expect(log.getLogger.mock.results[0].value.info).not.toBeCalled();
   });
 
-  test('should run hot', () => {
+  test('should run hot if emitter not passed in', () => {
     jest.mock('webpack/hot/emitter');
     const emitter = require('webpack/hot/emitter');
     emitter.emit = jest.fn();
 
     reloadApp(
       { hot: true, hotReload: true },
-      { isUnloading: false, currentHash: 'hash' }
+      { isUnloading: false, currentHash: 'hash' },
+      null
     );
 
     expect(
       log.getLogger.mock.results[0].value.info.mock.calls[0][0]
     ).toMatchSnapshot();
+    expect(emitter.emit.mock.calls[0][0]).toMatchSnapshot();
+    expect(self.postMessage.mock.calls[0]).toMatchSnapshot();
+  });
+
+  test('should run hot if emitter passed in', () => {
+    jest.mock('webpack/hot/emitter');
+    const emitterModule = require('webpack/hot/emitter');
+    emitterModule.emit = jest.fn();
+
+    const emitter = {
+      emit: jest.fn(),
+    };
+
+    reloadApp(
+      { hot: true, hotReload: true },
+      { isUnloading: false, currentHash: 'hash' },
+      emitter
+    );
+
+    expect(
+      log.getLogger.mock.results[0].value.info.mock.calls[0][0]
+    ).toMatchSnapshot();
+    expect(emitterModule.emit).not.toBeCalled();
     expect(emitter.emit.mock.calls[0][0]).toMatchSnapshot();
     expect(self.postMessage.mock.calls[0]).toMatchSnapshot();
   });
@@ -72,7 +96,8 @@ describe('reloadApp', () => {
 
     reloadApp(
       { hot: false, hotReload: true, liveReload: true },
-      { isUnloading: false }
+      { isUnloading: false },
+      null
     );
 
     setTimeout(() => {
@@ -87,7 +112,8 @@ describe('reloadApp', () => {
   test('should run liveReload when protocol is http:', (done) => {
     reloadApp(
       { hot: false, hotReload: true, liveReload: true },
-      { isUnloading: false }
+      { isUnloading: false },
+      null
     );
 
     setTimeout(() => {

--- a/test/ports-map.js
+++ b/test/ports-map.js
@@ -40,6 +40,7 @@ const portsList = {
   'progress-option': 1,
   'profile-option': 1,
   Iframe: 1,
+  entry: 1,
 };
 
 let startPort = 8089;

--- a/test/server/__snapshots__/Server.test.js.snap
+++ b/test/server/__snapshots__/Server.test.js.snap
@@ -4,7 +4,7 @@ exports[`Server addEntries add hot option 1`] = `
 Array [
   Array [
     "client",
-    "default",
+    "entry",
     "index.js?http:",
     "localhost:8100",
   ],
@@ -24,7 +24,7 @@ exports[`Server addEntries add hot-only option 1`] = `
 Array [
   Array [
     "client",
-    "default",
+    "entry",
     "index.js?http:",
     "localhost:8100",
   ],

--- a/test/server/utils/addEntries.test.js
+++ b/test/server/utils/addEntries.test.js
@@ -18,7 +18,7 @@ describe('addEntries util', () => {
 
     expect(webpackOptions.entry.length).toEqual(2);
     expect(
-      normalize(webpackOptions.entry[0]).indexOf('client/default/index.js?') !==
+      normalize(webpackOptions.entry[0]).indexOf('client/entry/index.js?') !==
         -1
     ).toBeTruthy();
     expect(normalize(webpackOptions.entry[1])).toEqual('./foo.js');
@@ -35,7 +35,7 @@ describe('addEntries util', () => {
 
     expect(webpackOptions.entry.length).toEqual(3);
     expect(
-      normalize(webpackOptions.entry[0]).indexOf('client/default/index.js?') !==
+      normalize(webpackOptions.entry[0]).indexOf('client/entry/index.js?') !==
         -1
     ).toBeTruthy();
     expect(webpackOptions.entry[1]).toEqual('./foo.js');
@@ -58,7 +58,7 @@ describe('addEntries util', () => {
 
     expect(
       normalize(webpackOptions.entry.foo[0]).indexOf(
-        'client/default/index.js?'
+        'client/entry/index.js?'
       ) !== -1
     ).toBeTruthy();
     expect(webpackOptions.entry.foo[1]).toEqual('./foo.js');
@@ -329,7 +329,7 @@ describe('addEntries util', () => {
       if (expectInline) {
         expect(
           normalize(webpackOptions.entry[0]).indexOf(
-            'client/default/index.js?'
+            'client/entry/index.js?'
           ) !== -1
         ).toBeTruthy();
       }
@@ -363,7 +363,7 @@ describe('addEntries util', () => {
       if (expectInline) {
         expect(
           normalize(webpackOptions.entry[0]).indexOf(
-            'client/default/index.js?'
+            'client/entry/index.js?'
           ) !== -1
         ).toBeTruthy();
       }
@@ -421,7 +421,7 @@ describe('addEntries util', () => {
 
     expect(
       normalize(webWebpackOptions.entry[0]).indexOf(
-        'client/default/index.js?'
+        'client/entry/index.js?'
       ) !== -1
     ).toBeTruthy();
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [x] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

Added bundle check test

### Motivation / Use-Case

We want the entire injected client code to be safe for older browsers: https://github.com/webpack/webpack-dev-server/issues/2649

The changes in here are mainly to create a client bundle that acts as a module, then pass the resourceQuery along to it so that everything behaves as it did before

### Breaking Changes

Yes, many breaking changes in client with the whole API, what do you think?

### Additional Info
