### PR TITLE
Fix: ES5 client

### DIFF
--- a/client-src/default/index.js
+++ b/client-src/default/index.js
@@ -6,7 +6,7 @@ window.process = window.process || {};
 window.process.env = window.process.env || {};
 
 /* global __resourceQuery WorkerGlobalScope self */
-const stripAnsi = require('strip-ansi');
+const stripAnsi = require('../transpiled-modules/strip-ansi');
 const socket = require('./socket');
 const overlay = require('./overlay');
 const { log, setLogLevel } = require('./utils/log');

--- a/client-src/default/utils/log.js
+++ b/client-src/default/utils/log.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const log = require('webpack/lib/logging/runtime');
+const log = require('../../transpiled-modules/log');
 
 const name = 'webpack-dev-server';
 // default level is set on the client side, so it does not need

--- a/client-src/transpiled-modules/log.js
+++ b/client-src/transpiled-modules/log.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('webpack/lib/logging/runtime');

--- a/client-src/transpiled-modules/strip-ansi.js
+++ b/client-src/transpiled-modules/strip-ansi.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('strip-ansi');

--- a/client-src/transpiled-modules/webpack.config.js
+++ b/client-src/transpiled-modules/webpack.config.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const path = require('path');
+const merge = require('webpack-merge');
+
+const base = {
+  mode: 'production',
+  output: {
+    path: path.resolve(__dirname, '../../client/transpiled-modules'),
+    libraryTarget: 'commonjs2',
+  },
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        use: [
+          {
+            loader: 'babel-loader',
+          },
+        ],
+      },
+    ],
+  },
+};
+
+module.exports = [
+  merge(base, {
+    entry: path.join(__dirname, 'log.js'),
+    output: {
+      filename: 'log.js',
+    },
+  }),
+  merge(base, {
+    entry: path.join(__dirname, 'strip-ansi.js'),
+    output: {
+      filename: 'strip-ansi.js',
+    },
+  }),
+];

--- a/package-lock.json
+++ b/package-lock.json
@@ -2813,9 +2813,9 @@
       }
     },
     "acorn": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
-      "integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.0.1.tgz",
+      "integrity": "sha512-dmKn4pqZ29iQl2Pvze1zTrps2luvls2PBY//neO2WJ0s10B3AxJXshN+Ph7B4GrhfGhHXrl4dnUwyNNXQcnWGQ==",
       "dev": true
     },
     "acorn-globals": {
@@ -2826,6 +2826,14 @@
       "requires": {
         "acorn": "^7.1.1",
         "acorn-walk": "^7.1.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "7.4.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
+          "integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==",
+          "dev": true
+        }
       }
     },
     "acorn-jsx": {
@@ -6622,6 +6630,14 @@
         "acorn": "^7.3.1",
         "acorn-jsx": "^5.2.0",
         "eslint-visitor-keys": "^1.3.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "7.4.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
+          "integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==",
+          "dev": true
+        }
       }
     },
     "esprima": {
@@ -10308,6 +10324,14 @@
         "whatwg-url": "^8.0.0",
         "ws": "^7.2.3",
         "xml-name-validator": "^3.0.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "7.4.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
+          "integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==",
+          "dev": true
+        }
       }
     },
     "jsesc": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16101,6 +16101,15 @@
         "schema-utils": "^2.7.0"
       }
     },
+    "webpack-merge": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-4.2.2.tgz",
+      "integrity": "sha512-TUE1UGoTX2Cd42j3krGYqObZbOD+xF7u28WB7tfUordytSjbWTIjK/8V0amkBfTYN4/pB/GIDlJZZ657BGG19g==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.15"
+      }
+    },
     "webpack-sources": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -133,11 +133,7 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "bindings": "^1.5.0",
-            "nan": "^2.12.1"
-          }
+          "optional": true
         },
         "glob-parent": {
           "version": "3.1.0",
@@ -3373,16 +3369,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
       "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ=="
-    },
-    "bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "file-uri-to-path": "1.0.0"
-      }
     },
     "bl": {
       "version": "4.0.2",
@@ -7167,13 +7153,6 @@
           }
         }
       }
-    },
-    "file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "dev": true,
-      "optional": true
     },
     "fill-range": {
       "version": "7.0.1",
@@ -11412,13 +11391,6 @@
       "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
       "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE="
     },
-    "nan": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
-      "dev": true,
-      "optional": true
-    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -15493,11 +15465,7 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "bindings": "^1.5.0",
-            "nan": "^2.12.1"
-          }
+          "optional": true
         },
         "glob-parent": {
           "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "build:client:clients": "babel client-src/clients --out-dir client/clients",
     "build:client:index": "webpack --color --config client-src/default/webpack.config.js",
     "build:client:sockjs": "webpack --color --config client-src/sockjs/webpack.config.js",
+    "build:client:transpiled-modules": "webpack --color --config client-src/transpiled-modules/webpack.config.js",
     "build:client": "rimraf ./client/* && npm-run-all -s -l -p \"build:client:**\"",
     "webpack-dev-server": "node examples/run-example.js",
     "release": "standard-version"
@@ -108,7 +109,8 @@
     "typescript": "^3.9.7",
     "url-loader": "^4.1.0",
     "webpack": "^4.44.1",
-    "webpack-cli": "^3.3.12"
+    "webpack-cli": "^3.3.12",
+    "webpack-merge": "^4.2.2"
   },
   "peerDependencies": {
     "webpack": "^4.0.0 || ^5.0.0"

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "@commitlint/cli": "^9.1.2",
     "@commitlint/config-conventional": "^10.0.0",
     "@jest/test-sequencer": "^26.3.0",
+    "acorn": "^8.0.1",
     "babel-jest": "^26.3.0",
     "babel-loader": "^8.1.0",
     "body-parser": "^1.19.0",

--- a/test/client/bundle.test.js
+++ b/test/client/bundle.test.js
@@ -1,0 +1,58 @@
+'use strict';
+
+const acorn = require('acorn');
+const request = require('supertest');
+const testServer = require('../helpers/test-server');
+const config = require('../fixtures/simple-config/webpack.config');
+const port = require('../ports-map').bundle;
+const isWebpack5 = require('../helpers/isWebpack5');
+
+describe('bundle', () => {
+  // the ES5 check test for the bundle will not work on webpack@5,
+  // because webpack@5 bundle output uses some ES6 syntax
+  const runBundleTest = isWebpack5 ? describe.skip : describe;
+
+  runBundleTest('bundled output', () => {
+    let server;
+    let req;
+
+    beforeAll((done) => {
+      server = testServer.start(config, { port }, done);
+      req = request(server.app);
+    });
+
+    afterAll(testServer.close);
+
+    it('should get full user bundle and parse with ES5', async () => {
+      const { text } = await req
+        .get('/main.js')
+        .expect('Content-Type', 'application/javascript; charset=UTF-8')
+        .expect(200);
+
+      expect(() => {
+        let evalStep = 0;
+        acorn.parse(text, {
+          ecmaVersion: 5,
+          onToken: (token) => {
+            if (token.type.label === 'name' && token.value === 'eval') {
+              evalStep += 1;
+            } else if (token.type.label === '(' && evalStep === 1) {
+              evalStep += 1;
+            } else if (token.type.label === 'string' && evalStep === 2) {
+              const program = token.value;
+              try {
+                acorn.parse(program, {
+                  ecmaVersion: 5,
+                });
+              } catch (e) {
+                console.log(program);
+              }
+
+              evalStep = 0;
+            }
+          },
+        });
+      }).not.toThrow();
+    });
+  });
+});

--- a/test/client/bundle.test.js
+++ b/test/client/bundle.test.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const fs = require('fs');
+const path = require('path');
 const acorn = require('acorn');
 const request = require('supertest');
 const testServer = require('../helpers/test-server');
@@ -13,7 +15,21 @@ describe('bundle', () => {
   // only be avoided with babel-loader
   const runBundleTest = isWebpack5 ? describe.skip : describe;
 
-  runBundleTest('bundled output', () => {
+  runBundleTest('index.bundle.js bundled output', () => {
+    it('should parse with ES5', () => {
+      const bundleStr = fs.readFileSync(
+        path.resolve(__dirname, '../../client/default/index.bundle.js'),
+        'utf8'
+      );
+      expect(() => {
+        acorn.parse(bundleStr, {
+          ecmaVersion: 5,
+        });
+      }).not.toThrow();
+    });
+  });
+
+  runBundleTest('main.js bundled output', () => {
     let server;
     let req;
 

--- a/test/client/bundle.test.js
+++ b/test/client/bundle.test.js
@@ -43,7 +43,7 @@ describe('bundle', () => {
     it('should get full user bundle and parse with ES5', async () => {
       const { text } = await req
         .get('/main.js')
-        .expect('Content-Type', 'application/javascript; charset=UTF-8')
+        .expect('Content-Type', 'application/javascript; charset=utf-8')
         .expect(200);
 
       expect(() => {

--- a/test/ports-map.js
+++ b/test/ports-map.js
@@ -42,6 +42,8 @@ const portsList = {
   Iframe: 1,
   SocketInjection: 1,
   'static-publicPath-option': 1,
+  'contentBasePublicPath-option': 1,
+  bundle: 1,
 };
 
 let startPort = 8089;


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [x] This is a **bugfix**
- [ ] This is a **feature**
- [x] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

Yes

### Motivation / Use-Case

We need to make the client work with ES5 for webpack@4. This PR does some case-specific patches, rather than trying to fully solve the problem, since webpack@5 always has ES6 syntax in its bundles, unless the user uses babel-loader.

The `webpack/lib/logging/runtime` and `strip-ansi` modules use ES6, so they are placed in the `transpiled-modules` directory and have files that act as a proxy entry to them. Then, these entry files are turned into a bundle with babel-loader, so that the result is a module that works with ES5 and behaves the same way.


Explanation for the ES5 check test: Since webpack takes all the JavaScript and puts it into a string in an `eval` function, a bundle that will not work with ES5 can still pass a basic ES5 check, since all this bad ES6 syntax is inside of a string. The best course of action for a test I think is to locate these strings in a bundle that `eval` is being run on, then check that they parse with ES5.

https://github.com/webpack/webpack-dev-server/issues/1286 Actually was not fixed on v4 for the reason above, but should be fixed by this PR.

If  you look at the test run below only after the first 2 commits, you can see that the test does not pass because there are still modules being used that don't work with ES5: https://github.com/webpack/webpack-dev-server/pull/2658/files/d01ac6855c0bc20f23054c9ca8832eea2539588d

### Breaking Changes

None, client API is the same

### Additional Info
