### PR TITLE
BREAKING CHANGES: create static option and remove replaced options

### DIFF
--- a/bin/cli-flags.js
+++ b/bin/cli-flags.js
@@ -81,7 +81,7 @@ module.exports = {
     {
       name: 'static',
       type: String,
-      describe: 'A directory or URL to serve HTML content from.',
+      describe: 'A directory to serve static content from.',
       group: RESPONSE_GROUP,
       multiple: true,
     },

--- a/bin/cli-flags.js
+++ b/bin/cli-flags.js
@@ -21,7 +21,7 @@ module.exports = {
       describe: 'Enables/Disables live reloading on changing files',
     },
     {
-      name: 'serveIndex',
+      name: 'static-serve-index',
       type: Boolean,
       describe: 'Enables/Disables serveIndex middleware',
       defaultValue: true,
@@ -85,15 +85,15 @@ module.exports = {
       describe: 'HTTP/2, must be used with HTTPS',
     },
     {
-      name: 'content-base',
+      name: 'static-directory',
       type: String,
       describe: 'A directory or URL to serve HTML content from.',
       group: RESPONSE_GROUP,
     },
     {
-      name: 'watch-content-base',
+      name: 'static-watch',
       type: Boolean,
-      describe: 'Enable live-reloading of the content-base.',
+      describe: 'Enable live-reloading of the static directory.',
       group: RESPONSE_GROUP,
     },
     {

--- a/bin/cli-flags.js
+++ b/bin/cli-flags.js
@@ -21,12 +21,6 @@ module.exports = {
       describe: 'Enables/Disables live reloading on changing files',
     },
     {
-      name: 'static-serve-index',
-      type: Boolean,
-      describe: 'Enables/Disables serveIndex middleware',
-      defaultValue: true,
-    },
-    {
       name: 'profile',
       type: Boolean,
       describe: 'Print compilation profile data for progress steps',
@@ -85,15 +79,9 @@ module.exports = {
       describe: 'HTTP/2, must be used with HTTPS',
     },
     {
-      name: 'static-directory',
+      name: 'static',
       type: String,
       describe: 'A directory or URL to serve HTML content from.',
-      group: RESPONSE_GROUP,
-    },
-    {
-      name: 'static-watch',
-      type: Boolean,
-      describe: 'Enable live-reloading of the static directory.',
       group: RESPONSE_GROUP,
     },
     {

--- a/bin/cli-flags.js
+++ b/bin/cli-flags.js
@@ -83,6 +83,7 @@ module.exports = {
       type: String,
       describe: 'A directory or URL to serve HTML content from.',
       group: RESPONSE_GROUP,
+      multiple: true,
     },
     {
       name: 'history-api-fallback',

--- a/bin/options.js
+++ b/bin/options.js
@@ -17,7 +17,7 @@ const options = {
     describe: 'Enables/Disables live reloading on changing files',
     default: true,
   },
-  serveIndex: {
+  'static-serve-index': {
     type: 'boolean',
     describe: 'Enables/Disables serveIndex middleware',
     default: true,
@@ -75,14 +75,14 @@ const options = {
     group: SSL_GROUP,
     describe: 'HTTP/2, must be used with HTTPS',
   },
-  'content-base': {
+  'static-directory': {
     type: 'string',
     describe: 'A directory or URL to serve HTML content from.',
     group: RESPONSE_GROUP,
   },
-  'watch-content-base': {
+  'static-watch': {
     type: 'boolean',
-    describe: 'Enable live-reloading of the content-base.',
+    describe: 'Enable live-reloading of the static directory.',
     group: RESPONSE_GROUP,
   },
   'history-api-fallback': {

--- a/bin/options.js
+++ b/bin/options.js
@@ -72,8 +72,7 @@ const options = {
   },
   static: {
     type: 'string',
-    describe:
-      'A comma-delimited string of directories to serve static content from.',
+    describe: 'A directory to serve static content from.',
     group: RESPONSE_GROUP,
   },
   'history-api-fallback': {

--- a/bin/options.js
+++ b/bin/options.js
@@ -17,11 +17,6 @@ const options = {
     describe: 'Enables/Disables live reloading on changing files',
     default: true,
   },
-  'static-serve-index': {
-    type: 'boolean',
-    describe: 'Enables/Disables serveIndex middleware',
-    default: true,
-  },
   profile: {
     type: 'boolean',
     describe: 'Print compilation profile data for progress steps',
@@ -75,14 +70,9 @@ const options = {
     group: SSL_GROUP,
     describe: 'HTTP/2, must be used with HTTPS',
   },
-  'static-directory': {
+  static: {
     type: 'string',
     describe: 'A directory or URL to serve HTML content from.',
-    group: RESPONSE_GROUP,
-  },
-  'static-watch': {
-    type: 'boolean',
-    describe: 'Enable live-reloading of the static directory.',
     group: RESPONSE_GROUP,
   },
   'history-api-fallback': {

--- a/bin/options.js
+++ b/bin/options.js
@@ -72,7 +72,8 @@ const options = {
   },
   static: {
     type: 'string',
-    describe: 'A directory or URL to serve HTML content from.',
+    describe:
+      'A comma-delimited string of directories to serve static content from.',
     group: RESPONSE_GROUP,
   },
   'history-api-fallback': {

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,7 +5,7 @@ module.exports = {
   collectCoverage: false,
   coveragePathIgnorePatterns: ['test', '<rootDir>/node_modules'],
   moduleFileExtensions: ['js', 'json'],
-  testMatch: ['**/test/**/*.test.js'],
+  testMatch: ['**/test/e2e/Socket-injection.test.js'],
   setupFilesAfterEnv: ['<rootDir>/setupTest.js'],
   globalSetup: '<rootDir>/globalSetupTest.js',
   testSequencer: '<rootDir>/test/testSequencer.js',

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,7 +5,7 @@ module.exports = {
   collectCoverage: false,
   coveragePathIgnorePatterns: ['test', '<rootDir>/node_modules'],
   moduleFileExtensions: ['js', 'json'],
-  testMatch: ['**/test/e2e/Socket-injection.test.js'],
+  testMatch: ['**/test/**/*.test.js'],
   setupFilesAfterEnv: ['<rootDir>/setupTest.js'],
   globalSetup: '<rootDir>/globalSetupTest.js',
   testSequencer: '<rootDir>/test/testSequencer.js',

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -309,26 +309,7 @@ class Server {
           publicPath,
           express.static(staticOption.directory, staticOption.staticOptions)
         );
-
-        if (staticOption.serveIndex) {
-          this.app.use(publicPath, (req, res, next) => {
-            // serve-index doesn't fallthrough non-get/head request to next middleware
-            if (req.method !== 'GET' && req.method !== 'HEAD') {
-              return next();
-            }
-
-            serveIndex(staticOption.directory, staticOption.serveIndex)(
-              req,
-              res,
-              next
-            );
-          });
-        }
       });
-
-      if (staticOption.watch) {
-        this.watchFiles(staticOption.directory, staticOption.watch);
-      }
     });
   }
 
@@ -350,10 +331,6 @@ class Server {
           });
         }
       });
-
-      if (staticOption.watch) {
-        this.watchFiles(staticOption.directory, staticOption.watch);
-      }
     });
   }
 
@@ -405,6 +382,12 @@ class Server {
       static: () => {
         this.setupStaticFeature();
       },
+      serveIndex: () => {
+        this.setupServeIndexFeature();
+      },
+      watchStatic: () => {
+        this.setupWatchStaticFeature();
+      },
       onBeforeSetupMiddleware: () => {
         if (typeof this.options.onBeforeSetupMiddleware === 'function') {
           this.setupOnBeforeSetupMiddlewareFeature();
@@ -439,20 +422,26 @@ class Server {
       runnableFeatures.push('onBeforeSetupMiddleware');
     }
 
-    runnableFeatures.push('headers');
+    runnableFeatures.push('headers', 'middleware');
 
     if (this.options.proxy) {
-      runnableFeatures.push('proxy');
+      runnableFeatures.push('proxy', 'middleware');
     }
-
-    if (this.options.historyApiFallback) {
-      runnableFeatures.push('historyApiFallback');
-    }
-
-    runnableFeatures.push('middleware');
 
     if (this.options.static) {
       runnableFeatures.push('static');
+    }
+
+    if (this.options.historyApiFallback) {
+      runnableFeatures.push('historyApiFallback', 'middleware');
+
+      if (this.options.static) {
+        runnableFeatures.push('static');
+      }
+    }
+
+    if (this.options.static) {
+      runnableFeatures.push('serveIndex', 'watchStatic');
     }
 
     runnableFeatures.push('magicHtml');

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -320,7 +320,7 @@ class Server {
       });
 
       if (staticOption.watch) {
-        this._watch(staticOption.directory, staticOption.watch);
+        this.watchFiles(staticOption.directory, staticOption.watch);
       }
     });
   }
@@ -807,7 +807,7 @@ class Server {
     }
   }
 
-  _watch(watchPath, watchOptions) {
+  watchFiles(watchPath, watchOptions) {
     // duplicate the same massaging of options that watchpack performs
     // https://github.com/webpack/watchpack/blob/master/lib/DirectoryWatcher.js#L49
     // this isn't an elegant solution, but we'll improve it in the future

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -18,7 +18,6 @@ const webpackDevMiddleware = require('webpack-dev-middleware');
 const getFilenameFromUrl = require('webpack-dev-middleware/dist/utils/getFilenameFromUrl')
   .default;
 const validateOptions = require('schema-utils');
-const isAbsoluteUrl = require('is-absolute-url');
 const normalizeOptions = require('./utils/normalizeOptions');
 const updateCompiler = require('./utils/updateCompiler');
 const getCertificate = require('./utils/getCertificate');
@@ -304,112 +303,37 @@ class Server {
   }
 
   setupStaticFeature() {
-    const contentBase = this.options.contentBase;
-    const contentBasePublicPath = this.options.contentBasePublicPath;
+    this.options.static.forEach((staticOption) => {
+      staticOption.publicPath.forEach((publicPath) => {
+        this.app.use(
+          publicPath,
+          express.static(staticOption.directory, staticOption.staticOptions)
+        );
 
-    if (Array.isArray(contentBase)) {
-      contentBase.forEach((item, index) => {
-        let publicPath = contentBasePublicPath;
-
-        if (
-          Array.isArray(contentBasePublicPath) &&
-          contentBasePublicPath[index]
-        ) {
-          publicPath = contentBasePublicPath[index] || contentBasePublicPath[0];
+        if (staticOption.serveIndex) {
+          this.setupServeIndexFeature(
+            staticOption.serveIndex,
+            staticOption.directory,
+            publicPath
+          );
         }
-
-        this.app.use(publicPath, express.static(item));
       });
-    } else if (isAbsoluteUrl(String(contentBase))) {
-      this.logger.warn(
-        'Using a URL as contentBase is deprecated and will be removed in the next major version. Please use the proxy option instead.'
-      );
 
-      this.logger.warn(
-        'proxy: {\n\t"*": "<your current contentBase configuration>"\n}'
-      );
-
-      // Redirect every request to contentBase
-      this.app.get('*', (req, res) => {
-        res.writeHead(302, {
-          Location: contentBase + req.path + (req._parsedUrl.search || ''),
-        });
-
-        res.end();
-      });
-    } else if (typeof contentBase === 'number') {
-      this.logger.warn(
-        'Using a number as contentBase is deprecated and will be removed in the next major version. Please use the proxy option instead.'
-      );
-
-      this.logger.warn(
-        'proxy: {\n\t"*": "//localhost:<your current contentBase configuration>"\n}'
-      );
-
-      // Redirect every request to the port contentBase
-      this.app.get('*', (req, res) => {
-        res.writeHead(302, {
-          Location: `//localhost:${contentBase}${req.path}${
-            req._parsedUrl.search || ''
-          }`,
-        });
-
-        res.end();
-      });
-    } else {
-      // route content request
-      this.app.use(
-        contentBasePublicPath,
-        express.static(contentBase, this.options.staticOptions)
-      );
-    }
+      if (staticOption.watch) {
+        this._watch(staticOption.directory, staticOption.watch);
+      }
+    });
   }
 
-  setupServeIndexFeature() {
-    const contentBase = this.options.contentBase;
-    const contentBasePublicPath = this.options.contentBasePublicPath;
+  setupServeIndexFeature(serveIndexOption, directory, publicPath) {
+    this.app.use(publicPath, (req, res, next) => {
+      // serve-index doesn't fallthrough non-get/head request to next middleware
+      if (req.method !== 'GET' && req.method !== 'HEAD') {
+        return next();
+      }
 
-    if (Array.isArray(contentBase)) {
-      contentBase.forEach((item) => {
-        this.app.use(contentBasePublicPath, (req, res, next) => {
-          // serve-index doesn't fallthrough non-get/head request to next middleware
-          if (req.method !== 'GET' && req.method !== 'HEAD') {
-            return next();
-          }
-
-          serveIndex(item, { icons: true })(req, res, next);
-        });
-      });
-    } else if (
-      typeof contentBase !== 'number' &&
-      !isAbsoluteUrl(String(contentBase))
-    ) {
-      this.app.use(contentBasePublicPath, (req, res, next) => {
-        // serve-index doesn't fallthrough non-get/head request to next middleware
-        if (req.method !== 'GET' && req.method !== 'HEAD') {
-          return next();
-        }
-
-        serveIndex(contentBase, { icons: true })(req, res, next);
-      });
-    }
-  }
-
-  setupWatchStaticFeature() {
-    const contentBase = this.options.contentBase;
-
-    if (isAbsoluteUrl(String(contentBase)) || typeof contentBase === 'number') {
-      throw new Error('Watching remote files is not supported.');
-    } else if (Array.isArray(contentBase)) {
-      contentBase.forEach((item) => {
-        if (isAbsoluteUrl(String(item)) || typeof item === 'number') {
-          throw new Error('Watching remote files is not supported.');
-        }
-        this._watch(item);
-      });
-    } else {
-      this._watch(contentBase);
-    }
+      serveIndex(directory, serveIndexOption)(req, res, next);
+    });
   }
 
   setupOnBeforeSetupMiddlewareFeature() {
@@ -450,16 +374,8 @@ class Server {
         }
       },
       // Todo rename to `static` in future major release
-      contentBaseFiles: () => {
+      static: () => {
         this.setupStaticFeature();
-      },
-      // Todo rename to `serveIndex` in future major release
-      contentBaseIndex: () => {
-        this.setupServeIndexFeature();
-      },
-      // Todo rename to `watchStatic` in future major release
-      watchContentBase: () => {
-        this.setupWatchStaticFeature();
       },
       onBeforeSetupMiddleware: () => {
         if (typeof this.options.onBeforeSetupMiddleware === 'function') {
@@ -501,24 +417,12 @@ class Server {
       runnableFeatures.push('proxy', 'middleware');
     }
 
-    if (this.options.contentBase !== false) {
-      runnableFeatures.push('contentBaseFiles');
+    if (this.options.static) {
+      runnableFeatures.push('static');
     }
 
     if (this.options.historyApiFallback) {
       runnableFeatures.push('historyApiFallback', 'middleware');
-
-      if (this.options.contentBase !== false) {
-        runnableFeatures.push('contentBaseFiles');
-      }
-    }
-
-    if (this.options.contentBase && this.options.serveIndex) {
-      runnableFeatures.push('contentBaseIndex');
-    }
-
-    if (this.options.watchContentBase) {
-      runnableFeatures.push('watchContentBase');
     }
 
     runnableFeatures.push('magicHtml');
@@ -903,31 +807,31 @@ class Server {
     }
   }
 
-  _watch(watchPath) {
+  _watch(watchPath, watchOptions) {
     // duplicate the same massaging of options that watchpack performs
     // https://github.com/webpack/watchpack/blob/master/lib/DirectoryWatcher.js#L49
     // this isn't an elegant solution, but we'll improve it in the future
     // eslint-disable-next-line no-undefined
-    const usePolling = this.options.watchOptions.poll ? true : undefined;
+    const usePolling = watchOptions.poll ? true : undefined;
     const interval =
-      typeof this.options.watchOptions.poll === 'number'
-        ? this.options.watchOptions.poll
+      typeof watchOptions.poll === 'number'
+        ? watchOptions.poll
         : // eslint-disable-next-line no-undefined
           undefined;
 
-    const watchOptions = {
+    const finalWatchOptions = {
       ignoreInitial: true,
       persistent: true,
       followSymlinks: false,
       atomic: false,
       alwaysStat: true,
       ignorePermissionErrors: true,
-      ignored: this.options.watchOptions.ignored,
+      ignored: watchOptions.ignored,
       usePolling,
       interval,
     };
 
-    const watcher = chokidar.watch(watchPath, watchOptions);
+    const watcher = chokidar.watch(watchPath, finalWatchOptions);
     // disabling refreshing on changing the content
     if (this.options.liveReload) {
       watcher.on('change', () => {

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -52,6 +52,10 @@ class Server {
     normalizeOptions(this.compiler, this.options);
     updateCompiler(this.compiler, this.options);
 
+    if (options.static) {
+      console.log(options.static);
+    }
+
     this.SocketServerImplementation = getSocketServerImplementation(
       this.options
     );

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -313,7 +313,7 @@ class Server {
     });
   }
 
-  setupServeIndexFeature() {
+  setupStaticServeIndexFeature() {
     this.options.static.forEach((staticOption) => {
       staticOption.publicPath.forEach((publicPath) => {
         if (staticOption.serveIndex) {
@@ -334,7 +334,7 @@ class Server {
     });
   }
 
-  setupWatchStaticFeature() {
+  setupStaticWatchFeature() {
     this.options.static.forEach((staticOption) => {
       if (staticOption.watch) {
         this.watchFiles(staticOption.directory, staticOption.watch);
@@ -383,10 +383,10 @@ class Server {
         this.setupStaticFeature();
       },
       staticServeIndex: () => {
-        this.setupServeIndexFeature();
+        this.setupStaticServeIndexFeature();
       },
       staticWatch: () => {
-        this.setupWatchStaticFeature();
+        this.setupStaticWatchFeature();
       },
       onBeforeSetupMiddleware: () => {
         if (typeof this.options.onBeforeSetupMiddleware === 'function') {

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -309,6 +309,21 @@ class Server {
           publicPath,
           express.static(staticOption.directory, staticOption.staticOptions)
         );
+
+        if (staticOption.serveIndex) {
+          this.app.use(publicPath, (req, res, next) => {
+            // serve-index doesn't fallthrough non-get/head request to next middleware
+            if (req.method !== 'GET' && req.method !== 'HEAD') {
+              return next();
+            }
+
+            serveIndex(staticOption.directory, staticOption.serveIndex)(
+              req,
+              res,
+              next
+            );
+          });
+        }
       });
     });
   }
@@ -331,6 +346,10 @@ class Server {
           });
         }
       });
+
+      if (staticOption.watch) {
+        this.watchFiles(staticOption.directory, staticOption.watch);
+      }
     });
   }
 
@@ -382,12 +401,6 @@ class Server {
       static: () => {
         this.setupStaticFeature();
       },
-      serveIndex: () => {
-        this.setupServeIndexFeature();
-      },
-      watchStatic: () => {
-        this.setupWatchStaticFeature();
-      },
       onBeforeSetupMiddleware: () => {
         if (typeof this.options.onBeforeSetupMiddleware === 'function') {
           this.setupOnBeforeSetupMiddlewareFeature();
@@ -422,26 +435,20 @@ class Server {
       runnableFeatures.push('onBeforeSetupMiddleware');
     }
 
-    runnableFeatures.push('headers', 'middleware');
+    runnableFeatures.push('headers');
 
     if (this.options.proxy) {
-      runnableFeatures.push('proxy', 'middleware');
-    }
-
-    if (this.options.static) {
-      runnableFeatures.push('static');
+      runnableFeatures.push('proxy');
     }
 
     if (this.options.historyApiFallback) {
-      runnableFeatures.push('historyApiFallback', 'middleware');
-
-      if (this.options.static) {
-        runnableFeatures.push('static');
-      }
+      runnableFeatures.push('historyApiFallback');
     }
 
+    runnableFeatures.push('middleware');
+
     if (this.options.static) {
-      runnableFeatures.push('serveIndex', 'watchStatic');
+      runnableFeatures.push('static');
     }
 
     runnableFeatures.push('magicHtml');

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -52,10 +52,6 @@ class Server {
     normalizeOptions(this.compiler, this.options);
     updateCompiler(this.compiler, this.options);
 
-    if (options.static) {
-      console.log(options.static);
-    }
-
     this.SocketServerImplementation = getSocketServerImplementation(
       this.options
     );

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -309,30 +309,36 @@ class Server {
           publicPath,
           express.static(staticOption.directory, staticOption.staticOptions)
         );
-
-        if (staticOption.serveIndex) {
-          this.setupServeIndexFeature(
-            staticOption.serveIndex,
-            staticOption.directory,
-            publicPath
-          );
-        }
       });
-
-      if (staticOption.watch) {
-        this.watchFiles(staticOption.directory, staticOption.watch);
-      }
     });
   }
 
-  setupServeIndexFeature(serveIndexOption, directory, publicPath) {
-    this.app.use(publicPath, (req, res, next) => {
-      // serve-index doesn't fallthrough non-get/head request to next middleware
-      if (req.method !== 'GET' && req.method !== 'HEAD') {
-        return next();
-      }
+  setupServeIndexFeature() {
+    this.options.static.forEach((staticOption) => {
+      staticOption.publicPath.forEach((publicPath) => {
+        if (staticOption.serveIndex) {
+          this.app.use(publicPath, (req, res, next) => {
+            // serve-index doesn't fallthrough non-get/head request to next middleware
+            if (req.method !== 'GET' && req.method !== 'HEAD') {
+              return next();
+            }
 
-      serveIndex(directory, serveIndexOption)(req, res, next);
+            serveIndex(staticOption.directory, staticOption.serveIndex)(
+              req,
+              res,
+              next
+            );
+          });
+        }
+      });
+    });
+  }
+
+  setupWatchStaticFeature() {
+    this.options.static.forEach((staticOption) => {
+      if (staticOption.watch) {
+        this.watchFiles(staticOption.directory, staticOption.watch);
+      }
     });
   }
 
@@ -373,9 +379,14 @@ class Server {
           this.setupHistoryApiFallbackFeature();
         }
       },
-      // Todo rename to `static` in future major release
       static: () => {
         this.setupStaticFeature();
+      },
+      serveIndex: () => {
+        this.setupServeIndexFeature();
+      },
+      watchStatic: () => {
+        this.setupWatchStaticFeature();
       },
       onBeforeSetupMiddleware: () => {
         if (typeof this.options.onBeforeSetupMiddleware === 'function') {
@@ -423,6 +434,14 @@ class Server {
 
     if (this.options.historyApiFallback) {
       runnableFeatures.push('historyApiFallback', 'middleware');
+
+      if (this.options.static) {
+        runnableFeatures.push('static');
+      }
+    }
+
+    if (this.options.static) {
+      runnableFeatures.push('serveIndex', 'watchStatic');
     }
 
     runnableFeatures.push('magicHtml');

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -382,10 +382,10 @@ class Server {
       static: () => {
         this.setupStaticFeature();
       },
-      serveIndex: () => {
+      staticServeIndex: () => {
         this.setupServeIndexFeature();
       },
-      watchStatic: () => {
+      staticWatch: () => {
         this.setupWatchStaticFeature();
       },
       onBeforeSetupMiddleware: () => {
@@ -441,7 +441,7 @@ class Server {
     }
 
     if (this.options.static) {
-      runnableFeatures.push('serveIndex', 'watchStatic');
+      runnableFeatures.push('staticServeIndex', 'staticWatch');
     }
 
     runnableFeatures.push('magicHtml');

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -325,6 +325,10 @@ class Server {
           });
         }
       });
+
+      if (staticOption.watch) {
+        this.watchFiles(staticOption.directory, staticOption.watch);
+      }
     });
   }
 

--- a/lib/options.json
+++ b/lib/options.json
@@ -41,8 +41,7 @@
             }
           ]
         }
-      },
-      "required": ["directory"]
+      }
     },
     "StaticString": {
       "type": "string",

--- a/lib/options.json
+++ b/lib/options.json
@@ -41,20 +41,6 @@
     "compress": {
       "type": "boolean"
     },
-    "contentBasePublicPath": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "minItems": 1
-        }
-      ]
-    },
     "contentBase": {
       "anyOf": [
         {
@@ -296,11 +282,74 @@
     "public": {
       "type": "string"
     },
-    "serveIndex": {
-      "type": "boolean"
-    },
-    "staticOptions": {
-      "type": "object"
+    "static": {
+      "anyOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "directory": {
+              "type": "string",
+              "minLength": 1
+            },
+            "staticOptions": {
+              "type": "object"
+            },
+            "publicPath": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 1
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "minItems": 1
+                }
+              ]
+            },
+            "serveIndex": {
+              "type": "boolean"
+            },
+            "watch": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "object"
+                }
+              ]
+            }
+          },
+          "required": ["directory"]
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "string",
+          "minLength": 1
+        },
+        {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1
+              },
+              {
+                "type": "object"
+              }
+            ]
+          },
+          "minItems": 1
+        }
+      ]
     },
     "transportMode": {
       "anyOf": [
@@ -330,12 +379,6 @@
     },
     "useLocalIp": {
       "type": "boolean"
-    },
-    "watchContentBase": {
-      "type": "boolean"
-    },
-    "watchOptions": {
-      "type": "object"
     }
   },
   "errorMessage": {
@@ -367,13 +410,9 @@
       "progress": "should be {Boolean} (https://webpack.js.org/configuration/dev-server/#devserverprogress---cli-only)",
       "proxy": "should be {Object|Array} (https://webpack.js.org/configuration/dev-server/#devserverproxy)",
       "public": "should be {String} (https://webpack.js.org/configuration/dev-server/#devserverpublic)",
-      "contentBasePublicPath": "should be {String|Array} (https://webpack.js.org/configuration/dev-server/#devservercontentbasepublicpath)",
-      "serveIndex": "should be {Boolean} (https://webpack.js.org/configuration/dev-server/#devserverserveindex)",
-      "staticOptions": "should be {Object} (https://webpack.js.org/configuration/dev-server/#devserverstaticoptions)",
+      "static": "should be {Boolean|String|Object|Array} (https://webpack.js.org/configuration/dev-server/#devserverstatic)",
       "transportMode": "should be {String|Object} (https://webpack.js.org/configuration/dev-server/#devservertransportmode)",
-      "useLocalIp": "should be {Boolean} (https://webpack.js.org/configuration/dev-server/#devserveruselocalip)",
-      "watchContentBase": "should be {Boolean} (https://webpack.js.org/configuration/dev-server/#devserverwatchcontentbase)",
-      "watchOptions": "should be {Object} (https://webpack.js.org/configuration/dev-server/#devserverwatchoptions)"
+      "useLocalIp": "should be {Boolean} (https://webpack.js.org/configuration/dev-server/#devserveruselocalip)"
     }
   },
   "additionalProperties": false

--- a/lib/options.json
+++ b/lib/options.json
@@ -29,7 +29,14 @@
           ]
         },
         "serveIndex": {
-          "type": "boolean"
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "object"
+            }
+          ]
         },
         "watch": {
           "anyOf": [

--- a/lib/options.json
+++ b/lib/options.json
@@ -41,26 +41,6 @@
     "compress": {
       "type": "boolean"
     },
-    "contentBase": {
-      "anyOf": [
-        {
-          "enum": [false]
-        },
-        {
-          "type": "number"
-        },
-        {
-          "type": "string"
-        },
-        {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "minItems": 1
-        }
-      ]
-    },
     "dev": {
       "type": "object"
     },
@@ -387,7 +367,6 @@
       "bonjour": "should be {Boolean} (https://webpack.js.org/configuration/dev-server/#devserverbonjour)",
       "client": "should be {Object} (https://webpack.js.org/configuration/dev-server/#devserverclient)",
       "compress": "should be {Boolean} (https://webpack.js.org/configuration/dev-server/#devservercompress)",
-      "contentBase": "should be {Number|String|Array} (https://webpack.js.org/configuration/dev-server/#devservercontentbase)",
       "dev": "should be {Object} (https://webpack.js.org/configuration/dev-server/#devserverdev-)",
       "disableHostCheck": "should be {Boolean} (https://webpack.js.org/configuration/dev-server/#devserverdisablehostcheck)",
       "headers": "should be {Object} (https://webpack.js.org/configuration/dev-server/#devserverheaders)",

--- a/lib/options.json
+++ b/lib/options.json
@@ -1,5 +1,54 @@
 {
   "type": "object",
+  "definitions": {
+    "StaticObject": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "directory": {
+          "type": "string",
+          "minLength": 1
+        },
+        "staticOptions": {
+          "type": "object"
+        },
+        "publicPath": {
+          "anyOf": [
+            {
+              "type": "string",
+              "minLength": 1
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              },
+              "minItems": 1
+            }
+          ]
+        },
+        "serveIndex": {
+          "type": "boolean"
+        },
+        "watch": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "object"
+            }
+          ]
+        }
+      },
+      "required": ["directory"]
+    },
+    "StaticString": {
+      "type": "string",
+      "minLength": 1
+    }
+  },
   "properties": {
     "allowedHosts": {
       "type": "array",
@@ -265,65 +314,23 @@
     "static": {
       "anyOf": [
         {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "directory": {
-              "type": "string",
-              "minLength": 1
-            },
-            "staticOptions": {
-              "type": "object"
-            },
-            "publicPath": {
-              "anyOf": [
-                {
-                  "type": "string",
-                  "minLength": 1
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "minItems": 1
-                }
-              ]
-            },
-            "serveIndex": {
-              "type": "boolean"
-            },
-            "watch": {
-              "anyOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "type": "object"
-                }
-              ]
-            }
-          },
-          "required": ["directory"]
-        },
-        {
           "type": "boolean"
         },
         {
-          "type": "string",
-          "minLength": 1
+          "$ref": "#/definitions/StaticString"
+        },
+        {
+          "$ref": "#/definitions/StaticObject"
         },
         {
           "type": "array",
           "items": {
             "anyOf": [
               {
-                "type": "string",
-                "minLength": 1
+                "$ref": "#/definitions/StaticString"
               },
               {
-                "type": "object"
+                "$ref": "#/definitions/StaticObject"
               }
             ]
           },

--- a/lib/utils/createConfig.js
+++ b/lib/utils/createConfig.js
@@ -73,7 +73,11 @@ function createConfig(config, argv, { port }) {
   if (argv.static === false) {
     options.static = false;
   } else if (argv.static) {
-    options.static = argv.static.split(',');
+    if (Array.isArray(argv.static)) {
+      options.static = argv.static;
+    } else {
+      options.static = [argv.static];
+    }
     options.static = options.static.map((staticDir) => path.resolve(staticDir));
   }
 

--- a/lib/utils/createConfig.js
+++ b/lib/utils/createConfig.js
@@ -73,7 +73,8 @@ function createConfig(config, argv, { port }) {
   if (argv.static === false) {
     options.static = false;
   } else if (argv.static) {
-    options.static = path.resolve(argv.static);
+    options.static = argv.static.split(',');
+    options.static = options.static.map((staticDir) => path.resolve(staticDir));
   }
 
   if (argv.https) {

--- a/lib/utils/createConfig.js
+++ b/lib/utils/createConfig.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const path = require('path');
-const isAbsoluteUrl = require('is-absolute-url');
 const defaultTo = require('./defaultTo');
 
 function createConfig(config, argv, { port }) {
@@ -71,25 +70,10 @@ function createConfig(config, argv, { port }) {
     }
   }
 
-  if (argv.contentBase) {
-    options.contentBase = argv.contentBase;
-
-    if (Array.isArray(options.contentBase)) {
-      options.contentBase = options.contentBase.map((p) => path.resolve(p));
-    } else if (/^[0-9]$/.test(options.contentBase)) {
-      options.contentBase = +options.contentBase;
-    } else if (!isAbsoluteUrl(String(options.contentBase))) {
-      options.contentBase = path.resolve(options.contentBase);
-    }
-  }
-  // It is possible to disable the contentBase by using
-  // `--no-content-base`, which results in arg["content-base"] = false
-  else if (argv.contentBase === false) {
-    options.contentBase = false;
-  }
-
-  if (argv.watchContentBase) {
-    options.watchContentBase = true;
+  if (argv.static === false) {
+    options.static = false;
+  } else if (argv.static) {
+    options.static = path.resolve(argv.static);
   }
 
   if (argv.https) {

--- a/lib/utils/createConfig.js
+++ b/lib/utils/createConfig.js
@@ -45,10 +45,6 @@ function createConfig(config, argv, { port }) {
 
   options.dev = options.dev || {};
 
-  if (!options.watchOptions && firstWpOpt.watchOptions) {
-    options.watchOptions = firstWpOpt.watchOptions;
-  }
-
   if (argv.stdin) {
     process.stdin.on('end', () => {
       // eslint-disable-next-line no-process-exit

--- a/lib/utils/normalizeOptions.js
+++ b/lib/utils/normalizeOptions.js
@@ -12,7 +12,6 @@ function normalizeOptions(compiler, options) {
   const watchOptions = watchOptionsConfig
     ? watchOptionsConfig.watchOptions
     : {};
-  console.log(compiler.options.watch);
   const defaultOptionsForStatic = {
     directory: process.cwd(),
     staticOptions: {},

--- a/lib/utils/normalizeOptions.js
+++ b/lib/utils/normalizeOptions.js
@@ -2,14 +2,40 @@
 
 function normalizeOptions(compiler, options) {
   // Setup default value
-  options.serveIndex =
-    typeof options.serveIndex !== 'undefined' ? options.serveIndex : true;
-  options.contentBase =
-    typeof options.contentBase !== 'undefined'
-      ? options.contentBase
-      : process.cwd();
-  options.contentBasePublicPath = options.contentBasePublicPath || '/';
-  options.watchOptions = options.watchOptions || {};
+  const defaultStaticDirectory = process.cwd();
+
+  if (typeof options.static === 'undefined' || options.static === true) {
+    options.static = {
+      directory: defaultStaticDirectory,
+    };
+  } else if (typeof options.static === 'string') {
+    options.static = {
+      directory: options.static,
+    };
+  } else if (
+    typeof options.static === 'object' &&
+    options.static instanceof Array
+  ) {
+    // what should be done with the array?
+  }
+
+  // options.static is now either an object (with directory property set) or false
+  if (options.static) {
+    options.static.serveIndex =
+      typeof options.static.serveIndex !== 'undefined'
+        ? options.static.serveIndex
+        : true;
+
+    options.static.publicPath = options.static.publicPath || '/';
+
+    if (
+      typeof options.static.watch === 'undefined' ||
+      options.static.watch === true
+    ) {
+      options.static.watch = {};
+    }
+  }
+
   options.hot =
     typeof options.hot === 'boolean' || options.hot === 'only'
       ? options.hot

--- a/lib/utils/normalizeOptions.js
+++ b/lib/utils/normalizeOptions.js
@@ -12,6 +12,7 @@ function normalizeOptions(compiler, options) {
   const watchOptions = watchOptionsConfig
     ? watchOptionsConfig.watchOptions
     : {};
+
   const defaultOptionsForStatic = {
     directory: process.cwd(),
     staticOptions: {},

--- a/lib/utils/normalizeOptions.js
+++ b/lib/utils/normalizeOptions.js
@@ -1,39 +1,68 @@
 'use strict';
 
-function normalizeOptions(compiler, options) {
-  // Setup default value
-  const defaultStaticDirectory = process.cwd();
+const isAbsoluteUrl = require('is-absolute-url');
+const getCompilerConfigArray = require('./getCompilerConfigArray');
 
-  if (typeof options.static === 'undefined' || options.static === true) {
-    options.static = {
-      directory: defaultStaticDirectory,
-    };
+function normalizeOptions(compiler, options) {
+  // TODO: improve this to not use .find for compiler watchOptions
+  const configArr = getCompilerConfigArray(compiler);
+  const watchOptionsConfig = configArr.find(
+    (config) => config.watch !== false && config.watchOptions
+  );
+  const watchOptions = watchOptionsConfig
+    ? watchOptionsConfig.watchOptions
+    : {};
+  console.log(compiler.options.watch);
+  const defaultOptionsForStatic = {
+    directory: process.cwd(),
+    staticOptions: {},
+    publicPath: ['/'],
+    serveIndex: { icons: true },
+    // Respect options from compiler watchOptions
+    watch: watchOptions,
+  };
+
+  if (typeof options.static === 'undefined') {
+    options.static = [defaultOptionsForStatic];
+  } else if (typeof options.static === 'boolean') {
+    options.static = options.static ? [defaultOptionsForStatic] : false;
   } else if (typeof options.static === 'string') {
-    options.static = {
-      directory: options.static,
-    };
-  } else if (
-    typeof options.static === 'object' &&
-    options.static instanceof Array
-  ) {
-    // what should be done with the array?
+    options.static = [
+      { ...defaultOptionsForStatic, directory: options.static },
+    ];
+  } else if (Array.isArray(options.static)) {
+    options.static = options.static.map((item) => {
+      if (typeof item === 'string') {
+        return { ...defaultOptionsForStatic, directory: item };
+      }
+
+      return { ...defaultOptionsForStatic, ...item };
+    });
+  } else {
+    options.static = [{ ...defaultOptionsForStatic, ...options.static }];
   }
 
-  // options.static is now either an object (with directory property set) or false
   if (options.static) {
-    options.static.serveIndex =
-      typeof options.static.serveIndex !== 'undefined'
-        ? options.static.serveIndex
-        : true;
+    options.static.forEach((staticOption) => {
+      if (isAbsoluteUrl(staticOption.directory)) {
+        throw new Error('Using a URL as static.directory is not supported');
+      }
 
-    options.static.publicPath = options.static.publicPath || '/';
+      // ensure that publicPath is an array
+      if (typeof staticOption.publicPath === 'string') {
+        staticOption.publicPath = [staticOption.publicPath];
+      }
 
-    if (
-      typeof options.static.watch === 'undefined' ||
-      options.static.watch === true
-    ) {
-      options.static.watch = {};
-    }
+      // ensure that watch is an object if true
+      if (staticOption.watch === true) {
+        staticOption.watch = defaultOptionsForStatic.watch;
+      }
+
+      // ensure that serveIndex is an object if true
+      if (staticOption.serveIndex === true) {
+        staticOption.serveIndex = defaultOptionsForStatic.serveIndex;
+      }
+    });
   }
 
   options.hot =

--- a/setupTest.js
+++ b/setupTest.js
@@ -1,3 +1,4 @@
 'use strict';
 
+process.env.CHOKIDAR_USEPOLLING = 'true';
 jest.setTimeout(120000);

--- a/setupTest.js
+++ b/setupTest.js
@@ -1,4 +1,4 @@
 'use strict';
 
-process.env.CHOKIDAR_USEPOLLING = 'true';
+process.env.CHOKIDAR_USEPOLLING = true;
 jest.setTimeout(120000);

--- a/test/Validation.test.js
+++ b/test/Validation.test.js
@@ -38,8 +38,8 @@ describe('Validation', () => {
         config: { overlay: { errors: 1 } },
       },
       {
-        name: 'invalid `contentBase` configuration',
-        config: { contentBase: [0] },
+        name: 'invalid `static` configuration',
+        config: { static: [0] },
       },
       {
         name: 'no additional properties',

--- a/test/Validation.test.js
+++ b/test/Validation.test.js
@@ -50,6 +50,9 @@ describe('Validation', () => {
     tests.forEach((test) => {
       it(`should fail validation for ${test.name}`, () => {
         try {
+          if (!test.config.static) {
+            test.config.static = false;
+          }
           server = new Server(compiler, test.config);
         } catch (err) {
           if (err.name !== 'ValidationError') {

--- a/test/__snapshots__/Validation.test.js.snap
+++ b/test/__snapshots__/Validation.test.js.snap
@@ -1,10 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Validation validation should fail validation for invalid \`contentBase\` configuration 1`] = `
-"Invalid configuration object. Object has been initialized using a configuration object that does not match the API schema.
- - configuration.contentBase[0] should be a string."
-`;
-
 exports[`Validation validation should fail validation for invalid \`hot\` configuration 1`] = `
 "Invalid configuration object. Object has been initialized using a configuration object that does not match the API schema.
  - configuration.hot should be one of these:
@@ -28,8 +23,21 @@ exports[`Validation validation should fail validation for invalid \`overlay\` co
  - configuration.overlay.errors should be a boolean."
 `;
 
+exports[`Validation validation should fail validation for invalid \`static\` configuration 1`] = `
+"Invalid configuration object. Object has been initialized using a configuration object that does not match the API schema.
+ - configuration.static should be one of these:
+   boolean | non-empty string | object { directory?, staticOptions?, publicPath?, serveIndex?, watch? } | [non-empty string | object { directory?, staticOptions?, publicPath?, serveIndex?, watch? }, ...] (should not have fewer than 1 item)
+   Details:
+    * configuration.static[0] should be one of these:
+      non-empty string | object { directory?, staticOptions?, publicPath?, serveIndex?, watch? }
+      Details:
+       * configuration.static[0] should be a non-empty string.
+       * configuration.static[0] should be an object:
+         object { directory?, staticOptions?, publicPath?, serveIndex?, watch? }"
+`;
+
 exports[`Validation validation should fail validation for no additional properties 1`] = `
 "Invalid configuration object. Object has been initialized using a configuration object that does not match the API schema.
  - configuration has an unknown property 'additional'. These properties are valid:
-   object { allowedHosts?, bonjour?, client?, compress?, contentBasePublicPath?, contentBase?, dev?, disableHostCheck?, headers?, historyApiFallback?, host?, hot?, http2?, https?, injectClient?, injectHot?, liveReload?, onAfterSetupMiddleware?, onBeforeSetupMiddleware?, onListening?, open?, openPage?, overlay?, port?, profile?, progress?, proxy?, public?, serveIndex?, staticOptions?, transportMode?, useLocalIp?, watchContentBase?, watchOptions? }"
+   object { allowedHosts?, bonjour?, client?, compress?, dev?, disableHostCheck?, headers?, historyApiFallback?, host?, hot?, http2?, https?, injectClient?, injectHot?, liveReload?, onAfterSetupMiddleware?, onBeforeSetupMiddleware?, onListening?, open?, openPage?, overlay?, port?, profile?, progress?, proxy?, public?, static?, transportMode?, useLocalIp? }"
 `;

--- a/test/e2e/Client.test.js
+++ b/test/e2e/Client.test.js
@@ -52,6 +52,7 @@ describe('reload', () => {
         const options = Object.assign(
           {},
           {
+            static: false,
             port,
             host: '0.0.0.0',
           },

--- a/test/e2e/Client.test.js
+++ b/test/e2e/Client.test.js
@@ -54,9 +54,6 @@ describe('reload', () => {
           {
             port,
             host: '0.0.0.0',
-            watchOptions: {
-              poll: true,
-            },
           },
           mode.options
         );

--- a/test/e2e/ClientOptions.test.js
+++ b/test/e2e/ClientOptions.test.js
@@ -32,9 +32,6 @@ describe('sockjs client proxy', () => {
       host: '0.0.0.0',
       disableHostCheck: true,
       hot: true,
-      watchOptions: {
-        poll: true,
-      },
     };
     testServer.startAwaitingCompilation(config, options, done);
   });
@@ -107,9 +104,6 @@ describe('ws client proxy', () => {
       host: '0.0.0.0',
       disableHostCheck: true,
       hot: true,
-      watchOptions: {
-        poll: true,
-      },
       public: 'myhost',
     };
     testServer.startAwaitingCompilation(config, options, done);
@@ -158,9 +152,6 @@ describe('sockjs public and client path', () => {
       transportMode: 'sockjs',
       port: port2,
       host: '0.0.0.0',
-      watchOptions: {
-        poll: true,
-      },
       public: 'myhost.test',
       client: {
         path: '/foo/test/bar/',
@@ -200,9 +191,6 @@ describe('sockjs client path and port', () => {
       transportMode: 'sockjs',
       port: port2,
       host: '0.0.0.0',
-      watchOptions: {
-        poll: true,
-      },
       client: {
         path: '/foo/test/bar/',
         port: port3,
@@ -246,9 +234,6 @@ describe('sockjs client port, no path', () => {
       transportMode: 'sockjs',
       port: port2,
       host: '0.0.0.0',
-      watchOptions: {
-        poll: true,
-      },
       client: {
         port: port3,
       },
@@ -285,9 +270,6 @@ describe('sockjs client host', () => {
       transportMode: 'sockjs',
       port: port2,
       host: '0.0.0.0',
-      watchOptions: {
-        poll: true,
-      },
       client: {
         host: 'myhost.test',
       },
@@ -324,9 +306,6 @@ describe('ws client host, port, and path', () => {
       transportMode: 'ws',
       port: port2,
       host: '0.0.0.0',
-      watchOptions: {
-        poll: true,
-      },
       client: {
         host: 'myhost',
         port: port3,

--- a/test/e2e/Progress.test.js
+++ b/test/e2e/Progress.test.js
@@ -38,9 +38,6 @@ describe('client progress', () => {
         host: '0.0.0.0',
         hot: true,
         progress: true,
-        watchOptions: {
-          poll: true,
-        },
       };
 
       // we need a delay between file writing and the start

--- a/test/e2e/ProvidePlugin.test.js
+++ b/test/e2e/ProvidePlugin.test.js
@@ -13,9 +13,6 @@ describe('ProvidePlugin', () => {
       const options = {
         port,
         host: '0.0.0.0',
-        watchOptions: {
-          poll: true,
-        },
       };
       testServer.startAwaitingCompilation(wsConfig, options, done);
     });
@@ -51,9 +48,6 @@ describe('ProvidePlugin', () => {
         port,
         host: '0.0.0.0',
         transportMode: 'sockjs',
-        watchOptions: {
-          poll: true,
-        },
       };
       testServer.startAwaitingCompilation(sockjsConfig, options, done);
     });

--- a/test/helpers/test-bin.js
+++ b/test/helpers/test-bin.js
@@ -26,7 +26,12 @@ function testBin(testArgs, configPath) {
     testArgs = testArgs.split(' ');
   }
 
-  const args = [webpackDevServerPath, '--config', configPath].concat(testArgs);
+  const args = [
+    webpackDevServerPath,
+    '--config',
+    configPath,
+    '--no-static',
+  ].concat(testArgs);
 
   return execa('node', args, { cwd, env, timeout: 10000 });
 }

--- a/test/helpers/test-server.js
+++ b/test/helpers/test-server.js
@@ -8,11 +8,10 @@ let server;
 // start server, returning the full setup of the server
 // (both the server and the compiler)
 function startFullSetup(config, options, done) {
+  // disable watching by default for tests
   if (typeof options.static === 'undefined') {
     options.static = {
-      watch: {
-        poll: true,
-      },
+      watch: false,
     };
   }
 

--- a/test/helpers/test-server.js
+++ b/test/helpers/test-server.js
@@ -8,6 +8,14 @@ let server;
 // start server, returning the full setup of the server
 // (both the server and the compiler)
 function startFullSetup(config, options, done) {
+  if (typeof options.static === 'undefined') {
+    options.static = {
+      watch: {
+        poll: true,
+      },
+    };
+  }
+
   const compiler = webpack(config);
 
   server = new Server(compiler, options);

--- a/test/helpers/test-server.js
+++ b/test/helpers/test-server.js
@@ -8,14 +8,6 @@ let server;
 // start server, returning the full setup of the server
 // (both the server and the compiler)
 function startFullSetup(config, options, done) {
-  // defaulting to this will hopefully help with problems on OSX in tests
-  // eslint-disable-next-line no-undefined
-  if (options.watchOptions === undefined) {
-    options.watchOptions = {
-      poll: true,
-    };
-  }
-
   const compiler = webpack(config);
 
   server = new Server(compiler, options);

--- a/test/helpers/test-server.js
+++ b/test/helpers/test-server.js
@@ -10,9 +10,10 @@ let server;
 function startFullSetup(config, options, done) {
   // disable watching by default for tests
   if (typeof options.static === 'undefined') {
-    options.static = {
-      watch: false,
-    };
+    options.static = false;
+  } else if (options.static === null) {
+    // this provides a way of using the default static value
+    delete options.static;
   }
 
   const compiler = webpack(config);

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -395,7 +395,7 @@ describe('options', () => {
               directory: 'path',
               staticOptions: {},
               publicPath: ['/public1/', '/public2/'],
-              serveIndex: true,
+              serveIndex: {},
               watch: {},
             },
           },

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -73,6 +73,10 @@ describe('options', () => {
                     [propertyName]: value,
                   };
 
+            if (typeof opts.static === 'undefined') {
+              opts.static = false;
+            }
+
             server = new Server(compiler, opts);
           })
           .then(() => {

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -233,10 +233,6 @@ describe('options', () => {
         success: [true],
         failure: [''],
       },
-      contentBase: {
-        success: [0, '.', false],
-        failure: [[1], [false]],
-      },
       dev: {
         success: [
           {
@@ -381,13 +377,42 @@ describe('options', () => {
         success: [''],
         failure: [false],
       },
-      serveIndex: {
-        success: [true],
-        failure: [''],
-      },
-      staticOptions: {
-        success: [{}],
-        failure: [false],
+      static: {
+        success: [
+          'path',
+          false,
+          {
+            static: {
+              directory: 'path',
+              staticOptions: {},
+              publicPath: '/',
+              serveIndex: true,
+              watch: true,
+            },
+          },
+          {
+            static: {
+              directory: 'path',
+              staticOptions: {},
+              publicPath: ['/public1/', '/public2/'],
+              serveIndex: true,
+              watch: {},
+            },
+          },
+          {
+            static: [
+              'path1',
+              {
+                directory: 'path2',
+                staticOptions: {},
+                publicPath: '/',
+                serveIndex: true,
+                watch: true,
+              },
+            ],
+          },
+        ],
+        failure: [0, null, ''],
       },
       transportMode: {
         success: [
@@ -447,14 +472,6 @@ describe('options', () => {
       },
       useLocalIp: {
         success: [false],
-        failure: [''],
-      },
-      watchContentBase: {
-        success: [true],
-        failure: [''],
-      },
-      watchOptions: {
-        success: [{}],
         failure: [''],
       },
     };

--- a/test/ports-map.js
+++ b/test/ports-map.js
@@ -41,7 +41,7 @@ const portsList = {
   'profile-option': 1,
   Iframe: 1,
   SocketInjection: 1,
-  'contentBasePublicPath-option': 1,
+  'static-publicPath-option': 1,
 };
 
 let startPort = 8089;

--- a/test/ports-map.js
+++ b/test/ports-map.js
@@ -16,7 +16,7 @@ const portsList = {
   'onAfterSetupMiddleware-option': 1,
   'onBeforeSetupMiddleware-option': 1,
   'compress-option': 1,
-  'contentBase-option': 1,
+  'static-directory-option': 1,
   'headers-option': 1,
   'historyApiFallback-option': 1,
   'host-option': 1,

--- a/test/server/Server.test.js
+++ b/test/server/Server.test.js
@@ -10,7 +10,10 @@ const isWebpack5 = require('../helpers/isWebpack5');
 
 jest.mock('sockjs/lib/transport');
 
-const baseDevConfig = { port };
+const baseDevConfig = {
+  port,
+  static: false,
+};
 
 describe('Server', () => {
   describe('sockjs', () => {

--- a/test/server/historyApiFallback-option.test.js
+++ b/test/server/historyApiFallback-option.test.js
@@ -55,12 +55,12 @@ describe('historyApiFallback option', () => {
     });
   });
 
-  describe('as object with contentBase', () => {
+  describe('as object with static', () => {
     beforeAll((done) => {
       server = testServer.start(
         config2,
         {
-          contentBase: path.resolve(
+          static: path.resolve(
             __dirname,
             '../fixtures/historyapifallback-2-config'
           ),
@@ -88,7 +88,7 @@ describe('historyApiFallback option', () => {
         .expect(200, /Foobar/, done);
     });
 
-    it('contentBase file should take preference above historyApiFallback', (done) => {
+    it('static file should take preference above historyApiFallback', (done) => {
       req
         .get('/random-file')
         .accept('html')
@@ -97,6 +97,8 @@ describe('historyApiFallback option', () => {
             done(err);
           }
 
+          console.log(res.statusCode);
+
           expect(res.body.toString().trim()).toEqual('Random file');
 
           done();
@@ -104,12 +106,12 @@ describe('historyApiFallback option', () => {
     });
   });
 
-  describe('as object with contentBase set to false', () => {
+  describe('as object with static set to false', () => {
     beforeAll((done) => {
       server = testServer.start(
         config3,
         {
-          contentBase: false,
+          static: false,
           historyApiFallback: {
             index: '/bar.html',
           },
@@ -128,13 +130,13 @@ describe('historyApiFallback option', () => {
     });
   });
 
-  describe('as object with contentBase and rewrites', () => {
+  describe('as object with static and rewrites', () => {
     beforeAll((done) => {
       server = testServer.start(
         config2,
         {
           port,
-          contentBase: path.resolve(
+          static: path.resolve(
             __dirname,
             '../fixtures/historyapifallback-2-config'
           ),
@@ -183,7 +185,7 @@ describe('historyApiFallback option', () => {
       server = testServer.start(
         config3,
         {
-          contentBase: path.resolve(
+          static: path.resolve(
             __dirname,
             '../fixtures/historyapifallback-3-config'
           ),
@@ -195,7 +197,7 @@ describe('historyApiFallback option', () => {
       req = request(server.app);
     });
 
-    it('should take precedence over contentBase files', (done) => {
+    it('should take precedence over static files', (done) => {
       req
         .get('/foo')
         .accept('html')

--- a/test/server/historyApiFallback-option.test.js
+++ b/test/server/historyApiFallback-option.test.js
@@ -97,8 +97,6 @@ describe('historyApiFallback option', () => {
             done(err);
           }
 
-          console.log(res.statusCode);
-
           expect(res.body.toString().trim()).toEqual('Random file');
 
           done();

--- a/test/server/host-option.test.js
+++ b/test/server/host-option.test.js
@@ -11,7 +11,16 @@ describe('host option', () => {
 
   describe('is not be specified', () => {
     beforeAll((done) => {
-      server = testServer.start(config, { port }, done);
+      server = testServer.start(
+        config,
+        {
+          static: {
+            watch: false,
+          },
+          port,
+        },
+        done
+      );
       req = request(server.app);
     });
 
@@ -34,6 +43,9 @@ describe('host option', () => {
       server = testServer.start(
         config,
         {
+          static: {
+            watch: false,
+          },
           // eslint-disable-next-line no-undefined
           host: undefined,
           port,
@@ -62,6 +74,9 @@ describe('host option', () => {
       server = testServer.start(
         config,
         {
+          static: {
+            watch: false,
+          },
           host: null,
           port,
         },
@@ -89,6 +104,9 @@ describe('host option', () => {
       server = testServer.start(
         config,
         {
+          static: {
+            watch: false,
+          },
           host: '127.0.0.1',
           port,
         },
@@ -116,6 +134,9 @@ describe('host option', () => {
       server = testServer.start(
         config,
         {
+          static: {
+            watch: false,
+          },
           host: 'localhost',
           port,
         },
@@ -143,6 +164,9 @@ describe('host option', () => {
       server = testServer.start(
         config,
         {
+          static: {
+            watch: false,
+          },
           host: '0.0.0.0',
           port,
         },

--- a/test/server/hot-option.test.js
+++ b/test/server/hot-option.test.js
@@ -14,9 +14,6 @@ describe('hot option', () => {
     beforeAll((done) => {
       const options = {
         port,
-        watchOptions: {
-          poll: true,
-        },
       };
       server = testServer.startAwaitingCompilation(config, options, done);
       req = request(server.app);
@@ -34,9 +31,6 @@ describe('hot option', () => {
       const options = {
         port,
         hot: 'only',
-        watchOptions: {
-          poll: true,
-        },
       };
       server = testServer.startAwaitingCompilation(config, options, done);
       req = request(server.app);
@@ -55,9 +49,6 @@ describe('hot option', () => {
     beforeAll((done) => {
       const options = {
         port,
-        watchOptions: {
-          poll: true,
-        },
       };
       server = testServer.startAwaitingCompilation(
         multiCompilerConfig,
@@ -79,9 +70,6 @@ describe('hot option', () => {
       const options = {
         port,
         hot: false,
-        watchOptions: {
-          poll: true,
-        },
       };
       server = testServer.startAwaitingCompilation(config, options, done);
       req = request(server.app);
@@ -108,9 +96,6 @@ describe('hot option', () => {
       let pluginFound = false;
       const options = {
         port,
-        watchOptions: {
-          poll: true,
-        },
       };
       const fullSetup = testServer.startAwaitingCompilationFullSetup(
         config,
@@ -140,9 +125,6 @@ describe('hot option', () => {
       let pluginFound = false;
       const options = {
         port,
-        watchOptions: {
-          poll: true,
-        },
       };
       const fullSetup = testServer.startAwaitingCompilationFullSetup(
         multiCompilerConfig,
@@ -173,9 +155,6 @@ describe('hot option', () => {
       const options = {
         port,
         hot: false,
-        watchOptions: {
-          poll: true,
-        },
       };
       const fullSetup = testServer.startAwaitingCompilationFullSetup(
         config,

--- a/test/server/http2-option.test.js
+++ b/test/server/http2-option.test.js
@@ -21,7 +21,10 @@ describe('http2 option', () => {
       server = testServer.start(
         config,
         {
-          static: contentBasePublic,
+          static: {
+            directory: contentBasePublic,
+            watch: false,
+          },
           https: true,
           http2: true,
           port,
@@ -63,7 +66,10 @@ describe('http2 option', () => {
       server = testServer.start(
         config,
         {
-          static: contentBasePublic,
+          static: {
+            directory: contentBasePublic,
+            watch: false,
+          },
           http2: true,
           port,
         },
@@ -84,7 +90,10 @@ describe('http2 option', () => {
       server = testServer.start(
         config,
         {
-          static: contentBasePublic,
+          static: {
+            directory: contentBasePublic,
+            watch: false,
+          },
           https: true,
           http2: false,
           port,

--- a/test/server/http2-option.test.js
+++ b/test/server/http2-option.test.js
@@ -21,7 +21,7 @@ describe('http2 option', () => {
       server = testServer.start(
         config,
         {
-          contentBase: contentBasePublic,
+          static: contentBasePublic,
           https: true,
           http2: true,
           port,
@@ -63,7 +63,7 @@ describe('http2 option', () => {
       server = testServer.start(
         config,
         {
-          contentBase: contentBasePublic,
+          static: contentBasePublic,
           http2: true,
           port,
         },
@@ -84,7 +84,7 @@ describe('http2 option', () => {
       server = testServer.start(
         config,
         {
-          contentBase: contentBasePublic,
+          static: contentBasePublic,
           https: true,
           http2: false,
           port,

--- a/test/server/https-option.test.js
+++ b/test/server/https-option.test.js
@@ -26,7 +26,7 @@ describe('https option', () => {
       server = testServer.start(
         config,
         {
-          contentBase: contentBasePublic,
+          static: contentBasePublic,
           https: true,
           port,
         },
@@ -49,7 +49,7 @@ describe('https option', () => {
       server = testServer.start(
         config,
         {
-          contentBase: contentBasePublic,
+          static: contentBasePublic,
           https: {
             ca: fs.readFileSync(path.join(httpsCertificateDirectory, 'ca.pem')),
             pfx: fs.readFileSync(
@@ -80,7 +80,7 @@ describe('https option', () => {
       server = testServer.start(
         config,
         {
-          contentBase: contentBasePublic,
+          static: contentBasePublic,
           https: {
             ca: path.join(httpsCertificateDirectory, 'ca.pem'),
             pfx: path.join(httpsCertificateDirectory, 'server.pfx'),
@@ -109,7 +109,7 @@ describe('https option', () => {
       server = testServer.start(
         config,
         {
-          contentBase: contentBasePublic,
+          static: contentBasePublic,
           https: {
             ca: path.join(httpsCertificateDirectory, 'ca-symlink.pem'),
             pfx: path.join(httpsCertificateDirectory, 'server-symlink.pfx'),
@@ -136,7 +136,7 @@ describe('https option', () => {
       server = testServer.start(
         config,
         {
-          contentBase: contentBasePublic,
+          static: contentBasePublic,
           https: {
             ca: fs
               .readFileSync(path.join(httpsCertificateDirectory, 'ca.pem'))
@@ -170,7 +170,7 @@ describe('https option', () => {
       server = testServer.start(
         config,
         {
-          contentBase: contentBasePublic,
+          static: contentBasePublic,
           https: {
             requestCert: true,
             ca: fs.readFileSync(path.join(httpsCertificateDirectory, 'ca.pem')),

--- a/test/server/https-option.test.js
+++ b/test/server/https-option.test.js
@@ -26,7 +26,10 @@ describe('https option', () => {
       server = testServer.start(
         config,
         {
-          static: contentBasePublic,
+          static: {
+            directory: contentBasePublic,
+            watch: false,
+          },
           https: true,
           port,
         },
@@ -49,7 +52,10 @@ describe('https option', () => {
       server = testServer.start(
         config,
         {
-          static: contentBasePublic,
+          static: {
+            directory: contentBasePublic,
+            watch: false,
+          },
           https: {
             ca: fs.readFileSync(path.join(httpsCertificateDirectory, 'ca.pem')),
             pfx: fs.readFileSync(
@@ -109,7 +115,10 @@ describe('https option', () => {
       server = testServer.start(
         config,
         {
-          static: contentBasePublic,
+          static: {
+            directory: contentBasePublic,
+            watch: false,
+          },
           https: {
             ca: path.join(httpsCertificateDirectory, 'ca-symlink.pem'),
             pfx: path.join(httpsCertificateDirectory, 'server-symlink.pfx'),
@@ -136,7 +145,10 @@ describe('https option', () => {
       server = testServer.start(
         config,
         {
-          static: contentBasePublic,
+          static: {
+            directory: contentBasePublic,
+            watch: false,
+          },
           https: {
             ca: fs
               .readFileSync(path.join(httpsCertificateDirectory, 'ca.pem'))
@@ -170,7 +182,10 @@ describe('https option', () => {
       server = testServer.start(
         config,
         {
-          static: contentBasePublic,
+          static: {
+            directory: contentBasePublic,
+            watch: false,
+          },
           https: {
             requestCert: true,
             ca: fs.readFileSync(path.join(httpsCertificateDirectory, 'ca.pem')),

--- a/test/server/liveReload-option.test.js
+++ b/test/server/liveReload-option.test.js
@@ -21,7 +21,10 @@ describe('liveReload option', () => {
       server = testServer.start(
         config,
         {
-          static: contentBasePublic,
+          static: {
+            directory: contentBasePublic,
+            watch: false,
+          },
           liveReload: false,
           port,
         },
@@ -75,7 +78,10 @@ describe('liveReload option', () => {
       server = testServer.start(
         config,
         {
-          static: contentBasePublic,
+          static: {
+            directory: contentBasePublic,
+            watch: false,
+          },
           liveReload: true,
           port,
         },

--- a/test/server/liveReload-option.test.js
+++ b/test/server/liveReload-option.test.js
@@ -21,8 +21,7 @@ describe('liveReload option', () => {
       server = testServer.start(
         config,
         {
-          contentBase: contentBasePublic,
-          watchContentBase: true,
+          static: contentBasePublic,
           liveReload: false,
           port,
         },
@@ -76,8 +75,7 @@ describe('liveReload option', () => {
       server = testServer.start(
         config,
         {
-          contentBase: contentBasePublic,
-          watchContentBase: true,
+          static: contentBasePublic,
           liveReload: true,
           port,
         },

--- a/test/server/liveReload-option.test.js
+++ b/test/server/liveReload-option.test.js
@@ -21,10 +21,7 @@ describe('liveReload option', () => {
       server = testServer.start(
         config,
         {
-          static: {
-            directory: contentBasePublic,
-            watch: false,
-          },
+          static: contentBasePublic,
           liveReload: false,
           port,
         },
@@ -78,10 +75,7 @@ describe('liveReload option', () => {
       server = testServer.start(
         config,
         {
-          static: {
-            directory: contentBasePublic,
-            watch: false,
-          },
+          static: contentBasePublic,
           liveReload: true,
           port,
         },

--- a/test/server/open-option.test.js
+++ b/test/server/open-option.test.js
@@ -20,6 +20,7 @@ describe('open option', () => {
     const server = new Server(compiler, {
       open: true,
       port,
+      static: false,
     });
 
     compiler.hooks.done.tap('webpack-dev-server', () => {

--- a/test/server/port-option.test.js
+++ b/test/server/port-option.test.js
@@ -11,7 +11,16 @@ describe('port', () => {
 
   describe('is not be specified', () => {
     beforeAll((done) => {
-      server = testServer.start(config, { port }, done);
+      server = testServer.start(
+        config,
+        {
+          static: {
+            watch: false,
+          },
+          port,
+        },
+        done
+      );
       req = request(server.app);
     });
 
@@ -35,6 +44,9 @@ describe('port', () => {
       server = testServer.start(
         config,
         {
+          static: {
+            watch: false,
+          },
           // eslint-disable-next-line no-undefined
           port: undefined,
         },
@@ -63,6 +75,9 @@ describe('port', () => {
       server = testServer.start(
         config,
         {
+          static: {
+            watch: false,
+          },
           port: null,
         },
         done
@@ -90,6 +105,9 @@ describe('port', () => {
       server = testServer.start(
         config,
         {
+          static: {
+            watch: false,
+          },
           port: '33333',
         },
         done
@@ -116,6 +134,9 @@ describe('port', () => {
       server = testServer.start(
         config,
         {
+          static: {
+            watch: false,
+          },
           port: '33333',
         },
         done

--- a/test/server/profile-option.test.js
+++ b/test/server/profile-option.test.js
@@ -24,6 +24,7 @@ describe('profile', () => {
         // profile will only have an effect when progress is enabled
         progress: true,
         profile: true,
+        static: false,
       });
 
       compiler.hooks.done.tap('webpack-dev-server', () => {

--- a/test/server/progress-option.test.js
+++ b/test/server/progress-option.test.js
@@ -22,6 +22,7 @@ describe('progress', () => {
       const server = new Server(compiler, {
         port,
         progress: true,
+        static: false,
       });
 
       compiler.hooks.done.tap('webpack-dev-server', () => {

--- a/test/server/proxy-option.test.js
+++ b/test/server/proxy-option.test.js
@@ -91,7 +91,7 @@ describe('proxy option', () => {
       server = testServer.start(
         config,
         {
-          contentBase,
+          static: contentBase,
           proxy: proxyOptionPathsAsProperties,
           port: port3,
         },
@@ -148,7 +148,7 @@ describe('proxy option', () => {
       server = testServer.start(
         config,
         {
-          contentBase,
+          static: contentBase,
           proxy: proxyOption,
           port: port3,
         },
@@ -179,7 +179,7 @@ describe('proxy option', () => {
       server = testServer.start(
         config,
         {
-          contentBase,
+          static: contentBase,
           proxy: proxyOptionOfArray,
           port: port3,
         },
@@ -224,7 +224,7 @@ describe('proxy option', () => {
       server = testServer.start(
         config,
         {
-          contentBase,
+          static: contentBase,
           proxy: {
             '/proxy1': proxyTarget,
             '/proxy2': proxyTarget,
@@ -264,7 +264,7 @@ describe('proxy option', () => {
           testServer.start(
             config,
             {
-              contentBase,
+              static: contentBase,
               transportMode,
               proxy: [
                 {
@@ -368,7 +368,7 @@ describe('proxy option', () => {
       server = testServer.start(
         config,
         {
-          contentBase,
+          static: contentBase,
           proxy: {
             '**': proxyTarget,
           },

--- a/test/server/proxy-option.test.js
+++ b/test/server/proxy-option.test.js
@@ -91,7 +91,10 @@ describe('proxy option', () => {
       server = testServer.start(
         config,
         {
-          static: contentBase,
+          static: {
+            directory: contentBase,
+            watch: false,
+          },
           proxy: proxyOptionPathsAsProperties,
           port: port3,
         },
@@ -148,7 +151,10 @@ describe('proxy option', () => {
       server = testServer.start(
         config,
         {
-          static: contentBase,
+          static: {
+            directory: contentBase,
+            watch: false,
+          },
           proxy: proxyOption,
           port: port3,
         },
@@ -179,7 +185,10 @@ describe('proxy option', () => {
       server = testServer.start(
         config,
         {
-          static: contentBase,
+          static: {
+            directory: contentBase,
+            watch: false,
+          },
           proxy: proxyOptionOfArray,
           port: port3,
         },
@@ -224,7 +233,10 @@ describe('proxy option', () => {
       server = testServer.start(
         config,
         {
-          static: contentBase,
+          static: {
+            directory: contentBase,
+            watch: false,
+          },
           proxy: {
             '/proxy1': proxyTarget,
             '/proxy2': proxyTarget,
@@ -264,7 +276,10 @@ describe('proxy option', () => {
           testServer.start(
             config,
             {
-              static: contentBase,
+              static: {
+                directory: contentBase,
+                watch: false,
+              },
               transportMode,
               proxy: [
                 {
@@ -368,7 +383,10 @@ describe('proxy option', () => {
       server = testServer.start(
         config,
         {
-          static: contentBase,
+          static: {
+            directory: contentBase,
+            watch: false,
+          },
           proxy: {
             '**': proxyTarget,
           },

--- a/test/server/static-directory-option.test.js
+++ b/test/server/static-directory-option.test.js
@@ -292,7 +292,13 @@ describe('static.directory option', () => {
     beforeAll((done) => {
       jest.spyOn(process, 'cwd').mockImplementation(() => publicDirectory);
 
-      server = testServer.start(config, {}, done);
+      server = testServer.start(
+        config,
+        {
+          static: null,
+        },
+        done
+      );
       req = request(server.app);
     });
 

--- a/test/server/static-directory-option.test.js
+++ b/test/server/static-directory-option.test.js
@@ -5,30 +5,32 @@ const fs = require('fs');
 const request = require('supertest');
 const testServer = require('../helpers/test-server');
 const config = require('../fixtures/contentbase-config/webpack.config');
-const port = require('../ports-map')['contentBase-option'];
+const port = require('../ports-map')['static-directory-option'];
 
-const contentBasePublic = path.resolve(
+const publicDirectory = path.resolve(
   __dirname,
   '../fixtures/contentbase-config/public'
 );
-const contentBaseOther = path.resolve(
+const otherPublicDirectory = path.resolve(
   __dirname,
   '../fixtures/contentbase-config/other'
 );
 
-describe('contentBase option', () => {
+describe('static.directory option', () => {
   let server;
   let req;
 
   describe('to directory', () => {
-    const nestedFile = path.resolve(contentBasePublic, 'assets/example.txt');
+    const nestedFile = path.resolve(publicDirectory, 'assets/example.txt');
 
     beforeAll((done) => {
       server = testServer.start(
         config,
         {
-          contentBase: contentBasePublic,
-          watchContentBase: true,
+          static: {
+            directory: publicDirectory,
+            watch: true,
+          },
           port,
         },
         done
@@ -66,11 +68,7 @@ describe('contentBase option', () => {
     });
 
     it('watch node_modules', (done) => {
-      const filePath = path.join(
-        contentBasePublic,
-        'node_modules',
-        'index.html'
-      );
+      const filePath = path.join(publicDirectory, 'node_modules', 'index.html');
       fs.writeFileSync(filePath, 'foo', 'utf8');
 
       // chokidar emitted a change,
@@ -87,14 +85,16 @@ describe('contentBase option', () => {
     });
   });
 
-  describe('test listing files in folders without index.html using the option serveIndex:false', () => {
+  describe('test listing files in folders without index.html using the option static.serveIndex:false', () => {
     beforeAll((done) => {
       server = testServer.start(
         config,
         {
-          contentBase: contentBasePublic,
-          watchContentBase: true,
-          serveIndex: false,
+          static: {
+            directory: publicDirectory,
+            watch: true,
+            serveIndex: false,
+          },
           port,
         },
         done
@@ -117,14 +117,16 @@ describe('contentBase option', () => {
     });
   });
 
-  describe('test listing files in folders without index.html using the option serveIndex:true', () => {
+  describe('test listing files in folders without index.html using the option static.serveIndex:true', () => {
     beforeAll((done) => {
       server = testServer.start(
         config,
         {
-          contentBase: contentBasePublic,
-          watchContentBase: true,
-          serveIndex: true,
+          static: {
+            directory: publicDirectory,
+            watch: true,
+            serveIndex: true,
+          },
           port,
         },
         done
@@ -147,13 +149,15 @@ describe('contentBase option', () => {
     });
   });
 
-  describe('test listing files in folders without index.html using the option serveIndex default (true)', () => {
+  describe('test listing files in folders without index.html using the option static.serveIndex default (true)', () => {
     beforeAll((done) => {
       server = testServer.start(
         config,
         {
-          contentBase: contentBasePublic,
-          watchContentBase: true,
+          static: {
+            directory: publicDirectory,
+            watch: true,
+          },
           port,
         },
         done
@@ -181,7 +185,7 @@ describe('contentBase option', () => {
       server = testServer.start(
         config,
         {
-          contentBase: [contentBasePublic, contentBaseOther],
+          static: [publicDirectory, otherPublicDirectory],
           port,
         },
         done
@@ -204,100 +208,24 @@ describe('contentBase option', () => {
     });
   });
 
-  describe('to port', () => {
-    beforeAll((done) => {
-      server = testServer.start(
-        config,
-        {
-          contentBase: 9099999,
-          port,
-        },
-        done
-      );
-      req = request(server.app);
-    });
-
-    afterAll((done) => {
-      testServer.close(() => {
-        done();
-      });
-    });
-
-    it('Request to page', (done) => {
-      req
-        .get('/other.html')
-        .expect('Location', '//localhost:9099999/other.html')
-        .expect(302, done);
-    });
-  });
-
-  describe('to external url', () => {
-    beforeAll((done) => {
-      server = testServer.start(
-        config,
-        {
-          contentBase: 'http://example.com/',
-          port,
-        },
-        done
-      );
-      req = request(server.app);
-    });
-
-    afterAll((done) => {
-      testServer.close(() => {
-        done();
-      });
-    });
-
-    it('Request to page', (done) => {
-      req
-        .get('/foo.html')
-        // TODO: hmm, two slashes seems to be a bug?
-        .expect('Location', 'http://example.com//foo.html')
-        .expect(302, done);
-    });
-
-    it('Request to page with search params', (done) => {
-      req
-        .get('/foo.html?space=ship')
-        // TODO: hmm, two slashes seems to be a bug?
-        .expect('Location', 'http://example.com//foo.html?space=ship')
-        .expect(302, done);
-    });
-  });
-
   describe('testing single & multiple external paths', () => {
     afterEach((done) => {
       testServer.close(() => {
         done();
       });
     });
-    it('Should throw exception (string)', (done) => {
+    it('Should throw exception (external url)', (done) => {
       try {
         // eslint-disable-next-line no-unused-vars
         server = testServer.start(config, {
-          contentBase: 'https://example.com/',
-          watchContentBase: true,
+          static: 'https://example.com/',
         });
 
         expect(true).toBe(false);
       } catch (e) {
-        expect(e.message).toBe('Watching remote files is not supported.');
-        done();
-      }
-    });
-    it('Should throw exception (number)', (done) => {
-      try {
-        // eslint-disable-next-line no-unused-vars
-        server = testServer.start(config, {
-          contentBase: 2,
-          watchContentBase: true,
-        });
-
-        expect(true).toBe(false);
-      } catch (e) {
-        expect(e.message).toBe('Watching remote files is not supported.');
+        expect(e.message).toBe(
+          'Using a URL as static.directory is not supported'
+        );
         done();
       }
     });
@@ -305,10 +233,12 @@ describe('contentBase option', () => {
       testServer.start(
         config,
         {
-          contentBase:
-            contentBasePublic.charAt(0).toLowerCase() +
-            contentBasePublic.substring(1),
-          watchContentBase: true,
+          static: {
+            directory:
+              publicDirectory.charAt(0).toLowerCase() +
+              publicDirectory.substring(1),
+            watch: true,
+          },
           port,
         },
         done
@@ -318,8 +248,10 @@ describe('contentBase option', () => {
       testServer.start(
         config,
         {
-          contentBase: 'c:\\absolute\\path\\to\\content-base',
-          watchContentBase: true,
+          static: {
+            directory: 'c:\\absolute\\path\\to\\content-base',
+            watch: true,
+          },
           port,
         },
         done
@@ -329,25 +261,28 @@ describe('contentBase option', () => {
       testServer.start(
         config,
         {
-          contentBase: 'C:\\absolute\\path\\to\\content-base',
-          watchContentBase: true,
+          static: {
+            directory: 'C:\\absolute\\path\\to\\content-base',
+            watch: true,
+          },
           port,
         },
         done
       );
     });
 
-    it('Should throw exception (array)', (done) => {
+    it('Should throw exception (array with absolute url)', (done) => {
       try {
         // eslint-disable-next-line no-unused-vars
         server = testServer.start(config, {
-          contentBase: [contentBasePublic, 'https://example.com/'],
-          watchContentBase: true,
+          static: [publicDirectory, 'https://example.com/'],
         });
 
         expect(true).toBe(false);
       } catch (e) {
-        expect(e.message).toBe('Watching remote files is not supported.');
+        expect(e.message).toBe(
+          'Using a URL as static.directory is not supported'
+        );
         done();
       }
     });
@@ -355,7 +290,7 @@ describe('contentBase option', () => {
 
   describe('default to PWD', () => {
     beforeAll((done) => {
-      jest.spyOn(process, 'cwd').mockImplementation(() => contentBasePublic);
+      jest.spyOn(process, 'cwd').mockImplementation(() => publicDirectory);
 
       server = testServer.start(config, {}, done);
       req = request(server.app);
@@ -376,12 +311,12 @@ describe('contentBase option', () => {
     beforeAll((done) => {
       // This is a somewhat weird test, but it is important that we mock
       // the PWD here, and test if /other.html in our "fake" PWD really is not requested.
-      jest.spyOn(process, 'cwd').mockImplementation(() => contentBasePublic);
+      jest.spyOn(process, 'cwd').mockImplementation(() => publicDirectory);
 
       server = testServer.start(
         config,
         {
-          contentBase: false,
+          static: false,
           port,
         },
         done
@@ -405,7 +340,7 @@ describe('contentBase option', () => {
       server = testServer.start(
         config,
         {
-          contentBase: [contentBasePublic],
+          static: [publicDirectory],
           port,
         },
         done

--- a/test/server/static-publicPath-option.test.js
+++ b/test/server/static-publicPath-option.test.js
@@ -333,4 +333,51 @@ describe('static.publicPath option', () => {
       req.get(`${otherStaticPublicPath}/foo.html`).expect(200, /Foo!/, done);
     });
   });
+
+  describe('multiple static.publicPath entries with publicPath array', () => {
+    beforeAll((done) => {
+      server = testServer.start(
+        config,
+        {
+          static: [
+            {
+              directory: publicDirectory,
+              publicPath: staticPublicPath,
+              watch: true,
+            },
+            {
+              directory: otherPublicDirectory,
+              publicPath: [staticPublicPath, otherStaticPublicPath],
+              watch: true,
+            },
+          ],
+          port,
+        },
+        done
+      );
+      req = request(server.app);
+    });
+
+    afterAll((done) => {
+      testServer.close(() => {
+        done();
+      });
+    });
+
+    it('Request the first path to index', (done) => {
+      req.get(`${staticPublicPath}/`).expect(200, /Heyo/, done);
+    });
+
+    it('Request the first path to other file', (done) => {
+      req.get(`${staticPublicPath}/other.html`).expect(200, /Other html/, done);
+    });
+
+    it('Request the first path to foo', (done) => {
+      req.get(`${staticPublicPath}/foo.html`).expect(200, /Foo!/, done);
+    });
+
+    it('Request the second path to foo', (done) => {
+      req.get(`${otherStaticPublicPath}/foo.html`).expect(200, /Foo!/, done);
+    });
+  });
 });

--- a/test/server/static-publicPath-option.test.js
+++ b/test/server/static-publicPath-option.test.js
@@ -4,21 +4,21 @@ const path = require('path');
 const request = require('supertest');
 const testServer = require('../helpers/test-server');
 const config = require('../fixtures/contentbase-config/webpack.config');
-const port = require('../ports-map')['contentBasePublicPath-option'];
+const port = require('../ports-map')['static-publicPath-option'];
 
-const contentBasePublic = path.resolve(
+const publicDirectory = path.resolve(
   __dirname,
   '../fixtures/contentbase-config/public'
 );
-const contentBaseOther = path.resolve(
+const otherPublicDirectory = path.resolve(
   __dirname,
   '../fixtures/contentbase-config/other'
 );
 
-const contentBasePublicPath = '/serve-content-base-at-this-url';
-const contentBasePublicOtherPath = '/serve-other-content-at-this-url';
+const staticPublicPath = '/serve-content-base-at-this-url';
+const otherStaticPublicPath = '/serve-other-content-at-this-url';
 
-describe('contentBasePublicPath option', () => {
+describe('static.publicPath option', () => {
   let server;
   let req;
 
@@ -27,9 +27,11 @@ describe('contentBasePublicPath option', () => {
       server = testServer.start(
         config,
         {
-          contentBase: contentBasePublic,
-          contentBasePublicPath,
-          watchContentBase: true,
+          static: {
+            directory: publicDirectory,
+            publicPath: staticPublicPath,
+            watch: true,
+          },
           port,
         },
         done
@@ -44,25 +46,25 @@ describe('contentBasePublicPath option', () => {
     });
 
     it('Request to index', (done) => {
-      req.get(`${contentBasePublicPath}/`).expect(200, /Heyo/, done);
+      req.get(`${staticPublicPath}/`).expect(200, /Heyo/, done);
     });
 
     it('Request to other file', (done) => {
-      req
-        .get(`${contentBasePublicPath}/other.html`)
-        .expect(200, /Other html/, done);
+      req.get(`${staticPublicPath}/other.html`).expect(200, /Other html/, done);
     });
   });
 
-  describe('test listing files in folders without index.html using the option serveIndex:false', () => {
+  describe('test listing files in folders without index.html using the option static.serveIndex:false', () => {
     beforeAll((done) => {
       server = testServer.start(
         config,
         {
-          contentBase: contentBasePublic,
-          contentBasePublicPath,
-          watchContentBase: true,
-          serveIndex: false,
+          static: {
+            directory: publicDirectory,
+            publicPath: staticPublicPath,
+            watch: true,
+            serveIndex: false,
+          },
           port,
         },
         done
@@ -77,23 +79,25 @@ describe('contentBasePublicPath option', () => {
     });
 
     it("shouldn't list the files inside the assets folder (404)", (done) => {
-      req.get(`${contentBasePublicPath}/assets/`).expect(404, done);
+      req.get(`${staticPublicPath}/assets/`).expect(404, done);
     });
 
     it('should show Heyo. because bar has index.html inside it (200)', (done) => {
-      req.get(`${contentBasePublicPath}/bar/`).expect(200, /Heyo/, done);
+      req.get(`${staticPublicPath}/bar/`).expect(200, /Heyo/, done);
     });
   });
 
-  describe('test listing files in folders without index.html using the option serveIndex:true', () => {
+  describe('test listing files in folders without index.html using the option static.serveIndex:true', () => {
     beforeAll((done) => {
       server = testServer.start(
         config,
         {
-          contentBase: contentBasePublic,
-          contentBasePublicPath,
-          watchContentBase: true,
-          serveIndex: true,
+          static: {
+            directory: publicDirectory,
+            publicPath: staticPublicPath,
+            watch: true,
+            serveIndex: true,
+          },
           port,
         },
         done
@@ -108,22 +112,24 @@ describe('contentBasePublicPath option', () => {
     });
 
     it('should list the files inside the assets folder (200)', (done) => {
-      req.get(`${contentBasePublicPath}/assets/`).expect(200, done);
+      req.get(`${staticPublicPath}/assets/`).expect(200, done);
     });
 
     it('should show Heyo. because bar has index.html inside it (200)', (done) => {
-      req.get(`${contentBasePublicPath}/bar/`).expect(200, /Heyo/, done);
+      req.get(`${staticPublicPath}/bar/`).expect(200, /Heyo/, done);
     });
   });
 
-  describe('test listing files in folders without index.html using the option serveIndex default (true)', () => {
+  describe('test listing files in folders without index.html using the option static.serveIndex default (true)', () => {
     beforeAll((done) => {
       server = testServer.start(
         config,
         {
-          contentBase: contentBasePublic,
-          contentBasePublicPath,
-          watchContentBase: true,
+          static: {
+            directory: publicDirectory,
+            publicPath: staticPublicPath,
+            watch: true,
+          },
           port,
         },
         done
@@ -138,11 +144,11 @@ describe('contentBasePublicPath option', () => {
     });
 
     it('should list the files inside the assets folder (200)', (done) => {
-      req.get(`${contentBasePublicPath}/assets/`).expect(200, done);
+      req.get(`${staticPublicPath}/assets/`).expect(200, done);
     });
 
     it('should show Heyo. because bar has index.html inside it (200)', (done) => {
-      req.get(`${contentBasePublicPath}/bar/`).expect(200, /Heyo/, done);
+      req.get(`${staticPublicPath}/bar/`).expect(200, /Heyo/, done);
     });
   });
 
@@ -151,8 +157,16 @@ describe('contentBasePublicPath option', () => {
       server = testServer.start(
         config,
         {
-          contentBase: [contentBasePublic, contentBaseOther],
-          contentBasePublicPath,
+          static: [
+            {
+              directory: publicDirectory,
+              publicPath: staticPublicPath,
+            },
+            {
+              directory: otherPublicDirectory,
+              publicPath: staticPublicPath,
+            },
+          ],
           port,
         },
         done
@@ -167,45 +181,24 @@ describe('contentBasePublicPath option', () => {
     });
 
     it('Request to first directory', (done) => {
-      req.get(`${contentBasePublicPath}/`).expect(200, /Heyo/, done);
+      req.get(`${staticPublicPath}/`).expect(200, /Heyo/, done);
     });
 
     it('Request to second directory', (done) => {
-      req.get(`${contentBasePublicPath}/foo.html`).expect(200, /Foo!/, done);
+      req.get(`${staticPublicPath}/foo.html`).expect(200, /Foo!/, done);
     });
   });
 
   describe('default to PWD', () => {
     beforeAll((done) => {
-      jest.spyOn(process, 'cwd').mockImplementation(() => contentBasePublic);
-
-      server = testServer.start(config, { contentBasePublicPath }, done);
-      req = request(server.app);
-    });
-
-    afterAll((done) => {
-      testServer.close(() => {
-        done();
-      });
-    });
-
-    it('Request to page', (done) => {
-      req.get(`${contentBasePublicPath}/other.html`).expect(200, done);
-    });
-  });
-
-  describe('disable', () => {
-    beforeAll((done) => {
-      // This is a somewhat weird test, but it is important that we mock
-      // the PWD here, and test if /other.html in our "fake" PWD really is not requested.
-      jest.spyOn(process, 'cwd').mockImplementation(() => contentBasePublic);
+      jest.spyOn(process, 'cwd').mockImplementation(() => publicDirectory);
 
       server = testServer.start(
         config,
         {
-          contentBase: false,
-          contentBasePublicPath,
-          port,
+          static: {
+            publicPath: staticPublicPath,
+          },
         },
         done
       );
@@ -219,7 +212,7 @@ describe('contentBasePublicPath option', () => {
     });
 
     it('Request to page', (done) => {
-      req.get(`${contentBasePublicPath}/other.html`).expect(404, done);
+      req.get(`${staticPublicPath}/other.html`).expect(200, done);
     });
   });
 
@@ -228,8 +221,10 @@ describe('contentBasePublicPath option', () => {
       server = testServer.start(
         config,
         {
-          contentBase: [contentBasePublic],
-          contentBasePublicPath,
+          static: {
+            directory: publicDirectory,
+            publicPath: staticPublicPath,
+          },
           port,
         },
         done
@@ -245,7 +240,7 @@ describe('contentBasePublicPath option', () => {
 
     it('Request foo.wasm', (done) => {
       req
-        .get(`${contentBasePublicPath}/foo.wasm`)
+        .get(`${staticPublicPath}/foo.wasm`)
         .expect('Content-Type', 'application/wasm', done);
     });
   });
@@ -255,9 +250,11 @@ describe('contentBasePublicPath option', () => {
       server = testServer.start(
         config,
         {
-          contentBase: contentBasePublic,
-          contentBasePublicPath,
-          watchContentBase: true,
+          static: {
+            directory: publicDirectory,
+            publicPath: staticPublicPath,
+            watch: true,
+          },
           port,
         },
         done
@@ -270,41 +267,47 @@ describe('contentBasePublicPath option', () => {
     });
 
     it('GET request', (done) => {
-      req.get(`${contentBasePublicPath}/`).expect(200, done);
+      req.get(`${staticPublicPath}/`).expect(200, done);
     });
 
     it('HEAD request', (done) => {
-      req.head(`${contentBasePublicPath}/`).expect(200, done);
+      req.head(`${staticPublicPath}/`).expect(200, done);
     });
 
     it('POST request', (done) => {
-      req.post(`${contentBasePublicPath}/`).expect(404, done);
+      req.post(`${staticPublicPath}/`).expect(404, done);
     });
 
     it('PUT request', (done) => {
-      req.put(`${contentBasePublicPath}/`).expect(404, done);
+      req.put(`${staticPublicPath}/`).expect(404, done);
     });
 
     it('DELETE request', (done) => {
-      req.delete(`${contentBasePublicPath}/`).expect(404, done);
+      req.delete(`${staticPublicPath}/`).expect(404, done);
     });
 
     it('PATCH request', (done) => {
-      req.patch(`${contentBasePublicPath}/`).expect(404, done);
+      req.patch(`${staticPublicPath}/`).expect(404, done);
     });
   });
 
-  describe('multiple contentBasePublicPath entries', () => {
+  describe('multiple static.publicPath entries', () => {
     beforeAll((done) => {
       server = testServer.start(
         config,
         {
-          contentBase: [contentBasePublic, contentBaseOther],
-          contentBasePublicPath: [
-            contentBasePublicPath,
-            contentBasePublicOtherPath,
+          static: [
+            {
+              directory: publicDirectory,
+              publicPath: staticPublicPath,
+              watch: true,
+            },
+            {
+              directory: otherPublicDirectory,
+              publicPath: otherStaticPublicPath,
+              watch: true,
+            },
           ],
-          watchContentBase: true,
           port,
         },
         done
@@ -319,19 +322,15 @@ describe('contentBasePublicPath option', () => {
     });
 
     it('Request the first path to index', (done) => {
-      req.get(`${contentBasePublicPath}/`).expect(200, /Heyo/, done);
+      req.get(`${staticPublicPath}/`).expect(200, /Heyo/, done);
     });
 
     it('Request the first path to other file', (done) => {
-      req
-        .get(`${contentBasePublicPath}/other.html`)
-        .expect(200, /Other html/, done);
+      req.get(`${staticPublicPath}/other.html`).expect(200, /Other html/, done);
     });
 
     it('Request the second path to foo', (done) => {
-      req
-        .get(`${contentBasePublicOtherPath}/foo.html`)
-        .expect(200, /Foo!/, done);
+      req.get(`${otherStaticPublicPath}/foo.html`).expect(200, /Foo!/, done);
     });
   });
 });

--- a/test/server/stats-option.test.js
+++ b/test/server/stats-option.test.js
@@ -22,7 +22,10 @@ describe('stats option', () => {
       return p.then(() => {
         return new Promise((resolve) => {
           const compiler = webpack(Object.assign({}, config, { stats }));
-          const server = new Server(compiler, { port });
+          const server = new Server(compiler, {
+            static: false,
+            port,
+          });
 
           compiler.hooks.done.tap('webpack-dev-server', (s) => {
             expect(Object.keys(server.getStats(s)).sort()).toMatchSnapshot();
@@ -44,6 +47,7 @@ describe('stats option', () => {
       })
     );
     const server = new Server(compiler, {
+      static: false,
       port,
     });
 

--- a/test/server/utils/__snapshots__/createConfig.test.js.snap
+++ b/test/server/utils/__snapshots__/createConfig.test.js.snap
@@ -606,12 +606,26 @@ Object {
 }
 `;
 
+exports[`createConfig static option (list of strings) 1`] = `
+Object {
+  "dev": Object {},
+  "hot": true,
+  "port": 8080,
+  "static": Array [
+    "assets1",
+    "assets2",
+  ],
+}
+`;
+
 exports[`createConfig static option (string) 1`] = `
 Object {
   "dev": Object {},
   "hot": true,
   "port": 8080,
-  "static": "assets",
+  "static": Array [
+    "assets",
+  ],
 }
 `;
 

--- a/test/server/utils/__snapshots__/createConfig.test.js.snap
+++ b/test/server/utils/__snapshots__/createConfig.test.js.snap
@@ -93,45 +93,6 @@ Object {
 }
 `;
 
-exports[`createConfig contentBase option (array) 1`] = `
-Object {
-  "contentBase": Array [
-    "assets",
-    "static",
-  ],
-  "dev": Object {},
-  "hot": true,
-  "port": 8080,
-}
-`;
-
-exports[`createConfig contentBase option (boolean) 1`] = `
-Object {
-  "contentBase": false,
-  "dev": Object {},
-  "hot": true,
-  "port": 8080,
-}
-`;
-
-exports[`createConfig contentBase option (string) (in devServer config) 1`] = `
-Object {
-  "contentBase": "assets",
-  "dev": Object {},
-  "hot": true,
-  "port": 8080,
-}
-`;
-
-exports[`createConfig contentBase option (string) 1`] = `
-Object {
-  "contentBase": "assets",
-  "dev": Object {},
-  "hot": true,
-  "port": 8080,
-}
-`;
-
 exports[`createConfig disableHostCheck option (in devServer config) 1`] = `
 Object {
   "dev": Object {},
@@ -627,6 +588,33 @@ Object {
 }
 `;
 
+exports[`createConfig static option (boolean) 1`] = `
+Object {
+  "dev": Object {},
+  "hot": true,
+  "port": 8080,
+  "static": false,
+}
+`;
+
+exports[`createConfig static option (in devServer config) 1`] = `
+Object {
+  "dev": Object {},
+  "hot": true,
+  "port": 8080,
+  "static": true,
+}
+`;
+
+exports[`createConfig static option (string) 1`] = `
+Object {
+  "dev": Object {},
+  "hot": true,
+  "port": 8080,
+  "static": "assets",
+}
+`;
+
 exports[`createConfig useLocalIp option (in devServer config) 1`] = `
 Object {
   "dev": Object {},
@@ -642,45 +630,5 @@ Object {
   "hot": true,
   "port": 8080,
   "useLocalIp": true,
-}
-`;
-
-exports[`createConfig watchContentBase option (in devServer config) 1`] = `
-Object {
-  "dev": Object {},
-  "hot": true,
-  "port": 8080,
-  "watchContentBase": true,
-}
-`;
-
-exports[`createConfig watchContentBase option 1`] = `
-Object {
-  "dev": Object {},
-  "hot": true,
-  "port": 8080,
-  "watchContentBase": true,
-}
-`;
-
-exports[`createConfig watchOptions option (in devServer config) 1`] = `
-Object {
-  "dev": Object {},
-  "hot": true,
-  "port": 8080,
-  "watchOptions": Object {
-    "poll": true,
-  },
-}
-`;
-
-exports[`createConfig watchOptions option (in output config) 1`] = `
-Object {
-  "dev": Object {},
-  "hot": true,
-  "port": 8080,
-  "watchOptions": Object {
-    "poll": true,
-  },
 }
 `;

--- a/test/server/utils/__snapshots__/normalizeOptions.test.js.snap
+++ b/test/server/utils/__snapshots__/normalizeOptions.test.js.snap
@@ -86,67 +86,6 @@ Object {
 }
 `;
 
-exports[`normalizeOptions contentBase array should set correct options 1`] = `
-Object {
-  "client": Object {
-    "path": "/ws",
-  },
-  "contentBase": Array [
-    "/path/to/dist1",
-    "/path/to/dist2",
-  ],
-  "dev": Object {},
-  "hot": true,
-  "liveReload": true,
-  "static": Array [
-    Object {
-      "directory": "CWD",
-      "publicPath": Array [
-        "/",
-      ],
-      "serveIndex": Object {
-        "icons": true,
-      },
-      "staticOptions": Object {},
-      "watch": Object {},
-    },
-  ],
-  "transportMode": Object {
-    "client": "ws",
-    "server": "ws",
-  },
-}
-`;
-
-exports[`normalizeOptions contentBase string should set correct options 1`] = `
-Object {
-  "client": Object {
-    "path": "/ws",
-  },
-  "contentBase": "/path/to/dist",
-  "dev": Object {},
-  "hot": true,
-  "liveReload": true,
-  "static": Array [
-    Object {
-      "directory": "CWD",
-      "publicPath": Array [
-        "/",
-      ],
-      "serveIndex": Object {
-        "icons": true,
-      },
-      "staticOptions": Object {},
-      "watch": Object {},
-    },
-  ],
-  "transportMode": Object {
-    "client": "ws",
-    "server": "ws",
-  },
-}
-`;
-
 exports[`normalizeOptions dev is set should set correct options 1`] = `
 Object {
   "client": Object {
@@ -1099,37 +1038,6 @@ Object {
   "transportMode": Object {
     "client": "ws",
     "server": "ws",
-  },
-}
-`;
-
-exports[`normalizeOptions watchOptions should set correct options 1`] = `
-Object {
-  "client": Object {
-    "path": "/ws",
-  },
-  "dev": Object {},
-  "hot": true,
-  "liveReload": true,
-  "static": Array [
-    Object {
-      "directory": "CWD",
-      "publicPath": Array [
-        "/",
-      ],
-      "serveIndex": Object {
-        "icons": true,
-      },
-      "staticOptions": Object {},
-      "watch": Object {},
-    },
-  ],
-  "transportMode": Object {
-    "client": "ws",
-    "server": "ws",
-  },
-  "watchOptions": Object {
-    "poll": true,
   },
 }
 `;

--- a/test/server/utils/__snapshots__/normalizeOptions.test.js.snap
+++ b/test/server/utils/__snapshots__/normalizeOptions.test.js.snap
@@ -7,16 +7,26 @@ Object {
     "path": "/ws",
     "port": 9000,
   },
-  "contentBasePublicPath": "/",
   "dev": Object {},
   "hot": true,
   "liveReload": true,
-  "serveIndex": true,
+  "static": Array [
+    Object {
+      "directory": "CWD",
+      "publicPath": Array [
+        "/",
+      ],
+      "serveIndex": Object {
+        "icons": true,
+      },
+      "staticOptions": Object {},
+      "watch": Object {},
+    },
+  ],
   "transportMode": Object {
     "client": "ws",
     "server": "ws",
   },
-  "watchOptions": Object {},
 }
 `;
 
@@ -25,16 +35,26 @@ Object {
   "client": Object {
     "path": "/custom/path",
   },
-  "contentBasePublicPath": "/",
   "dev": Object {},
   "hot": true,
   "liveReload": true,
-  "serveIndex": true,
+  "static": Array [
+    Object {
+      "directory": "CWD",
+      "publicPath": Array [
+        "/",
+      ],
+      "serveIndex": Object {
+        "icons": true,
+      },
+      "staticOptions": Object {},
+      "watch": Object {},
+    },
+  ],
   "transportMode": Object {
     "client": "ws",
     "server": "ws",
   },
-  "watchOptions": Object {},
 }
 `;
 
@@ -43,16 +63,26 @@ Object {
   "client": Object {
     "path": "/custom/path",
   },
-  "contentBasePublicPath": "/",
   "dev": Object {},
   "hot": true,
   "liveReload": true,
-  "serveIndex": true,
+  "static": Array [
+    Object {
+      "directory": "CWD",
+      "publicPath": Array [
+        "/",
+      ],
+      "serveIndex": Object {
+        "icons": true,
+      },
+      "staticOptions": Object {},
+      "watch": Object {},
+    },
+  ],
   "transportMode": Object {
     "client": "ws",
     "server": "ws",
   },
-  "watchOptions": Object {},
 }
 `;
 
@@ -65,16 +95,26 @@ Object {
     "/path/to/dist1",
     "/path/to/dist2",
   ],
-  "contentBasePublicPath": "/",
   "dev": Object {},
   "hot": true,
   "liveReload": true,
-  "serveIndex": true,
+  "static": Array [
+    Object {
+      "directory": "CWD",
+      "publicPath": Array [
+        "/",
+      ],
+      "serveIndex": Object {
+        "icons": true,
+      },
+      "staticOptions": Object {},
+      "watch": Object {},
+    },
+  ],
   "transportMode": Object {
     "client": "ws",
     "server": "ws",
   },
-  "watchOptions": Object {},
 }
 `;
 
@@ -84,34 +124,26 @@ Object {
     "path": "/ws",
   },
   "contentBase": "/path/to/dist",
-  "contentBasePublicPath": "/",
   "dev": Object {},
   "hot": true,
   "liveReload": true,
-  "serveIndex": true,
+  "static": Array [
+    Object {
+      "directory": "CWD",
+      "publicPath": Array [
+        "/",
+      ],
+      "serveIndex": Object {
+        "icons": true,
+      },
+      "staticOptions": Object {},
+      "watch": Object {},
+    },
+  ],
   "transportMode": Object {
     "client": "ws",
     "server": "ws",
   },
-  "watchOptions": Object {},
-}
-`;
-
-exports[`normalizeOptions contentBasePublicPath string should set correct options 1`] = `
-Object {
-  "client": Object {
-    "path": "/ws",
-  },
-  "contentBasePublicPath": "/content-base-public-path",
-  "dev": Object {},
-  "hot": true,
-  "liveReload": true,
-  "serveIndex": true,
-  "transportMode": Object {
-    "client": "ws",
-    "server": "ws",
-  },
-  "watchOptions": Object {},
 }
 `;
 
@@ -120,18 +152,28 @@ Object {
   "client": Object {
     "path": "/ws",
   },
-  "contentBasePublicPath": "/",
   "dev": Object {
     "serverSideRender": true,
   },
   "hot": true,
   "liveReload": true,
-  "serveIndex": true,
+  "static": Array [
+    Object {
+      "directory": "CWD",
+      "publicPath": Array [
+        "/",
+      ],
+      "serveIndex": Object {
+        "icons": true,
+      },
+      "staticOptions": Object {},
+      "watch": Object {},
+    },
+  ],
   "transportMode": Object {
     "client": "ws",
     "server": "ws",
   },
-  "watchOptions": Object {},
 }
 `;
 
@@ -140,16 +182,26 @@ Object {
   "client": Object {
     "path": "/ws",
   },
-  "contentBasePublicPath": "/",
   "dev": Object {},
   "hot": false,
   "liveReload": true,
-  "serveIndex": true,
+  "static": Array [
+    Object {
+      "directory": "CWD",
+      "publicPath": Array [
+        "/",
+      ],
+      "serveIndex": Object {
+        "icons": true,
+      },
+      "staticOptions": Object {},
+      "watch": Object {},
+    },
+  ],
   "transportMode": Object {
     "client": "ws",
     "server": "ws",
   },
-  "watchOptions": Object {},
 }
 `;
 
@@ -158,16 +210,26 @@ Object {
   "client": Object {
     "path": "/ws",
   },
-  "contentBasePublicPath": "/",
   "dev": Object {},
   "hot": "only",
   "liveReload": true,
-  "serveIndex": true,
+  "static": Array [
+    Object {
+      "directory": "CWD",
+      "publicPath": Array [
+        "/",
+      ],
+      "serveIndex": Object {
+        "icons": true,
+      },
+      "staticOptions": Object {},
+      "watch": Object {},
+    },
+  ],
   "transportMode": Object {
     "client": "ws",
     "server": "ws",
   },
-  "watchOptions": Object {},
 }
 `;
 
@@ -176,16 +238,26 @@ Object {
   "client": Object {
     "path": "/ws",
   },
-  "contentBasePublicPath": "/",
   "dev": Object {},
   "hot": true,
   "liveReload": true,
-  "serveIndex": true,
+  "static": Array [
+    Object {
+      "directory": "CWD",
+      "publicPath": Array [
+        "/",
+      ],
+      "serveIndex": Object {
+        "icons": true,
+      },
+      "staticOptions": Object {},
+      "watch": Object {},
+    },
+  ],
   "transportMode": Object {
     "client": "ws",
     "server": "ws",
   },
-  "watchOptions": Object {},
 }
 `;
 
@@ -194,16 +266,26 @@ Object {
   "client": Object {
     "path": "/ws",
   },
-  "contentBasePublicPath": "/",
   "dev": Object {},
   "hot": true,
   "liveReload": false,
-  "serveIndex": true,
+  "static": Array [
+    Object {
+      "directory": "CWD",
+      "publicPath": Array [
+        "/",
+      ],
+      "serveIndex": Object {
+        "icons": true,
+      },
+      "staticOptions": Object {},
+      "watch": Object {},
+    },
+  ],
   "transportMode": Object {
     "client": "ws",
     "server": "ws",
   },
-  "watchOptions": Object {},
 }
 `;
 
@@ -212,16 +294,26 @@ Object {
   "client": Object {
     "path": "/ws",
   },
-  "contentBasePublicPath": "/",
   "dev": Object {},
   "hot": true,
   "liveReload": true,
-  "serveIndex": true,
+  "static": Array [
+    Object {
+      "directory": "CWD",
+      "publicPath": Array [
+        "/",
+      ],
+      "serveIndex": Object {
+        "icons": true,
+      },
+      "staticOptions": Object {},
+      "watch": Object {},
+    },
+  ],
   "transportMode": Object {
     "client": "ws",
     "server": "ws",
   },
-  "watchOptions": Object {},
 }
 `;
 
@@ -230,16 +322,215 @@ Object {
   "client": Object {
     "path": "/ws",
   },
-  "contentBasePublicPath": "/",
   "dev": Object {},
   "hot": true,
   "liveReload": true,
-  "serveIndex": true,
+  "static": Array [
+    Object {
+      "directory": "CWD",
+      "publicPath": Array [
+        "/",
+      ],
+      "serveIndex": Object {
+        "icons": true,
+      },
+      "staticOptions": Object {},
+      "watch": Object {},
+    },
+  ],
   "transportMode": Object {
     "client": "ws",
     "server": "ws",
   },
-  "watchOptions": Object {},
+}
+`;
+
+exports[`normalizeOptions static is an array of static objects should set correct options 1`] = `
+Object {
+  "client": Object {
+    "path": "/ws",
+  },
+  "dev": Object {},
+  "hot": true,
+  "liveReload": true,
+  "static": Array [
+    Object {
+      "directory": "/static/path1",
+      "publicPath": Array [
+        "/",
+      ],
+      "serveIndex": Object {
+        "icons": true,
+      },
+      "staticOptions": Object {},
+      "watch": Object {},
+    },
+    Object {
+      "directory": "CWD",
+      "publicPath": Array [
+        "/static/public/path",
+      ],
+      "serveIndex": Object {
+        "icons": true,
+      },
+      "staticOptions": Object {},
+      "watch": Object {},
+    },
+  ],
+  "transportMode": Object {
+    "client": "ws",
+    "server": "ws",
+  },
+}
+`;
+
+exports[`normalizeOptions static is an array of strings and static objects should set correct options 1`] = `
+Object {
+  "client": Object {
+    "path": "/ws",
+  },
+  "dev": Object {},
+  "hot": true,
+  "liveReload": true,
+  "static": Array [
+    Object {
+      "directory": "/static/path1",
+      "publicPath": Array [
+        "/",
+      ],
+      "serveIndex": Object {
+        "icons": true,
+      },
+      "staticOptions": Object {},
+      "watch": Object {},
+    },
+    Object {
+      "directory": "CWD",
+      "publicPath": Array [
+        "/static/public/path",
+      ],
+      "serveIndex": Object {
+        "icons": true,
+      },
+      "staticOptions": Object {},
+      "watch": Object {},
+    },
+  ],
+  "transportMode": Object {
+    "client": "ws",
+    "server": "ws",
+  },
+}
+`;
+
+exports[`normalizeOptions static is an array of strings should set correct options 1`] = `
+Object {
+  "client": Object {
+    "path": "/ws",
+  },
+  "dev": Object {},
+  "hot": true,
+  "liveReload": true,
+  "static": Array [
+    Object {
+      "directory": "/static/path1",
+      "publicPath": Array [
+        "/",
+      ],
+      "serveIndex": Object {
+        "icons": true,
+      },
+      "staticOptions": Object {},
+      "watch": Object {},
+    },
+    Object {
+      "directory": "/static/path2",
+      "publicPath": Array [
+        "/",
+      ],
+      "serveIndex": Object {
+        "icons": true,
+      },
+      "staticOptions": Object {},
+      "watch": Object {},
+    },
+  ],
+  "transportMode": Object {
+    "client": "ws",
+    "server": "ws",
+  },
+}
+`;
+
+exports[`normalizeOptions static is false should set correct options 1`] = `
+Object {
+  "client": Object {
+    "path": "/ws",
+  },
+  "dev": Object {},
+  "hot": true,
+  "liveReload": true,
+  "static": false,
+  "transportMode": Object {
+    "client": "ws",
+    "server": "ws",
+  },
+}
+`;
+
+exports[`normalizeOptions static is string should set correct options 1`] = `
+Object {
+  "client": Object {
+    "path": "/ws",
+  },
+  "dev": Object {},
+  "hot": true,
+  "liveReload": true,
+  "static": Array [
+    Object {
+      "directory": "/static/path",
+      "publicPath": Array [
+        "/",
+      ],
+      "serveIndex": Object {
+        "icons": true,
+      },
+      "staticOptions": Object {},
+      "watch": Object {},
+    },
+  ],
+  "transportMode": Object {
+    "client": "ws",
+    "server": "ws",
+  },
+}
+`;
+
+exports[`normalizeOptions static is true should set correct options 1`] = `
+Object {
+  "client": Object {
+    "path": "/ws",
+  },
+  "dev": Object {},
+  "hot": true,
+  "liveReload": true,
+  "static": Array [
+    Object {
+      "directory": "CWD",
+      "publicPath": Array [
+        "/",
+      ],
+      "serveIndex": Object {
+        "icons": true,
+      },
+      "staticOptions": Object {},
+      "watch": Object {},
+    },
+  ],
+  "transportMode": Object {
+    "client": "ws",
+    "server": "ws",
+  },
 }
 `;
 
@@ -248,16 +539,26 @@ Object {
   "client": Object {
     "path": "/ws",
   },
-  "contentBasePublicPath": "/",
   "dev": Object {},
   "hot": true,
   "liveReload": true,
-  "serveIndex": true,
+  "static": Array [
+    Object {
+      "directory": "CWD",
+      "publicPath": Array [
+        "/",
+      ],
+      "serveIndex": Object {
+        "icons": true,
+      },
+      "staticOptions": Object {},
+      "watch": Object {},
+    },
+  ],
   "transportMode": Object {
     "client": "/path/to/custom/client/",
     "server": "ws",
   },
-  "watchOptions": Object {},
 }
 `;
 
@@ -266,16 +567,26 @@ Object {
   "client": Object {
     "path": "/ws",
   },
-  "contentBasePublicPath": "/",
   "dev": Object {},
   "hot": true,
   "liveReload": true,
-  "serveIndex": true,
+  "static": Array [
+    Object {
+      "directory": "CWD",
+      "publicPath": Array [
+        "/",
+      ],
+      "serveIndex": Object {
+        "icons": true,
+      },
+      "staticOptions": Object {},
+      "watch": Object {},
+    },
+  ],
   "transportMode": Object {
     "client": "ws",
     "server": [Function],
   },
-  "watchOptions": Object {},
 }
 `;
 
@@ -284,16 +595,26 @@ Object {
   "client": Object {
     "path": "/ws",
   },
-  "contentBasePublicPath": "/",
   "dev": Object {},
   "hot": true,
   "liveReload": true,
-  "serveIndex": true,
+  "static": Array [
+    Object {
+      "directory": "CWD",
+      "publicPath": Array [
+        "/",
+      ],
+      "serveIndex": Object {
+        "icons": true,
+      },
+      "staticOptions": Object {},
+      "watch": Object {},
+    },
+  ],
   "transportMode": Object {
     "client": "ws",
     "server": "/path/to/custom/server/",
   },
-  "watchOptions": Object {},
 }
 `;
 
@@ -302,16 +623,26 @@ Object {
   "client": Object {
     "path": "/ws",
   },
-  "contentBasePublicPath": "/",
   "dev": Object {},
   "hot": true,
   "liveReload": true,
-  "serveIndex": true,
+  "static": Array [
+    Object {
+      "directory": "CWD",
+      "publicPath": Array [
+        "/",
+      ],
+      "serveIndex": Object {
+        "icons": true,
+      },
+      "staticOptions": Object {},
+      "watch": Object {},
+    },
+  ],
   "transportMode": Object {
     "client": "sockjs",
     "server": "sockjs",
   },
-  "watchOptions": Object {},
 }
 `;
 
@@ -320,16 +651,26 @@ Object {
   "client": Object {
     "path": "/ws",
   },
-  "contentBasePublicPath": "/",
   "dev": Object {},
   "hot": true,
   "liveReload": true,
-  "serveIndex": true,
+  "static": Array [
+    Object {
+      "directory": "CWD",
+      "publicPath": Array [
+        "/",
+      ],
+      "serveIndex": Object {
+        "icons": true,
+      },
+      "staticOptions": Object {},
+      "watch": Object {},
+    },
+  ],
   "transportMode": Object {
     "client": "ws",
     "server": "ws",
   },
-  "watchOptions": Object {},
 }
 `;
 
@@ -338,16 +679,26 @@ Object {
   "client": Object {
     "path": "/ws",
   },
-  "contentBasePublicPath": "/",
   "dev": Object {},
   "hot": true,
   "liveReload": true,
-  "serveIndex": true,
+  "static": Array [
+    Object {
+      "directory": "CWD",
+      "publicPath": Array [
+        "/",
+      ],
+      "serveIndex": Object {
+        "icons": true,
+      },
+      "staticOptions": Object {},
+      "watch": Object {},
+    },
+  ],
   "transportMode": Object {
     "client": "ws",
     "server": "ws",
   },
-  "watchOptions": Object {},
 }
 `;
 
@@ -356,11 +707,22 @@ Object {
   "client": Object {
     "path": "/ws",
   },
-  "contentBasePublicPath": "/",
   "dev": Object {},
   "hot": true,
   "liveReload": true,
-  "serveIndex": true,
+  "static": Array [
+    Object {
+      "directory": "CWD",
+      "publicPath": Array [
+        "/",
+      ],
+      "serveIndex": Object {
+        "icons": true,
+      },
+      "staticOptions": Object {},
+      "watch": Object {},
+    },
+  ],
   "transportMode": Object {
     "client": "ws",
     "server": "ws",

--- a/test/server/utils/__snapshots__/normalizeOptions.test.js.snap
+++ b/test/server/utils/__snapshots__/normalizeOptions.test.js.snap
@@ -317,7 +317,155 @@ Object {
 }
 `;
 
+exports[`normalizeOptions multi compiler watchOptions is set should set correct options 1`] = `
+Object {
+  "client": Object {
+    "path": "/ws",
+  },
+  "dev": Object {},
+  "hot": true,
+  "liveReload": true,
+  "static": Array [
+    Object {
+      "directory": "CWD",
+      "publicPath": Array [
+        "/",
+      ],
+      "serveIndex": Object {
+        "icons": true,
+      },
+      "staticOptions": Object {},
+      "watch": Object {
+        "aggregateTimeout": 300,
+      },
+    },
+  ],
+  "transportMode": Object {
+    "client": "ws",
+    "server": "ws",
+  },
+}
+`;
+
 exports[`normalizeOptions no options should set correct options 1`] = `
+Object {
+  "client": Object {
+    "path": "/ws",
+  },
+  "dev": Object {},
+  "hot": true,
+  "liveReload": true,
+  "static": Array [
+    Object {
+      "directory": "CWD",
+      "publicPath": Array [
+        "/",
+      ],
+      "serveIndex": Object {
+        "icons": true,
+      },
+      "staticOptions": Object {},
+      "watch": Object {},
+    },
+  ],
+  "transportMode": Object {
+    "client": "ws",
+    "server": "ws",
+  },
+}
+`;
+
+exports[`normalizeOptions single compiler watchOptions is object should set correct options 1`] = `
+Object {
+  "client": Object {
+    "path": "/ws",
+  },
+  "dev": Object {},
+  "hot": true,
+  "liveReload": true,
+  "static": Array [
+    Object {
+      "directory": "CWD",
+      "publicPath": Array [
+        "/",
+      ],
+      "serveIndex": Object {
+        "icons": true,
+      },
+      "staticOptions": Object {},
+      "watch": Object {
+        "aggregateTimeout": 300,
+      },
+    },
+  ],
+  "transportMode": Object {
+    "client": "ws",
+    "server": "ws",
+  },
+}
+`;
+
+exports[`normalizeOptions single compiler watchOptions is object with static watch overriding it should set correct options 1`] = `
+Object {
+  "client": Object {
+    "path": "/ws",
+  },
+  "dev": Object {},
+  "hot": true,
+  "liveReload": true,
+  "static": Array [
+    Object {
+      "directory": "CWD",
+      "publicPath": Array [
+        "/",
+      ],
+      "serveIndex": Object {
+        "icons": true,
+      },
+      "staticOptions": Object {},
+      "watch": Object {
+        "poll": 500,
+      },
+    },
+  ],
+  "transportMode": Object {
+    "client": "ws",
+    "server": "ws",
+  },
+}
+`;
+
+exports[`normalizeOptions single compiler watchOptions is object with static watch true should set correct options 1`] = `
+Object {
+  "client": Object {
+    "path": "/ws",
+  },
+  "dev": Object {},
+  "hot": true,
+  "liveReload": true,
+  "static": Array [
+    Object {
+      "directory": "CWD",
+      "publicPath": Array [
+        "/",
+      ],
+      "serveIndex": Object {
+        "icons": true,
+      },
+      "staticOptions": Object {},
+      "watch": Object {
+        "aggregateTimeout": 300,
+      },
+    },
+  ],
+  "transportMode": Object {
+    "client": "ws",
+    "server": "ws",
+  },
+}
+`;
+
+exports[`normalizeOptions single compiler watchOptions is object with watch false should set correct options 1`] = `
 Object {
   "client": Object {
     "path": "/ws",
@@ -407,7 +555,7 @@ Object {
     Object {
       "directory": "CWD",
       "publicPath": Array [
-        "/static/public/path",
+        "/static/public/path/",
       ],
       "serveIndex": Object {
         "icons": true,
@@ -445,6 +593,34 @@ Object {
     },
     Object {
       "directory": "/static/path2",
+      "publicPath": Array [
+        "/",
+      ],
+      "serveIndex": Object {
+        "icons": true,
+      },
+      "staticOptions": Object {},
+      "watch": Object {},
+    },
+  ],
+  "transportMode": Object {
+    "client": "ws",
+    "server": "ws",
+  },
+}
+`;
+
+exports[`normalizeOptions static is an object should set correct options 1`] = `
+Object {
+  "client": Object {
+    "path": "/ws",
+  },
+  "dev": Object {},
+  "hot": true,
+  "liveReload": true,
+  "static": Array [
+    Object {
+      "directory": "/static/path",
       "publicPath": Array [
         "/",
       ],
@@ -507,6 +683,231 @@ Object {
 `;
 
 exports[`normalizeOptions static is true should set correct options 1`] = `
+Object {
+  "client": Object {
+    "path": "/ws",
+  },
+  "dev": Object {},
+  "hot": true,
+  "liveReload": true,
+  "static": Array [
+    Object {
+      "directory": "CWD",
+      "publicPath": Array [
+        "/",
+      ],
+      "serveIndex": Object {
+        "icons": true,
+      },
+      "staticOptions": Object {},
+      "watch": Object {},
+    },
+  ],
+  "transportMode": Object {
+    "client": "ws",
+    "server": "ws",
+  },
+}
+`;
+
+exports[`normalizeOptions static publicPath is a string should set correct options 1`] = `
+Object {
+  "client": Object {
+    "path": "/ws",
+  },
+  "dev": Object {},
+  "hot": true,
+  "liveReload": true,
+  "static": Array [
+    Object {
+      "directory": "CWD",
+      "publicPath": Array [
+        "/static/public/path/",
+      ],
+      "serveIndex": Object {
+        "icons": true,
+      },
+      "staticOptions": Object {},
+      "watch": Object {},
+    },
+  ],
+  "transportMode": Object {
+    "client": "ws",
+    "server": "ws",
+  },
+}
+`;
+
+exports[`normalizeOptions static publicPath is an array should set correct options 1`] = `
+Object {
+  "client": Object {
+    "path": "/ws",
+  },
+  "dev": Object {},
+  "hot": true,
+  "liveReload": true,
+  "static": Array [
+    Object {
+      "directory": "CWD",
+      "publicPath": Array [
+        "/static/public/path1/",
+        "/static/public/path2/",
+      ],
+      "serveIndex": Object {
+        "icons": true,
+      },
+      "staticOptions": Object {},
+      "watch": Object {},
+    },
+  ],
+  "transportMode": Object {
+    "client": "ws",
+    "server": "ws",
+  },
+}
+`;
+
+exports[`normalizeOptions static serveIndex is an object should set correct options 1`] = `
+Object {
+  "client": Object {
+    "path": "/ws",
+  },
+  "dev": Object {},
+  "hot": true,
+  "liveReload": true,
+  "static": Array [
+    Object {
+      "directory": "CWD",
+      "publicPath": Array [
+        "/",
+      ],
+      "serveIndex": Object {
+        "icons": false,
+      },
+      "staticOptions": Object {},
+      "watch": Object {},
+    },
+  ],
+  "transportMode": Object {
+    "client": "ws",
+    "server": "ws",
+  },
+}
+`;
+
+exports[`normalizeOptions static serveIndex is false should set correct options 1`] = `
+Object {
+  "client": Object {
+    "path": "/ws",
+  },
+  "dev": Object {},
+  "hot": true,
+  "liveReload": true,
+  "static": Array [
+    Object {
+      "directory": "CWD",
+      "publicPath": Array [
+        "/",
+      ],
+      "serveIndex": false,
+      "staticOptions": Object {},
+      "watch": Object {},
+    },
+  ],
+  "transportMode": Object {
+    "client": "ws",
+    "server": "ws",
+  },
+}
+`;
+
+exports[`normalizeOptions static serveIndex is true should set correct options 1`] = `
+Object {
+  "client": Object {
+    "path": "/ws",
+  },
+  "dev": Object {},
+  "hot": true,
+  "liveReload": true,
+  "static": Array [
+    Object {
+      "directory": "CWD",
+      "publicPath": Array [
+        "/",
+      ],
+      "serveIndex": Object {
+        "icons": true,
+      },
+      "staticOptions": Object {},
+      "watch": Object {},
+    },
+  ],
+  "transportMode": Object {
+    "client": "ws",
+    "server": "ws",
+  },
+}
+`;
+
+exports[`normalizeOptions static watch is an object should set correct options 1`] = `
+Object {
+  "client": Object {
+    "path": "/ws",
+  },
+  "dev": Object {},
+  "hot": true,
+  "liveReload": true,
+  "static": Array [
+    Object {
+      "directory": "CWD",
+      "publicPath": Array [
+        "/",
+      ],
+      "serveIndex": Object {
+        "icons": true,
+      },
+      "staticOptions": Object {},
+      "watch": Object {
+        "poll": 500,
+      },
+    },
+  ],
+  "transportMode": Object {
+    "client": "ws",
+    "server": "ws",
+  },
+}
+`;
+
+exports[`normalizeOptions static watch is false should set correct options 1`] = `
+Object {
+  "client": Object {
+    "path": "/ws",
+  },
+  "dev": Object {},
+  "hot": true,
+  "liveReload": true,
+  "static": Array [
+    Object {
+      "directory": "CWD",
+      "publicPath": Array [
+        "/",
+      ],
+      "serveIndex": Object {
+        "icons": true,
+      },
+      "staticOptions": Object {},
+      "watch": false,
+    },
+  ],
+  "transportMode": Object {
+    "client": "ws",
+    "server": "ws",
+  },
+}
+`;
+
+exports[`normalizeOptions static watch is true should set correct options 1`] = `
 Object {
   "client": Object {
     "path": "/ws",

--- a/test/server/utils/createConfig.test.js
+++ b/test/server/utils/createConfig.test.js
@@ -257,30 +257,6 @@ describe('createConfig', () => {
     expect(config).toMatchSnapshot();
   });
 
-  it('watchOptions option (in output config)', () => {
-    const config = createConfig(
-      Object.assign({}, webpackConfig, {
-        watchOptions: { poll: true },
-      }),
-      argv,
-      { port: 8080 }
-    );
-
-    expect(config).toMatchSnapshot();
-  });
-
-  it('watchOptions option (in devServer config)', () => {
-    const config = createConfig(
-      Object.assign({}, webpackConfig, {
-        devServer: { watchOptions: { poll: true } },
-      }),
-      argv,
-      { port: 8080 }
-    );
-
-    expect(config).toMatchSnapshot();
-  });
-
   it('hot option (true)', () => {
     const config = createConfig(
       webpackConfig,
@@ -391,70 +367,32 @@ describe('createConfig', () => {
     expect(config).toMatchSnapshot();
   });
 
-  it('contentBase option (string)', () => {
+  it('static option (string)', () => {
     const config = createConfig(
       webpackConfig,
-      Object.assign({}, argv, { contentBase: 'assets' }),
+      Object.assign({}, argv, { static: 'assets' }),
       { port: 8080 }
     );
 
-    config.contentBase = path.relative(process.cwd(), config.contentBase);
+    config.static = path.relative(process.cwd(), config.static);
 
     expect(config).toMatchSnapshot();
   });
 
-  it('contentBase option (array)', () => {
+  it('static option (boolean)', () => {
     const config = createConfig(
       webpackConfig,
-      Object.assign({}, argv, { contentBase: ['assets', 'static'] }),
-      { port: 8080 }
-    );
-
-    config.contentBase = config.contentBase.map((item) =>
-      path.relative(process.cwd(), item)
-    );
-
-    expect(config).toMatchSnapshot();
-  });
-
-  it('contentBase option (boolean)', () => {
-    const config = createConfig(
-      webpackConfig,
-      Object.assign({}, argv, { contentBase: false }),
+      Object.assign({}, argv, { static: false }),
       { port: 8080 }
     );
 
     expect(config).toMatchSnapshot();
   });
 
-  it('contentBase option (string) (in devServer config)', () => {
+  it('static option (in devServer config)', () => {
     const config = createConfig(
       Object.assign({}, webpackConfig, {
-        devServer: { contentBase: 'assets' },
-      }),
-      argv,
-      { port: 8080 }
-    );
-
-    config.contentBase = path.relative(process.cwd(), config.contentBase);
-
-    expect(config).toMatchSnapshot();
-  });
-
-  it('watchContentBase option', () => {
-    const config = createConfig(
-      webpackConfig,
-      Object.assign({}, argv, { watchContentBase: true }),
-      { port: 8080 }
-    );
-
-    expect(config).toMatchSnapshot();
-  });
-
-  it('watchContentBase option (in devServer config)', () => {
-    const config = createConfig(
-      Object.assign({}, webpackConfig, {
-        devServer: { watchContentBase: true },
+        devServer: { static: true },
       }),
       argv,
       { port: 8080 }

--- a/test/server/utils/createConfig.test.js
+++ b/test/server/utils/createConfig.test.js
@@ -384,7 +384,7 @@ describe('createConfig', () => {
   it('static option (list of strings)', () => {
     const config = createConfig(
       webpackConfig,
-      Object.assign({}, argv, { static: 'assets1,assets2' }),
+      Object.assign({}, argv, { static: ['assets1', 'assets2'] }),
       { port: 8080 }
     );
 

--- a/test/server/utils/createConfig.test.js
+++ b/test/server/utils/createConfig.test.js
@@ -374,7 +374,23 @@ describe('createConfig', () => {
       { port: 8080 }
     );
 
-    config.static = path.relative(process.cwd(), config.static);
+    config.static = config.static.map((staticDir) =>
+      path.relative(process.cwd(), staticDir)
+    );
+
+    expect(config).toMatchSnapshot();
+  });
+
+  it('static option (list of strings)', () => {
+    const config = createConfig(
+      webpackConfig,
+      Object.assign({}, argv, { static: 'assets1,assets2' }),
+      { port: 8080 }
+    );
+
+    config.static = config.static.map((staticDir) =>
+      path.relative(process.cwd(), staticDir)
+    );
 
     expect(config).toMatchSnapshot();
   });

--- a/test/server/utils/createDomain.test.js
+++ b/test/server/utils/createDomain.test.js
@@ -94,6 +94,7 @@ describe('createDomain', () => {
   tests.forEach((test) => {
     it(`test createDomain '${test.name}'`, (done) => {
       const { options, expected } = test;
+      options.static = false;
 
       server = new Server(compiler, options);
 

--- a/test/server/utils/normalizeOptions.test.js
+++ b/test/server/utils/normalizeOptions.test.js
@@ -95,14 +95,6 @@ describe('normalizeOptions', () => {
       optionsResults: null,
     },
     {
-      title: 'contentBasePublicPath string',
-      multiCompiler: false,
-      options: {
-        contentBasePublicPath: '/content-base-public-path',
-      },
-      optionsResults: null,
-    },
-    {
       title: 'client host and port',
       multiCompiler: false,
       options: {
@@ -183,6 +175,66 @@ describe('normalizeOptions', () => {
       },
       optionsResults: null,
     },
+    {
+      title: 'static is true',
+      multiCompiler: false,
+      options: {
+        static: true,
+      },
+      optionsResults: null,
+    },
+    {
+      title: 'static is false',
+      multiCompiler: false,
+      options: {
+        static: false,
+      },
+      optionsResults: null,
+    },
+    {
+      title: 'static is string',
+      multiCompiler: false,
+      options: {
+        static: '/static/path',
+      },
+      optionsResults: null,
+    },
+    {
+      title: 'static is an array of strings',
+      multiCompiler: false,
+      options: {
+        static: ['/static/path1', '/static/path2'],
+      },
+      optionsResults: null,
+    },
+    {
+      title: 'static is an array of static objects',
+      multiCompiler: false,
+      options: {
+        static: [
+          {
+            directory: '/static/path1',
+          },
+          {
+            publicPath: '/static/public/path',
+          },
+        ],
+      },
+      optionsResults: null,
+    },
+    {
+      title: 'static is an array of strings and static objects',
+      multiCompiler: false,
+      options: {
+        static: [
+          '/static/path1',
+          {
+            publicPath: '/static/public/path',
+          },
+        ],
+      },
+      optionsResults: null,
+    },
   ];
 
   cases.forEach((data) => {
@@ -211,6 +263,17 @@ describe('normalizeOptions', () => {
             expect(data.options.contentBase).toEqual(process.cwd());
             delete data.options.contentBase;
           }
+
+          if (data.options.static) {
+            data.options.static.forEach((staticOpts) => {
+              if (staticOpts.directory === process.cwd()) {
+                // give an indication in the snapshot that this is the
+                // current working directory
+                staticOpts.directory = 'CWD';
+              }
+            });
+          }
+
           expect(data.options).toMatchSnapshot();
         }
       });

--- a/test/server/utils/normalizeOptions.test.js
+++ b/test/server/utils/normalizeOptions.test.js
@@ -229,11 +229,192 @@ describe('normalizeOptions', () => {
         static: [
           '/static/path1',
           {
-            publicPath: '/static/public/path',
+            publicPath: '/static/public/path/',
           },
         ],
       },
       optionsResults: null,
+    },
+    {
+      title: 'static is an object',
+      multiCompiler: false,
+      options: {
+        static: {
+          directory: '/static/path',
+        },
+      },
+      optionsResults: null,
+    },
+    {
+      title: 'static directory is an absolute url and throws error',
+      multiCompiler: false,
+      options: {
+        static: {
+          directory: 'http://localhost:8080',
+        },
+      },
+      optionsResults: null,
+      throws: 'Using a URL as static.directory is not supported',
+    },
+    {
+      title: 'static publicPath is a string',
+      multiCompiler: false,
+      options: {
+        static: {
+          publicPath: '/static/public/path/',
+        },
+      },
+      optionsResults: null,
+    },
+    {
+      title: 'static publicPath is an array',
+      multiCompiler: false,
+      options: {
+        static: {
+          publicPath: ['/static/public/path1/', '/static/public/path2/'],
+        },
+      },
+      optionsResults: null,
+    },
+    {
+      title: 'static watch is false',
+      multiCompiler: false,
+      options: {
+        static: {
+          watch: false,
+        },
+      },
+      optionsResults: null,
+    },
+    {
+      title: 'static watch is true',
+      multiCompiler: false,
+      options: {
+        static: {
+          watch: true,
+        },
+      },
+      optionsResults: null,
+    },
+    {
+      title: 'static watch is an object',
+      multiCompiler: false,
+      options: {
+        static: {
+          watch: {
+            poll: 500,
+          },
+        },
+      },
+      optionsResults: null,
+    },
+    {
+      title: 'static serveIndex is false',
+      multiCompiler: false,
+      options: {
+        static: {
+          serveIndex: false,
+        },
+      },
+      optionsResults: null,
+    },
+    {
+      title: 'static serveIndex is true',
+      multiCompiler: false,
+      options: {
+        static: {
+          serveIndex: true,
+        },
+      },
+      optionsResults: null,
+    },
+    {
+      title: 'static serveIndex is an object',
+      multiCompiler: false,
+      options: {
+        static: {
+          serveIndex: {
+            icons: false,
+          },
+        },
+      },
+      optionsResults: null,
+    },
+
+    {
+      title: 'single compiler watchOptions is object',
+      multiCompiler: false,
+      options: {},
+      optionsResults: null,
+      webpackConfig: {
+        watch: true,
+        watchOptions: {
+          aggregateTimeout: 300,
+        },
+      },
+    },
+    {
+      title: 'single compiler watchOptions is object with watch false',
+      multiCompiler: false,
+      options: {},
+      optionsResults: null,
+      webpackConfig: {
+        watch: false,
+        watchOptions: {
+          aggregateTimeout: 300,
+        },
+      },
+    },
+    {
+      title: 'single compiler watchOptions is object with static watch true',
+      multiCompiler: false,
+      options: {
+        static: {
+          watch: true,
+        },
+      },
+      optionsResults: null,
+      webpackConfig: {
+        watch: true,
+        watchOptions: {
+          aggregateTimeout: 300,
+        },
+      },
+    },
+    {
+      title:
+        'single compiler watchOptions is object with static watch overriding it',
+      multiCompiler: false,
+      options: {
+        static: {
+          watch: {
+            poll: 500,
+          },
+        },
+      },
+      optionsResults: null,
+      webpackConfig: {
+        watch: true,
+        watchOptions: {
+          aggregateTimeout: 300,
+        },
+      },
+    },
+    {
+      title: 'multi compiler watchOptions is set',
+      multiCompiler: true,
+      options: {},
+      optionsResults: null,
+      webpackConfig: [
+        {},
+        // watchOptions are set on the second compiler
+        {
+          watch: true,
+          watchOptions: {
+            aggregateTimeout: 300,
+          },
+        },
+      ],
     },
   ];
 
@@ -244,8 +425,20 @@ describe('normalizeOptions', () => {
         let webpackConfig;
         if (data.multiCompiler) {
           webpackConfig = require('../../fixtures/multi-compiler-config/webpack.config');
+          if (Array.isArray(data.webpackConfig)) {
+            webpackConfig = data.webpackConfig.map((config, index) =>
+              Object.assign({}, webpackConfig[index], config)
+            );
+          }
         } else {
           webpackConfig = require('../../fixtures/simple-config/webpack.config');
+          if (data.webpackConfig) {
+            webpackConfig = Object.assign(
+              {},
+              webpackConfig,
+              data.webpackConfig
+            );
+          }
         }
 
         compiler = webpack(webpackConfig);
@@ -253,6 +446,13 @@ describe('normalizeOptions', () => {
 
       it('should set correct options', () => {
         const originalContentBase = data.options.contentBase;
+        if (data.throws) {
+          expect(() => {
+            normalizeOptions(compiler, data.options);
+          }).toThrow();
+          return;
+        }
+
         normalizeOptions(compiler, data.options);
         if (data.optionsResults) {
           expect(data.options).toEqual(data.optionsResults);

--- a/test/server/utils/normalizeOptions.test.js
+++ b/test/server/utils/normalizeOptions.test.js
@@ -12,32 +12,6 @@ describe('normalizeOptions', () => {
       optionsResults: null,
     },
     {
-      title: 'contentBase string',
-      multiCompiler: false,
-      options: {
-        contentBase: '/path/to/dist',
-      },
-      optionsResults: null,
-    },
-    {
-      title: 'contentBase array',
-      multiCompiler: false,
-      options: {
-        contentBase: ['/path/to/dist1', '/path/to/dist2'],
-      },
-      optionsResults: null,
-    },
-    {
-      title: 'watchOptions',
-      multiCompiler: false,
-      options: {
-        watchOptions: {
-          poll: true,
-        },
-      },
-      optionsResults: null,
-    },
-    {
       title: 'transportMode sockjs string',
       multiCompiler: false,
       options: {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [ ] This is a **bugfix**
- [ ] This is a **feature**
- [x] This is a **code refactor**
- [x] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

Not yet

### Motivation / Use-Case

`static` option is replacing many existing options. See `options.json`.

### Breaking Changes

- Remove `contentBase`, `contentBasePublicPath`, `serveIndex`, `staticOptions`, `watchContentBase`, `watchOptions` in favor of `static`
- API changes related to `contentBase`

### Additional Info
