### PR TITLE
fix: allow iframe app to reload the page when changing the contents

### DIFF
--- a/client-src/live/index.js
+++ b/client-src/live/index.js
@@ -64,6 +64,9 @@ $(() => {
       $errors.hide();
       reloadApp();
     },
+    'content-changed': function contentChanged() {
+      window.location.reload();
+    },
     warnings() {
       okness.text('Warnings while compiling.');
       $errors.hide();


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [x ] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

I didn't find any test cases that targets **client-src/live/index.js**, so I just ignore it.

### Motivation / Use-Case

1. Give the following webpack.config.js

```
var path = require('path');

module.exports = {
  entry: {
    bundle: path.resolve(__dirname, 'src/index.js')
  },
  output: {
    path: path.resolve(__dirname, 'dist'),
    filename: 'bundle.js',
  },
  devServer: {
    contentBase: path.resolve(__dirname, 'html'),
    port: 9000,
    inline: false,
    watchContentBase: true,
    open: true,
  },
};
```
2. Add this line to `scripts` of package.json
```
"start": "webpack-dev-server"
```
3. Run
```
npm run start
``` 

4. The browser opens a new tab `http://localhost:9000/webpack-dev-server/`
5. Change the content of `html/index.html`
6. LiveReload mechanism didn't work, because `client-src/live/index.js` didn't handle `content-changed` event

What does this pull request do:
1. Add the "content-changed" event handler so whenever "content-base" gets changed, the iframe app will reload


### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  potential migration path for existing applications.
-->

### Additional Info
