### PR TITLE
feat(server): allow async bypass function for proxying

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -292,7 +292,7 @@ class Server {
         this.websocketProxies.push(proxyMiddleware);
       }
 
-      const handle = (req, res, next) => {
+      const handle = async (req, res, next) => {
         if (typeof proxyConfigOrCallback === 'function') {
           const newProxyConfig = proxyConfigOrCallback();
 
@@ -307,7 +307,7 @@ class Server {
         // bypassUrl from it otherwise bypassUrl would be null
         const isByPassFuncDefined = typeof proxyConfig.bypass === 'function';
         const bypassUrl = isByPassFuncDefined
-          ? proxyConfig.bypass(req, res, proxyConfig)
+          ? await proxyConfig.bypass(req, res, proxyConfig)
           : null;
 
         if (typeof bypassUrl === 'boolean') {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [ ] This is a **bugfix**
- [x] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

All tests passed. Not sure if updates in tests are required here.

### Motivation / Use-Case

Currently result of bypass function is used immediately and there is no way to make it asynchronous. This update allows returning Promise from bypass function in proxy.

It can be useful for downloading content from original source and "patching" it, instead of storing the whole response. 

### Breaking Changes

No

### Additional Info
