### PR TITLE
fix(deps): upgrade security vulnerability in sockjs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5393,9 +5393,9 @@
       "dev": true
     },
     "faye-websocket": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
-      "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.3.tgz",
+      "integrity": "sha512-D2y4bovYpzziGgbHYtGCMjlJM36vAl/y+xUyn1C+FVx8szd1E+86KwVw6XvYSzOP8iMpm1X0I4xJD+QtUb36OA==",
       "requires": {
         "websocket-driver": ">=0.5.1"
       }
@@ -6456,6 +6456,11 @@
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         }
       }
+    },
+    "http-parser-js": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.2.tgz",
+      "integrity": "sha512-opCO9ASqg5Wy2FNo7A0sxy71yGbbkJJXLdgMK04Tcypw9jr2MgWbyubb0+WdmDmGnFflO7fRbqbaihh/ENDlRQ=="
     },
     "http-proxy": {
       "version": "1.18.0",
@@ -11014,13 +11019,25 @@
       }
     },
     "sockjs": {
-      "version": "0.3.20",
-      "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.20.tgz",
-      "integrity": "sha512-SpmVOVpdq0DJc0qArhF3E5xsxvaiqGNb73XfgBpK1y3UD5gs8DSo8aCTsuT5pX8rssdc2NDIzANwP9eCAiSdTA==",
+      "version": "0.3.21",
+      "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.21.tgz",
+      "integrity": "sha512-DhbPFGpxjc6Z3I+uX07Id5ZO2XwYsWOrYjaSeieES78cq+JaJvVe5q/m1uvjIQhXinhIeCFRH6JgXe+mvVMyXw==",
       "requires": {
-        "faye-websocket": "^0.10.0",
+        "faye-websocket": "^0.11.3",
         "uuid": "^3.4.0",
-        "websocket-driver": "0.6.5"
+        "websocket-driver": "^0.7.4"
+      },
+      "dependencies": {
+        "websocket-driver": {
+          "version": "0.7.4",
+          "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
+          "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+          "requires": {
+            "http-parser-js": ">=0.5.1",
+            "safe-buffer": ">=5.1.0",
+            "websocket-extensions": ">=0.1.1"
+          }
+        }
       }
     },
     "sockjs-client": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "selfsigned": "^1.10.7",
     "semver": "^6.3.0",
     "serve-index": "^1.9.1",
-    "sockjs": "0.3.20",
+    "sockjs": "0.3.21",
     "sockjs-client": "1.4.0",
     "spdy": "^4.0.2",
     "strip-ansi": "^3.0.1",


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [ ] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

<!-- Please note that we won't approve your changes if you don't add tests. -->

### Motivation / Use-Case

A security vulnerability exists in `websocket-extensions`, which is indirectly dependent on `sockjs`. So upgrading `sockjs` to a patch.

https://github.com/sockjs/sockjs-node/releases/tag/v0.3.21

The vulnerabilities are described in Additional Info.

<!--
  What existing problem does the pull request solve?

  Please explain the motivation or use-case for making this change.
  If this Pull Request addresses an issue, please link to the issue.
-->

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  potential migration path for existing applications.
-->

### Additional Info

https://blog.jcoglan.com/2020/06/02/redos-vulnerability-in-websocket-extensions/