### PR TITLE
fix(cli): fix certain flags for webpack-cli serve

### DIFF
--- a/bin/cli-flags.js
+++ b/bin/cli-flags.js
@@ -18,6 +18,7 @@ module.exports = {
       name: 'live-reload',
       type: Boolean,
       describe: 'Enables/Disables live reloading on changing files',
+      negative: true,
     },
     {
       name: 'profile',
@@ -43,7 +44,7 @@ module.exports = {
     },
     {
       name: 'open',
-      type: String,
+      type: [String, Boolean],
       describe:
         'Open the default browser, or optionally specify a browser name',
     },
@@ -79,10 +80,11 @@ module.exports = {
     },
     {
       name: 'static',
-      type: String,
+      type: [String, Boolean],
       describe: 'A directory to serve static content from.',
       group: RESPONSE_GROUP,
       multiple: true,
+      negative: true,
     },
     {
       name: 'history-api-fallback',
@@ -121,8 +123,6 @@ module.exports = {
       describe: 'The hostname/ip address the server will bind to',
       group: CONNECTION_GROUP,
     },
-    // use command-line-args "multiple" option, allowing the usage: --allowed-hosts host1 host2 host3
-    // instead of the old, comma-separated syntax: --allowed-hosts host1,host2,host3
     {
       name: 'allowed-hosts',
       type: String,


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [ ] This is a **bugfix**
- [ ] This is a **feature**
- [x] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

N/A

### Motivation / Use-Case

Some adjustments are needed for certain flags to work as expected with `webpack-cli serve`.

This PR will rely on some fixes to how the webpack-cli arg parser works in here: https://github.com/webpack/webpack-cli/pull/1649

### Breaking Changes

N/A

### Additional Info
