### PR TITLE
fix(status): public path appearing as 'undefined'

### DIFF
--- a/lib/utils/status.js
+++ b/lib/utils/status.js
@@ -26,7 +26,12 @@ function status(uri, options, log, useColor) {
   }
 
   log.info(
-    `webpack output is served from ${colors.info(useColor, options.publicPath)}`
+    `webpack output is served from ${colors.info(
+      useColor,
+      typeof options.contentBasePublicPath === 'string'
+        ? options.contentBasePublicPath
+        : options.publicPath
+    )}`
   );
 
   if (contentBase) {


### PR DESCRIPTION
- [x] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

No

### Motivation / Use-Case

Instead of:

```bash
webpack output is served from undefined
```

The correct public path for webpack 5 will be shown:

```bash
webpack output is served from /
```

### Breaking Changes

No

### Additional Info

n/a
