### PR TITLE
test: add stats:verbose to cli's webpack config

### DIFF
--- a/test/fixtures/cli/webpack.config.js
+++ b/test/fixtures/cli/webpack.config.js
@@ -4,6 +4,7 @@ module.exports = {
   mode: 'development',
   context: __dirname,
   entry: './foo.js',
+  stats: 'verbose',
   plugins: [
     {
       apply(compiler) {


### PR DESCRIPTION
- [ ] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [x] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

updated

<!-- Please note that we won't approve your changes if you don't add tests. -->

### Motivation / Use-Case

when we use webpack@5.0.0-beta.30, our CI will be broken.

output logs are the difference between beta.29 and beta.30. 

webpack@5.0.0-beta.29

```
    <i> [webpack-dev-server] Project is running at http://localhost:8080/
    <i> [webpack-dev-server] webpack output is served from undefined
    <i> [webpack-dev-middleware] Hash: 44cb6417926dcafb24fe
    <i> Version: webpack 5.0.0-beta.29
    <i> Time: 267 ms
    <i> Built at: 2020-09-12 13:25:14
    <i> asset main.js 231 KiB [emitted] (name: main)
    <i> Entrypoint main = main.js
    <i> ./foo.js 41 bytes [built]
    <i> ../../../client/default/index.js?http://localhost:8080 4.4 KiB [built]
    <i> ../../../node_modules/webpack/hot/dev-server.js 1.59 KiB [built]
    <i> ../../../client/transpiled-modules/strip-ansi.js 1.4 KiB [built]
    <i> ../../../client/default/socket.js 1.27 KiB [built]
    <i> ../../../client/default/utils/log.js 414 bytes [built]
    <i> ../../../client/default/overlay.js 3.53 KiB [built]
    <i> ../../../client/default/utils/sendMessage.js 402 bytes [built]
    <i> ../../../client/default/utils/reloadApp.js 1.58 KiB [built]
    <i> ../../../node_modules/webpack/hot/emitter.js 75 bytes [built]
    <i> ../../../client/default/utils/createSocketUrl.js 2.87 KiB [built]
    <i> ../../../node_modules/webpack/hot sync nonrecursive ^\.\/log$ 170 bytes [built]
    <i> ../../../node_modules/webpack/hot/log.js 1.34 KiB [built]
    <i> ../../../node_modules/webpack/hot/log-apply-result.js 1.29 KiB [built]
    <i> ../../../client/clients/WebsocketClient.js 4.07 KiB [built]
    <i>     + 25 hidden modules
    <i> [webpack-dev-middleware] Compiled successfully.

```

webpack@5.0.0-beta.30

```
    <i> [webpack-dev-server] Project is running at http://localhost:8080/
    <i> [webpack-dev-server] webpack output is served from undefined
    <i> [webpack-dev-middleware] asset main.js 231 KiB [emitted] (name: main)
    <i> runtime modules 23.8 KiB 10 modules
    <i> cacheable modules 169 KiB
    <i>   modules by path ../../../node_modules/ 122 KiB
    <i>     modules by path ../../../node_modules/webpack/hot/ 4.3 KiB 4 modules
    <i>     modules by path ../../../node_modules/html-entities/lib/ 57.9 KiB 4 modules
    <i>     modules by path ../../../node_modules/url/ 37.4 KiB 3 modules
    <i>     modules by path ../../../node_modules/querystring/ 4.51 KiB 3 modules
    <i>     2 modules
    <i>   modules by path ../../../client/ 46.6 KiB
    <i>     modules by path ../../../client/transpiled-modules/ 26.4 KiB 2 modules
    <i>     modules by path ../../../client/clients/ 5.12 KiB
    <i>       ../../../client/clients/WebsocketClient.js 4.07 KiB [built] [code generated]
    <i>       ../../../client/clients/BaseClient.js 1.04 KiB [built] [code generated]
    <i>     modules by path ../../../client/default/ 15.1 KiB
    <i>   ./foo.js 41 bytes [built] [code generated]
    <i> ../../../node_modules/webpack/hot/ sync nonrecursive ^\.\/log$ 170 bytes [built] [code generated]
    <i> webpack 5.0.0-beta.30 compiled successfully in 259 ms
    <i> [webpack-dev-middleware] Compiled successfully.
```

<!--
  What existing problem does the pull request solve?

  Please explain the motivation or use-case for making this change.
  If this Pull Request addresses an issue, please link to the issue.
-->

### Breaking Changes

no 

<!--
  If this PR introduces a breaking change, please describe the impact and a
  potential migration path for existing applications.
-->

### Additional Info
