### PR TITLE
chore: upgrade selfsigned dependency for node-forge security patch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9035,9 +9035,9 @@
       }
     },
     "node-forge": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.0.tgz",
-      "integrity": "sha512-7ASaDa3pD+lJ3WvXFsxekJQelBKRpne+GOVbLbtHYdd7pFspyeuJHnWfLplGf3SwKGbfs/aYl5V/JCIaHVUKKQ=="
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
     },
     "node-int64": {
       "version": "0.4.0",
@@ -10680,11 +10680,11 @@
       "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo="
     },
     "selfsigned": {
-      "version": "1.10.7",
-      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.7.tgz",
-      "integrity": "sha512-8M3wBCzeWIJnQfl43IKwOmC4H/RAp50S8DF60znzjW5GVqTcSe2vWclt7hmYVPkKPlHWOu5EaWOMZ2Y6W8ZXTA==",
+      "version": "1.10.8",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.8.tgz",
+      "integrity": "sha512-2P4PtieJeEwVgTU9QEcwIRDQ/mXJLX8/+I3ur+Pg16nS8oNbrGxEso9NyYWy8NAmXiNl4dlAp5MwoNeCWzON4w==",
       "requires": {
-        "node-forge": "0.9.0"
+        "node-forge": "^0.10.0"
       }
     },
     "semver": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "p-retry": "^3.0.1",
     "portfinder": "^1.0.26",
     "schema-utils": "^1.0.0",
-    "selfsigned": "^1.10.7",
+    "selfsigned": "^1.10.8",
     "semver": "^6.3.0",
     "serve-index": "^1.9.1",
     "sockjs": "0.3.20",


### PR DESCRIPTION
- [ ] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**
- [X] This is a **dependency update**

### For Bugs and Features; did you add new tests?

N/A

### Motivation / Use-Case

Security vulnerability in a dependency of selfsigned; they bumped a version to patch it, so this updates webpack-dev-server's dependency to the patched version.

### Breaking Changes

N/A

### Additional Info

N/A