### PR TITLE
fix: contentBase (static) logging

### DIFF
--- a/lib/utils/status.js
+++ b/lib/utils/status.js
@@ -17,7 +17,7 @@ function status(uri, options, logger, useColor) {
     `webpack output is served from ${colors.info(useColor, options.publicPath)}`
   );
 
-  if (options.static && options.static.length) {
+  if (options.static && options.static.length > 0) {
     logger.info(
       `Content not from webpack is served from ${colors.info(
         useColor,

--- a/lib/utils/status.js
+++ b/lib/utils/status.js
@@ -5,10 +5,6 @@ const runOpen = require('./runOpen');
 
 // TODO: don't emit logs when webpack-dev-server is used via Node.js API
 function status(uri, options, logger, useColor) {
-  const contentBase = Array.isArray(options.contentBase)
-    ? options.contentBase.join(', ')
-    : options.contentBase;
-
   if (options.socket) {
     logger.info(
       `Listening to socket at ${colors.info(useColor, options.socket)}`
@@ -21,11 +17,11 @@ function status(uri, options, logger, useColor) {
     `webpack output is served from ${colors.info(useColor, options.publicPath)}`
   );
 
-  if (contentBase) {
+  if (options.static && options.static.length) {
     logger.info(
       `Content not from webpack is served from ${colors.info(
         useColor,
-        contentBase
+        options.static.map((staticOption) => staticOption.directory).join(', ')
       )}`
     );
   }


### PR DESCRIPTION
- [x] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?
N/A (covered by existing tests)

### Motivation / Use-Case
`contentBase` has been removed in favor of `static` in #2670.

### Breaking Changes
N/A

### Additional Info
