### PR TITLE
Update overlay.js to display actual error message when works with webpack 5.0.0?

### DIFF
--- a/client-src/default/overlay.js
+++ b/client-src/default/overlay.js
@@ -112,11 +112,17 @@ function clear() {
 // Compilation with errors (e.g. syntax error or missing modules).
 function showMessage(messages) {
   ensureOverlayDivExists((div) => {
+    let singleMessage = messages[0];
+
+    if (singleMessage && singleMessage.message) {
+      singleMessage = singleMessage.message;
+    }
+
     // Make it look similar to our terminal.
     div.innerHTML = `<span style="color: #${
       colors.red
     }">Failed to compile.</span><br><br>${ansiHTML(
-      entities.encode(messages[0].message || messages[0])
+      entities.encode(singleMessage)
     )}`;
   });
 }

--- a/client-src/default/overlay.js
+++ b/client-src/default/overlay.js
@@ -116,7 +116,7 @@ function showMessage(messages) {
     div.innerHTML = `<span style="color: #${
       colors.red
     }">Failed to compile.</span><br><br>${ansiHTML(
-      entities.encode(messages[0])
+      entities.encode(messages[0].message || messages[0])
     )}`;
   });
 }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [x ] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

<!-- Please note that we won't approve your changes if you don't add tests. -->

### Motivation / Use-Case
As a user I have updated to Webpack 5.0.0.
Not sure if this fix should be addressed here or in webpack/webpack repo.
Trying to use webpack-dev-server 3.11.0 in order with webpack 5.0.0 and using "overlay" feature I see data format is changed and errors are not displayed in browser's overlay.
This change should avoid the issue and be backward compatible.



### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  potential migration path for existing applications.
-->

### Additional Info
