### PR TITLE
fix: more friendly error message for webpack-cli@4

### DIFF
--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -53,12 +53,24 @@ yargs.usage(
 );
 
 // webpack-cli@3.3 path : 'webpack-cli/bin/config/config-yargs'
+// removed in webpack-cli@4
 let configYargsPath;
 try {
   require.resolve('webpack-cli/bin/config/config-yargs');
   configYargsPath = 'webpack-cli/bin/config/config-yargs';
 } catch (e) {
-  configYargsPath = 'webpack-cli/bin/config-yargs';
+  try {
+    require.resolve('webpack-cli/bin/config-yargs');
+    configYargsPath = 'webpack-cli/bin/config-yargs';
+  } catch (e2) {
+    console.error('The webpack-dev-server CLI will be removed in v4');
+    console.error(
+      "Please use 'webpack serve' command from webpack-cli to run webpack-dev-server"
+    );
+
+    // eslint-disable-next-line no-process-exit
+    process.exit(1);
+  }
 }
 // eslint-disable-next-line import/no-extraneous-dependencies
 // eslint-disable-next-line import/no-dynamic-require


### PR DESCRIPTION
- [x] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?
N/A

#### Test plan
```
$ yarn add -D webpack webpack-cli webpack-dev-server@portal:<path to webpack-dev-server>
$ yarn webpack-dev-server
The webpack-dev-server CLI will be removed in v4
Please use 'webpack serve' command from webpack-cli to run webpack-dev-server
$ echo $?
1
```

### Motivation / Use-Case
This PR adds more friendly error message for webpack-dev-server v3 used with webpack-cli v4 (#2424).

### Breaking Changes
No

### Additional Info
