### PR TITLE
fix: remove default CLI values from flags

### DIFF
--- a/bin/cli-flags.js
+++ b/bin/cli-flags.js
@@ -22,19 +22,16 @@ module.exports = {
     {
       name: 'liveReload',
       type: Boolean,
-      defaultValue: true,
       describe: 'Enables/Disables live reloading on changing files',
     },
     {
       name: 'serveIndex',
       type: Boolean,
       describe: 'Enables/Disables serveIndex middleware',
-      defaultValue: true,
     },
     {
       name: 'inline',
       type: Boolean,
-      defaultValue: true,
       describe:
         'Inline mode (set to false to disable including client scripts like livereload)',
     },
@@ -80,7 +77,6 @@ module.exports = {
       name: 'client-log-level',
       type: String,
       group: DISPLAY_GROUP,
-      defaultValue: 'info',
       describe:
         'Log level in the browser (trace, debug, info, warn, error or silent)',
     },


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [x] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

Nope, do we have them for default values? if not then we can take a snapshot and test it

### Motivation / Use-Case

https://github.com/webpack/webpack-cli/issues/2018

These values are applied during arg parsing and config values are not able to override it.

### Breaking Changes

Not sure

### Additional Info
