### PR TITLE
fix: support webpack@5

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -58,7 +58,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         node-version: [10.x, 12.x, 14.x]
-        webpack-version: [latest, next]
+        webpack-version: [4, latest]
 
     runs-on: ${{ matrix.os }}
 

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -146,10 +146,7 @@ class Server {
 
   setupDevMiddleware() {
     // middleware for serving webpack bundle
-    this.middleware = webpackDevMiddleware.default(
-      this.compiler,
-      this.options.dev
-    );
+    this.middleware = webpackDevMiddleware(this.compiler, this.options.dev);
   }
 
   setupCompressFeature() {

--- a/lib/utils/routes.js
+++ b/lib/utils/routes.js
@@ -44,6 +44,10 @@ function routes(server) {
     res.end('</body></html>');
 
     function writeDirectory(baseUrl, basePath) {
+      if (baseUrl === 'auto') {
+        baseUrl = '';
+      }
+
       const content = filesystem.readdirSync(basePath);
 
       res.write('<ul>');

--- a/package-lock.json
+++ b/package-lock.json
@@ -11039,12 +11039,12 @@
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
     "mem": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/mem/-/mem-6.1.0.tgz",
-      "integrity": "sha512-RlbnLQgRHk5lwqTtpEkBTQ2ll/CG/iB+J4Hy2Wh97PjgZgXgWJWrFF+XXujh3UUVLvR4OOTgZzcWMMwnehlEUg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-8.0.0.tgz",
+      "integrity": "sha512-qrcJOe6uD+EW8Wrci1Vdiua/15Xw3n/QnaNXE7varnB6InxSk7nu3/i5jfy3S6kWxr8WYJ6R1o0afMUtvorTsA==",
       "requires": {
         "map-age-cleaner": "^0.1.3",
-        "mimic-fn": "^3.0.0"
+        "mimic-fn": "^3.1.0"
       },
       "dependencies": {
         "mimic-fn": {
@@ -16213,15 +16213,43 @@
       }
     },
     "webpack-dev-middleware": {
-      "version": "4.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-4.0.0-rc.3.tgz",
-      "integrity": "sha512-nuZHcVtI1qVJxGYWEnCeN9UiQesOTUYQZQiJnrt1ma5FSYK1OTH0ySG45yUE44aVSFrN+teZX7WQTH6hF2vgFA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-4.0.2.tgz",
+      "integrity": "sha512-xyAICqIugWtT1RRH5aMMmZlPhDhEqPTDL0TWhmMZsuZ+cFlAvRxv4thCbuxdk9MW+OYK4c9BkfmgdQ1/7imkJA==",
       "requires": {
-        "mem": "^6.1.0",
+        "mem": "^8.0.0",
         "memfs": "^3.2.0",
         "mime-types": "^2.1.27",
         "range-parser": "^1.2.1",
-        "schema-utils": "^2.7.0"
+        "schema-utils": "^3.0.0"
+      },
+      "dependencies": {
+        "@types/json-schema": {
+          "version": "7.0.6",
+          "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.6.tgz",
+          "integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw=="
+        },
+        "ajv": {
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "schema-utils": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.0.0.tgz",
+          "integrity": "sha512-6D82/xSzO094ajanoOSbe4YvXWMfn2A//8Y1+MUqFAJul5Bs+yn36xbK9OtNDcRVSBJ9jjeoXftM6CfztsjOAA==",
+          "requires": {
+            "@types/json-schema": "^7.0.6",
+            "ajv": "^6.12.5",
+            "ajv-keywords": "^3.5.2"
+          }
+        }
       }
     },
     "webpack-merge": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11531,9 +11531,9 @@
       }
     },
     "node-forge": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.0.tgz",
-      "integrity": "sha512-7ASaDa3pD+lJ3WvXFsxekJQelBKRpne+GOVbLbtHYdd7pFspyeuJHnWfLplGf3SwKGbfs/aYl5V/JCIaHVUKKQ=="
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
     },
     "node-int64": {
       "version": "0.4.0",
@@ -13496,11 +13496,11 @@
       "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo="
     },
     "selfsigned": {
-      "version": "1.10.7",
-      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.7.tgz",
-      "integrity": "sha512-8M3wBCzeWIJnQfl43IKwOmC4H/RAp50S8DF60znzjW5GVqTcSe2vWclt7hmYVPkKPlHWOu5EaWOMZ2Y6W8ZXTA==",
+      "version": "1.10.8",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.8.tgz",
+      "integrity": "sha512-2P4PtieJeEwVgTU9QEcwIRDQ/mXJLX8/+I3ur+Pg16nS8oNbrGxEso9NyYWy8NAmXiNl4dlAp5MwoNeCWzON4w==",
       "requires": {
-        "node-forge": "0.9.0"
+        "node-forge": "^0.10.0"
       }
     },
     "semver": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "strip-ansi": "^6.0.0",
     "url": "^0.11.0",
     "util": "^0.12.3",
-    "webpack-dev-middleware": "^4.0.0-rc.3",
+    "webpack-dev-middleware": "^4.0.2",
     "ws": "^7.3.1",
     "yargs": "^13.3.2"
   },

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "p-retry": "^4.2.0",
     "portfinder": "^1.0.28",
     "schema-utils": "^2.7.0",
-    "selfsigned": "^1.10.7",
+    "selfsigned": "^1.10.8",
     "serve-index": "^1.9.1",
     "sockjs": "0.3.20",
     "sockjs-client": "1.4.0",


### PR DESCRIPTION
- [x] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [x] This is a **test update**
- [ ] This is a **docs update**
- [x] This is a **metadata update**

### For Bugs and Features; did you add new tests?
N/A (Covered by existing tests)

### Motivation / Use-Case
* Update `webpack-dev-middleware` to 4.0.2 and `selfsigned` to 1.10.8: closes #2763, closes #2740, closes #2752, and closes #2795.
* Fix failing `ClientOptions` tests: use the Chrome DevTools protocol directly to detect WebSocket and fix `startAwaitingCompilation` usage
* Update CI to use `4` and `latest` instead of `latest` and `next`, respectively, since webpack 5 has been released.
* Attempt to fix directory listing for webpack 5

### Breaking Changes
N/A

### Additional Info
[Ignoring whitespace changes in diff](https://github.com/webpack/webpack-dev-server/pull/2828/files?diff=split&w=1) would help review changes in https://github.com/webpack/webpack-dev-server/pull/2828/commits/0f0e9e9f14d1c0ac9da2fe1a726d69113e3161c1.