### PR TITLE
fix(utils): use plugin to add entries for webpack@5

### DIFF
--- a/lib/utils/DevServerEntryPlugin.js
+++ b/lib/utils/DevServerEntryPlugin.js
@@ -1,0 +1,59 @@
+/*
+  MIT License http://www.opensource.org/licenses/mit-license.php
+  Based on webpack/lib/DynamicEntryPlugin
+	Author Naoyuki Kanezawa @nkzawa
+*/
+
+'use strict';
+
+const webpack = require('webpack');
+
+// @ts-ignore
+const EntryPlugin = webpack.EntryPlugin;
+
+class DevServerEntryPlugin {
+  /**
+   * @param {string} context context path
+   * @param {string[]} entries entry paths
+   * @param {?Object | string} options entry options
+   */
+  constructor(context, entries, options) {
+    if (!EntryPlugin) {
+      throw new Error(
+        'DevServerEntryPlugin is supported in webpack 5 or greater'
+      );
+    }
+
+    this.context = context;
+    this.entries = entries;
+    this.options = options || '';
+  }
+
+  /**
+   * Apply the plugin
+   * @param {Object} compiler the compiler instance
+   * @returns {void}
+   */
+  apply(compiler) {
+    compiler.hooks.make.tapPromise('DevServerEntryPlugin', (compilation) =>
+      Promise.all(
+        this.entries.map(
+          (entry) =>
+            new Promise((resolve, reject) => {
+              compilation.addEntry(
+                this.context,
+                EntryPlugin.createDependency(entry, this.options),
+                this.options,
+                (err) => {
+                  if (err) return reject(err);
+                  resolve();
+                }
+              );
+            })
+        )
+      )
+    );
+  }
+}
+
+module.exports = DevServerEntryPlugin;

--- a/lib/utils/addEntries.js
+++ b/lib/utils/addEntries.js
@@ -2,6 +2,7 @@
 
 const webpack = require('webpack');
 const createDomain = require('./createDomain');
+const DevServerEntryPlugin = require('./DevServerEntryPlugin');
 
 /**
  * A Entry, it can be of type string or string[] or Object<string | string[],string>
@@ -142,8 +143,29 @@ function addEntries(compiler, options, server) {
       additionalEntries.push(hotEntry);
     }
 
-    config.entry = prependEntry(config.entry || './src', additionalEntries);
-    compiler.hooks.entryOption.call(config.context, config.entry);
+    // use a plugin to add entries if available
+    // @ts-ignore
+    if (webpack.EntryPlugin) {
+      // use existing plugin if possible
+      let entryPlugin = config.plugins.find(
+        (plugin) => plugin.constructor.name === 'DevServerEntryPlugin'
+      );
+
+      if (entryPlugin) {
+        entryPlugin.entries = additionalEntries;
+      } else {
+        entryPlugin = new DevServerEntryPlugin(
+          compiler.context,
+          additionalEntries,
+          {} // global entry
+        );
+        config.plugins.push(entryPlugin);
+        entryPlugin.apply(compiler);
+      }
+    } else {
+      config.entry = prependEntry(config.entry || './src', additionalEntries);
+      compiler.hooks.entryOption.call(config.context, config.entry);
+    }
 
     if (options.hot || options.hot === 'only') {
       config.plugins = config.plugins || [];

--- a/lib/utils/addEntries.js
+++ b/lib/utils/addEntries.js
@@ -10,12 +10,12 @@ const createDomain = require('./createDomain');
 
 /**
  * Add entries Method
- * @param {?Object} config - Webpack config
+ * @param {?Object} compiler - Webpack compiler
  * @param {?Object} options - Dev-Server options
  * @param {?Object} server
  * @returns {void}
  */
-function addEntries(config, options, server) {
+function addEntries(compiler, options, server) {
   // we're stubbing the app in this method as it's static and doesn't require
   // a server to be supplied. createDomain requires an app with the
   // address() signature.
@@ -114,8 +114,11 @@ function addEntries(config, options, server) {
     return defaultValue;
   };
 
+  const compilers = compiler.compilers || [compiler];
+
   // eslint-disable-next-line no-shadow
-  [].concat(config).forEach((config) => {
+  compilers.forEach((compiler) => {
+    const config = compiler.options;
     /** @type {Boolean} */
     const webTarget = [
       'web',
@@ -140,6 +143,7 @@ function addEntries(config, options, server) {
     }
 
     config.entry = prependEntry(config.entry || './src', additionalEntries);
+    compiler.hooks.entryOption.call(config.context, config.entry);
 
     if (options.hot || options.hot === 'only') {
       config.plugins = config.plugins || [];

--- a/lib/utils/addEntries.js
+++ b/lib/utils/addEntries.js
@@ -54,7 +54,7 @@ function addEntries(config, options, server) {
     hotEntry = require.resolve('webpack/hot/dev-server');
   }
   /**
-   * prependEntry Method
+   * prependEntry Method for webpack 4
    * @param {Entry} originalEntry
    * @param {Entry} additionalEntries
    * @returns {Entry}
@@ -74,13 +74,7 @@ function addEntries(config, options, server) {
       Object.keys(originalEntry).forEach((key) => {
         // entry[key] should be a string here
         const entryDescription = originalEntry[key];
-        if (typeof entryDescription === 'object' && entryDescription.import) {
-          clone[key] = Object.assign({}, entryDescription, {
-            import: prependEntry(entryDescription.import, additionalEntries),
-          });
-        } else {
-          clone[key] = prependEntry(entryDescription, additionalEntries);
-        }
+        clone[key] = prependEntry(entryDescription, additionalEntries);
       });
 
       return clone;

--- a/lib/utils/updateCompiler.js
+++ b/lib/utils/updateCompiler.js
@@ -18,19 +18,15 @@ function updateCompiler(compiler, options) {
 
   const compilers = [];
   const compilersWithoutHMR = [];
-  let webpackConfig;
   if (compiler.compilers) {
-    webpackConfig = [];
     // eslint-disable-next-line no-shadow
     compiler.compilers.forEach((compiler) => {
-      webpackConfig.push(compiler.options);
       compilers.push(compiler);
       if (!findHMRPlugin(compiler.options)) {
         compilersWithoutHMR.push(compiler);
       }
     });
   } else {
-    webpackConfig = compiler.options;
     compilers.push(compiler);
     if (!findHMRPlugin(compiler.options)) {
       compilersWithoutHMR.push(compiler);
@@ -42,12 +38,9 @@ function updateCompiler(compiler, options) {
   // the changes we are making to the compiler
   // important: this relies on the fact that addEntries now
   // prevents duplicate new entries.
-  addEntries(webpackConfig, options);
+  addEntries(compiler, options);
   // eslint-disable-next-line no-shadow
   compilers.forEach((compiler) => {
-    const config = compiler.options;
-    compiler.hooks.entryOption.call(config.context, config.entry);
-
     const providePlugin = new webpack.ProvidePlugin({
       __webpack_dev_server_client__: getSocketClientPath(options),
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -15732,6 +15732,12 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
     },
+    "require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true
+    },
     "require-main-filename": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "npm-run-all": "^4.1.5",
     "prettier": "^2.0.5",
     "puppeteer": "^5.2.1",
+    "require-from-string": "^2.0.2",
     "rimraf": "^3.0.2",
     "standard-version": "^9.0.0",
     "style-loader": "^1.2.1",

--- a/test/fixtures/module-federation-config/entry1.js
+++ b/test/fixtures/module-federation-config/entry1.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = 'entry1';

--- a/test/fixtures/module-federation-config/entry2.js
+++ b/test/fixtures/module-federation-config/entry2.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = 'entry2';

--- a/test/fixtures/module-federation-config/webpack.config.js
+++ b/test/fixtures/module-federation-config/webpack.config.js
@@ -1,0 +1,15 @@
+'use strict';
+
+module.exports = {
+  mode: 'development',
+  target: 'node',
+  context: __dirname,
+  entry: ['./entry1.js', './entry2.js'],
+  output: {
+    path: '/',
+    libraryTarget: 'umd',
+  },
+  infrastructureLogging: {
+    level: 'warn',
+  },
+};

--- a/test/fixtures/module-federation-config/webpack.multi.config.js
+++ b/test/fixtures/module-federation-config/webpack.multi.config.js
@@ -1,0 +1,17 @@
+'use strict';
+
+module.exports = [
+  {
+    mode: 'development',
+    target: 'node',
+    context: __dirname,
+    entry: ['./entry1.js', './entry2.js'],
+    output: {
+      path: '/',
+      libraryTarget: 'umd',
+    },
+    infrastructureLogging: {
+      level: 'warn',
+    },
+  },
+];

--- a/test/fixtures/module-federation-config/webpack.object-entry.config.js
+++ b/test/fixtures/module-federation-config/webpack.object-entry.config.js
@@ -1,0 +1,18 @@
+'use strict';
+
+module.exports = {
+  mode: 'development',
+  target: 'node',
+  context: __dirname,
+  entry: {
+    foo: './entry1.js',
+    main: ['./entry1.js', './entry2.js'],
+  },
+  output: {
+    path: '/',
+    libraryTarget: 'umd',
+  },
+  infrastructureLogging: {
+    level: 'warn',
+  },
+};

--- a/test/integration/ModuleFederation.test.js
+++ b/test/integration/ModuleFederation.test.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const request = require('supertest');
+const requireFromString = require('require-from-string');
+const testServer = require('../helpers/test-server');
+const simpleConfig = require('../fixtures/module-federation-config/webpack.config');
+const objectEntryConfig = require('../fixtures/module-federation-config/webpack.object-entry.config');
+const multiConfig = require('../fixtures/module-federation-config/webpack.multi.config');
+const port = require('../ports-map').ModuleFederation;
+
+describe('module federation', () => {
+  describe.each([
+    ['simple multi-entry config', simpleConfig],
+    ['object multi-entry config', objectEntryConfig],
+    ['multi compiler config', multiConfig],
+  ])('%s', (title, config) => {
+    let server;
+    let req;
+
+    beforeAll((done) => {
+      server = testServer.start(config, { port }, done);
+      req = request(server.app);
+    });
+
+    afterAll(testServer.close);
+
+    it('should use the last entry export', async () => {
+      const { text, statusCode } = await req.get('/main.js');
+      expect(statusCode).toEqual(200);
+      expect(text).toContain('entry1');
+
+      let exports;
+      expect(() => {
+        exports = requireFromString(text);
+      }).not.toThrow();
+
+      expect(exports).toEqual('entry2');
+    });
+
+    if (title === 'object multi-entry config') {
+      it('should support the named entry export', async () => {
+        const { text, statusCode } = await req.get('/foo.js');
+        expect(statusCode).toEqual(200);
+        expect(text).not.toContain('entry2');
+
+        let exports;
+        expect(() => {
+          exports = requireFromString(text);
+        }).not.toThrow();
+
+        expect(exports).toEqual('entry1');
+      });
+    }
+  });
+});

--- a/test/ports-map.js
+++ b/test/ports-map.js
@@ -44,6 +44,7 @@ const portsList = {
   'static-publicPath-option': 1,
   'contentBasePublicPath-option': 1,
   bundle: 1,
+  ModuleFederation: 1,
 };
 
 let startPort = 8089;

--- a/test/server/Server.test.js
+++ b/test/server/Server.test.js
@@ -25,17 +25,9 @@ describe('Server', () => {
   });
 
   describe('addEntries', () => {
-    it('add hot option', (done) => {
-      const compiler = webpack(config);
-      const server = new Server(
-        compiler,
-        Object.assign({}, baseDevConfig, {
-          hot: true,
-        })
-      );
+    let entries;
 
-      let entries;
-
+    function getEntries(server) {
       if (isWebpack5) {
         entries = server.middleware.context.compiler.options.entry.main.import.map(
           (p) => {
@@ -47,6 +39,18 @@ describe('Server', () => {
           return relative('.', p).split(sep);
         });
       }
+    }
+
+    it('add hot option', (done) => {
+      const compiler = webpack(config);
+      const server = new Server(
+        compiler,
+        Object.assign({}, baseDevConfig, {
+          hot: true,
+        })
+      );
+
+      getEntries(server);
       expect(entries).toMatchSnapshot();
       expect(server.middleware.context.compiler.options.plugins).toEqual([
         new webpack.HotModuleReplacementPlugin(),
@@ -68,20 +72,7 @@ describe('Server', () => {
         })
       );
 
-      let entries;
-
-      if (isWebpack5) {
-        entries = server.middleware.context.compiler.options.entry.main.import.map(
-          (p) => {
-            return relative('.', p).split(sep);
-          }
-        );
-      } else {
-        entries = server.middleware.context.compiler.options.entry.map((p) => {
-          return relative('.', p).split(sep);
-        });
-      }
-
+      getEntries(server);
       expect(entries).toMatchSnapshot();
       expect(server.middleware.context.compiler.options.plugins).toEqual([
         new webpack.HotModuleReplacementPlugin(),

--- a/test/server/utils/addEntries.test.js
+++ b/test/server/utils/addEntries.test.js
@@ -10,20 +10,24 @@ const configEntryAsDescriptor = require('./../../fixtures/entry-as-descriptor/we
 const normalize = (entry) => entry.split(path.sep).join('/');
 
 describe('addEntries util', () => {
+  function getEntries(compiler) {
+    const entryOption = compiler.options.entry;
+    return entryOption;
+  }
+
   it('should adds devServer entry points to a single entry point', () => {
     const webpackOptions = Object.assign({}, config);
     const compiler = webpack(webpackOptions);
     const devServerOptions = {};
 
     addEntries(compiler, devServerOptions);
+    const entries = getEntries(compiler);
 
-    expect(compiler.options.entry.length).toEqual(2);
+    expect(entries.length).toEqual(2);
     expect(
-      normalize(compiler.options.entry[0]).indexOf(
-        'client/default/index.js?'
-      ) !== -1
+      normalize(entries[0]).indexOf('client/default/index.js?') !== -1
     ).toBeTruthy();
-    expect(normalize(compiler.options.entry[1])).toEqual('./foo.js');
+    expect(normalize(entries[1])).toEqual('./foo.js');
   });
 
   it('should adds devServer entry points to a multi-module entry point', () => {
@@ -35,15 +39,14 @@ describe('addEntries util', () => {
     const devServerOptions = {};
 
     addEntries(compiler, devServerOptions);
+    const entries = getEntries(compiler);
 
-    expect(compiler.options.entry.length).toEqual(3);
+    expect(entries.length).toEqual(3);
     expect(
-      normalize(compiler.options.entry[0]).indexOf(
-        'client/default/index.js?'
-      ) !== -1
+      normalize(entries[0]).indexOf('client/default/index.js?') !== -1
     ).toBeTruthy();
-    expect(compiler.options.entry[1]).toEqual('./foo.js');
-    expect(compiler.options.entry[2]).toEqual('./bar.js');
+    expect(entries[1]).toEqual('./foo.js');
+    expect(entries[2]).toEqual('./bar.js');
   });
 
   it('should adds devServer entry points to a multi entry point object', () => {
@@ -58,16 +61,15 @@ describe('addEntries util', () => {
     const devServerOptions = {};
 
     addEntries(compiler, devServerOptions);
+    const entries = getEntries(compiler);
 
-    expect(compiler.options.entry.foo.length).toEqual(2);
+    expect(entries.foo.length).toEqual(2);
 
     expect(
-      normalize(compiler.options.entry.foo[0]).indexOf(
-        'client/default/index.js?'
-      ) !== -1
+      normalize(entries.foo[0]).indexOf('client/default/index.js?') !== -1
     ).toBeTruthy();
-    expect(compiler.options.entry.foo[1]).toEqual('./foo.js');
-    expect(compiler.options.entry.bar[1]).toEqual('./bar.js');
+    expect(entries.foo[1]).toEqual('./foo.js');
+    expect(entries.bar[1]).toEqual('./bar.js');
   });
 
   it('should set defaults to src if no entry point is given', () => {
@@ -76,9 +78,10 @@ describe('addEntries util', () => {
     const devServerOptions = {};
 
     addEntries(compiler, devServerOptions);
+    const entries = getEntries(compiler);
 
-    expect(compiler.options.entry.length).toEqual(2);
-    expect(compiler.options.entry[1]).toEqual('./src');
+    expect(entries.length).toEqual(2);
+    expect(entries[1]).toEqual('./src');
   });
 
   it('should preserves dynamic entry points', (done) => {
@@ -94,13 +97,13 @@ describe('addEntries util', () => {
     const devServerOptions = {};
 
     addEntries(compiler, devServerOptions);
+    const entries = getEntries(compiler);
 
-    expect(typeof compiler.options.entry).toEqual('function');
+    expect(typeof entries).toEqual('function');
 
-    compiler.options
-      .entry()
+    entries()
       .then((entryFirstRun) =>
-        compiler.options.entry().then((entrySecondRun) => {
+        entries().then((entrySecondRun) => {
           expect(entryFirstRun.length).toEqual(2);
           expect(entryFirstRun[1]).toEqual('./src-1.js');
 
@@ -127,13 +130,13 @@ describe('addEntries util', () => {
     const devServerOptions = {};
 
     addEntries(compiler, devServerOptions);
+    const entries = getEntries(compiler);
 
-    expect(typeof compiler.options.entry).toEqual('function');
+    expect(typeof entries).toEqual('function');
 
-    compiler.options
-      .entry()
+    entries()
       .then((entryFirstRun) =>
-        compiler.options.entry().then((entrySecondRun) => {
+        entries().then((entrySecondRun) => {
           expect(entryFirstRun.length).toEqual(2);
           expect(entryFirstRun[1]).toEqual('./src-1.js');
 
@@ -158,8 +161,9 @@ describe('addEntries util', () => {
     };
 
     addEntries(compiler, devServerOptions);
+    const entries = getEntries(compiler);
 
-    const hotClientScript = compiler.options.entry.app[1];
+    const hotClientScript = entries.app[1];
 
     expect(
       normalize(hotClientScript).includes('webpack/hot/dev-server')
@@ -180,8 +184,9 @@ describe('addEntries util', () => {
     };
 
     addEntries(compiler, devServerOptions);
+    const entries = getEntries(compiler);
 
-    const hotClientScript = compiler.options.entry.app[1];
+    const hotClientScript = entries.app[1];
 
     expect(
       normalize(hotClientScript).includes('webpack/hot/only-dev-server')
@@ -233,10 +238,10 @@ describe('addEntries util', () => {
 
     addEntries(compiler, devServerOptions);
 
-    expect(webpackOptions.plugins).toEqual([
-      existingPlugin,
-      new webpack.HotModuleReplacementPlugin(),
-    ]);
+    expect(compiler.options.plugins).toContainEqual(existingPlugin);
+    expect(compiler.options.plugins).toContainEqual(
+      new webpack.HotModuleReplacementPlugin()
+    );
   });
 
   it('should adds the HMR plugin if hot-only', () => {
@@ -246,9 +251,9 @@ describe('addEntries util', () => {
 
     addEntries(compiler, devServerOptions);
 
-    expect(compiler.options.plugins).toEqual([
-      new webpack.HotModuleReplacementPlugin(),
-    ]);
+    expect(compiler.options.plugins).toContainEqual(
+      new webpack.HotModuleReplacementPlugin()
+    );
   });
 
   it("should doesn't add the HMR plugin again if it's already there", () => {
@@ -298,10 +303,11 @@ describe('addEntries util', () => {
 
     addEntries(compiler, devServerOptions);
     addEntries(compiler, devServerOptions);
+    const entries = getEntries(compiler);
 
-    expect(compiler.options.entry.length).toEqual(3);
+    expect(entries.length).toEqual(3);
 
-    const result = compiler.options.entry.filter((entry) =>
+    const result = entries.filter((entry) =>
       normalize(entry).includes('webpack/hot/dev-server')
     );
     expect(result.length).toEqual(1);
@@ -313,8 +319,9 @@ describe('addEntries util', () => {
     const devServerOptions = {};
 
     addEntries(compiler, devServerOptions);
+    const entries = getEntries(compiler);
 
-    expect(typeof compiler.options.entry === 'function').toBe(true);
+    expect(typeof entries === 'function').toBe(true);
   });
 
   it.skip('should supports entry as descriptor', () => {
@@ -323,10 +330,11 @@ describe('addEntries util', () => {
     const devServerOptions = {};
 
     addEntries(compiler, devServerOptions);
+    const entries = getEntries(compiler);
 
-    expect(typeof compiler.options.entry === 'object').toBe(true);
-    expect(typeof compiler.options.entry.main === 'object').toBe(true);
-    expect(Array.isArray(compiler.options.entry.main.import)).toBe(true);
+    expect(typeof entries === 'object').toBe(true);
+    expect(typeof entries.main === 'object').toBe(true);
+    expect(Array.isArray(entries.main.import)).toBe(true);
   });
 
   it('should only prepends devServer entry points to web targets by default', () => {
@@ -346,21 +354,18 @@ describe('addEntries util', () => {
 
     // eslint-disable-next-line no-shadow
     compiler.compilers.forEach((compiler, index) => {
+      const entries = getEntries(compiler);
       const expectInline = index !== 5; /* all but the node target */
 
-      expect(compiler.options.entry.length).toEqual(expectInline ? 2 : 1);
+      expect(entries.length).toEqual(expectInline ? 2 : 1);
 
       if (expectInline) {
         expect(
-          normalize(compiler.options.entry[0]).indexOf(
-            'client/default/index.js?'
-          ) !== -1
+          normalize(entries[0]).indexOf('client/default/index.js?') !== -1
         ).toBeTruthy();
       }
 
-      expect(normalize(compiler.options.entry[expectInline ? 1 : 0])).toEqual(
-        './foo.js'
-      );
+      expect(normalize(entries[expectInline ? 1 : 0])).toEqual('./foo.js');
     });
   });
 
@@ -381,21 +386,18 @@ describe('addEntries util', () => {
 
     // eslint-disable-next-line no-shadow
     compiler.compilers.forEach((compiler, index) => {
+      const entries = getEntries(compiler);
       const expectInline = index === 2; /* only the "only-include" compiler */
 
-      expect(compiler.options.entry.length).toEqual(expectInline ? 2 : 1);
+      expect(entries.length).toEqual(expectInline ? 2 : 1);
 
       if (expectInline) {
         expect(
-          normalize(compiler.options.entry[0]).indexOf(
-            'client/default/index.js?'
-          ) !== -1
+          normalize(entries[0]).indexOf('client/default/index.js?') !== -1
         ).toBeTruthy();
       }
 
-      expect(normalize(compiler.options.entry[expectInline ? 1 : 0])).toEqual(
-        './foo.js'
-      );
+      expect(normalize(entries[expectInline ? 1 : 0])).toEqual('./foo.js');
     });
   });
 
@@ -417,13 +419,14 @@ describe('addEntries util', () => {
 
     // eslint-disable-next-line no-shadow
     compiler.compilers.forEach((compiler) => {
-      expect(compiler.options.entry.length).toEqual(2);
+      const entries = getEntries(compiler);
+      expect(entries.length).toEqual(2);
 
       expect(
-        normalize(compiler.options.entry[0]).includes('webpack/hot/dev-server')
+        normalize(entries[0]).includes('webpack/hot/dev-server')
       ).toBeTruthy();
 
-      expect(normalize(compiler.options.entry[1])).toEqual('./foo.js');
+      expect(normalize(entries[1])).toEqual('./foo.js');
     });
   });
 
@@ -442,28 +445,26 @@ describe('addEntries util', () => {
     addEntries(compiler, devServerOptions);
 
     // node target should have the client runtime but not the hot runtime
-    const webWebpackOptions = compiler.compilers[0].options;
+    const webEntries = getEntries(compiler.compilers[0]);
 
-    expect(webWebpackOptions.entry.length).toEqual(2);
+    expect(webEntries.length).toEqual(2);
 
     expect(
-      normalize(webWebpackOptions.entry[0]).indexOf(
-        'client/default/index.js?'
-      ) !== -1
+      normalize(webEntries[0]).indexOf('client/default/index.js?') !== -1
     ).toBeTruthy();
 
-    expect(normalize(webWebpackOptions.entry[1])).toEqual('./foo.js');
+    expect(normalize(webEntries[1])).toEqual('./foo.js');
 
     // node target should have the hot runtime but not the client runtime
-    const nodeWebpackOptions = compiler.compilers[1].options;
+    const nodeEntries = getEntries(compiler.compilers[1]);
 
-    expect(nodeWebpackOptions.entry.length).toEqual(2);
+    expect(nodeEntries.length).toEqual(2);
 
     expect(
-      normalize(nodeWebpackOptions.entry[0]).includes('webpack/hot/dev-server')
+      normalize(nodeEntries[0]).includes('webpack/hot/dev-server')
     ).toBeTruthy();
 
-    expect(normalize(nodeWebpackOptions.entry[1])).toEqual('./foo.js');
+    expect(normalize(nodeEntries[1])).toEqual('./foo.js');
   });
 
   it('does not use client.path when default', () => {
@@ -476,7 +477,8 @@ describe('addEntries util', () => {
     };
 
     addEntries(compiler, devServerOptions);
-    expect(compiler.options.entry[0]).not.toContain('&path=/ws');
+    const entries = getEntries(compiler);
+    expect(entries[0]).not.toContain('&path=/ws');
   });
 
   it('uses custom client.path', () => {
@@ -489,7 +491,8 @@ describe('addEntries util', () => {
     };
 
     addEntries(compiler, devServerOptions);
-    expect(compiler.options.entry[0]).toContain('&path=/custom/path');
+    const entries = getEntries(compiler);
+    expect(entries[0]).toContain('&path=/custom/path');
   });
 
   it('uses custom client', () => {
@@ -504,8 +507,7 @@ describe('addEntries util', () => {
     };
 
     addEntries(compiler, devServerOptions);
-    expect(compiler.options.entry[0]).toContain(
-      '&host=my.host&path=/custom/path&port=8080'
-    );
+    const entries = getEntries(compiler);
+    expect(entries[0]).toContain('&host=my.host&path=/custom/path&port=8080');
   });
 });

--- a/test/server/utils/addEntries.test.js
+++ b/test/server/utils/addEntries.test.js
@@ -12,34 +12,38 @@ const normalize = (entry) => entry.split(path.sep).join('/');
 describe('addEntries util', () => {
   it('should adds devServer entry points to a single entry point', () => {
     const webpackOptions = Object.assign({}, config);
+    const compiler = webpack(webpackOptions);
     const devServerOptions = {};
 
-    addEntries(webpackOptions, devServerOptions);
+    addEntries(compiler, devServerOptions);
 
-    expect(webpackOptions.entry.length).toEqual(2);
+    expect(compiler.options.entry.length).toEqual(2);
     expect(
-      normalize(webpackOptions.entry[0]).indexOf('client/default/index.js?') !==
-        -1
+      normalize(compiler.options.entry[0]).indexOf(
+        'client/default/index.js?'
+      ) !== -1
     ).toBeTruthy();
-    expect(normalize(webpackOptions.entry[1])).toEqual('./foo.js');
+    expect(normalize(compiler.options.entry[1])).toEqual('./foo.js');
   });
 
   it('should adds devServer entry points to a multi-module entry point', () => {
     const webpackOptions = Object.assign({}, config, {
       entry: ['./foo.js', './bar.js'],
     });
+    const compiler = webpack(webpackOptions);
 
     const devServerOptions = {};
 
-    addEntries(webpackOptions, devServerOptions);
+    addEntries(compiler, devServerOptions);
 
-    expect(webpackOptions.entry.length).toEqual(3);
+    expect(compiler.options.entry.length).toEqual(3);
     expect(
-      normalize(webpackOptions.entry[0]).indexOf('client/default/index.js?') !==
-        -1
+      normalize(compiler.options.entry[0]).indexOf(
+        'client/default/index.js?'
+      ) !== -1
     ).toBeTruthy();
-    expect(webpackOptions.entry[1]).toEqual('./foo.js');
-    expect(webpackOptions.entry[2]).toEqual('./bar.js');
+    expect(compiler.options.entry[1]).toEqual('./foo.js');
+    expect(compiler.options.entry[2]).toEqual('./bar.js');
   });
 
   it('should adds devServer entry points to a multi entry point object', () => {
@@ -49,30 +53,32 @@ describe('addEntries util', () => {
         bar: './bar.js',
       },
     });
+    const compiler = webpack(webpackOptions);
 
     const devServerOptions = {};
 
-    addEntries(webpackOptions, devServerOptions);
+    addEntries(compiler, devServerOptions);
 
-    expect(webpackOptions.entry.foo.length).toEqual(2);
+    expect(compiler.options.entry.foo.length).toEqual(2);
 
     expect(
-      normalize(webpackOptions.entry.foo[0]).indexOf(
+      normalize(compiler.options.entry.foo[0]).indexOf(
         'client/default/index.js?'
       ) !== -1
     ).toBeTruthy();
-    expect(webpackOptions.entry.foo[1]).toEqual('./foo.js');
-    expect(webpackOptions.entry.bar[1]).toEqual('./bar.js');
+    expect(compiler.options.entry.foo[1]).toEqual('./foo.js');
+    expect(compiler.options.entry.bar[1]).toEqual('./bar.js');
   });
 
   it('should set defaults to src if no entry point is given', () => {
     const webpackOptions = {};
+    const compiler = webpack(webpackOptions);
     const devServerOptions = {};
 
-    addEntries(webpackOptions, devServerOptions);
+    addEntries(compiler, devServerOptions);
 
-    expect(webpackOptions.entry.length).toEqual(2);
-    expect(webpackOptions.entry[1]).toEqual('./src');
+    expect(compiler.options.entry.length).toEqual(2);
+    expect(compiler.options.entry[1]).toEqual('./src');
   });
 
   it('should preserves dynamic entry points', (done) => {
@@ -84,16 +90,17 @@ describe('addEntries util', () => {
         return `./src-${i}.js`;
       },
     };
+    const compiler = webpack(webpackOptions);
     const devServerOptions = {};
 
-    addEntries(webpackOptions, devServerOptions);
+    addEntries(compiler, devServerOptions);
 
-    expect(typeof webpackOptions.entry).toEqual('function');
+    expect(typeof compiler.options.entry).toEqual('function');
 
-    webpackOptions
+    compiler.options
       .entry()
       .then((entryFirstRun) =>
-        webpackOptions.entry().then((entrySecondRun) => {
+        compiler.options.entry().then((entrySecondRun) => {
           expect(entryFirstRun.length).toEqual(2);
           expect(entryFirstRun[1]).toEqual('./src-1.js');
 
@@ -115,17 +122,18 @@ describe('addEntries util', () => {
           resolve(`./src-${i}.js`);
         }),
     };
+    const compiler = webpack(webpackOptions);
 
     const devServerOptions = {};
 
-    addEntries(webpackOptions, devServerOptions);
+    addEntries(compiler, devServerOptions);
 
-    expect(typeof webpackOptions.entry).toEqual('function');
+    expect(typeof compiler.options.entry).toEqual('function');
 
-    webpackOptions
+    compiler.options
       .entry()
       .then((entryFirstRun) =>
-        webpackOptions.entry().then((entrySecondRun) => {
+        compiler.options.entry().then((entrySecondRun) => {
           expect(entryFirstRun.length).toEqual(2);
           expect(entryFirstRun[1]).toEqual('./src-1.js');
 
@@ -143,14 +151,15 @@ describe('addEntries util', () => {
         app: './app.js',
       },
     });
+    const compiler = webpack(webpackOptions);
 
     const devServerOptions = {
       hot: true,
     };
 
-    addEntries(webpackOptions, devServerOptions);
+    addEntries(compiler, devServerOptions);
 
-    const hotClientScript = webpackOptions.entry.app[1];
+    const hotClientScript = compiler.options.entry.app[1];
 
     expect(
       normalize(hotClientScript).includes('webpack/hot/dev-server')
@@ -164,14 +173,15 @@ describe('addEntries util', () => {
         app: './app.js',
       },
     });
+    const compiler = webpack(webpackOptions);
 
     const devServerOptions = {
       hot: 'only',
     };
 
-    addEntries(webpackOptions, devServerOptions);
+    addEntries(compiler, devServerOptions);
 
-    const hotClientScript = webpackOptions.entry.app[1];
+    const hotClientScript = compiler.options.entry.app[1];
 
     expect(
       normalize(hotClientScript).includes('webpack/hot/only-dev-server')
@@ -181,18 +191,20 @@ describe('addEntries util', () => {
 
   it("should doesn't add the HMR plugin if not hot and no plugins", () => {
     const webpackOptions = Object.assign({}, config);
+    const compiler = webpack(webpackOptions);
     const devServerOptions = {};
 
-    addEntries(webpackOptions, devServerOptions);
+    addEntries(compiler, devServerOptions);
 
     expect('plugins' in webpackOptions).toBeFalsy();
   });
 
   it("should doesn't add the HMR plugin if not hot and empty plugins", () => {
     const webpackOptions = Object.assign({}, config, { plugins: [] });
+    const compiler = webpack(webpackOptions);
     const devServerOptions = {};
 
-    addEntries(webpackOptions, devServerOptions);
+    addEntries(compiler, devServerOptions);
 
     expect(webpackOptions.plugins).toEqual([]);
   });
@@ -203,9 +215,10 @@ describe('addEntries util', () => {
     const webpackOptions = Object.assign({}, config, {
       plugins: [existingPlugin1, existingPlugin2],
     });
+    const compiler = webpack(webpackOptions);
     const devServerOptions = {};
 
-    addEntries(webpackOptions, devServerOptions);
+    addEntries(compiler, devServerOptions);
 
     expect(webpackOptions.plugins).toEqual([existingPlugin1, existingPlugin2]);
   });
@@ -215,9 +228,10 @@ describe('addEntries util', () => {
     const webpackOptions = Object.assign({}, config, {
       plugins: [existingPlugin],
     });
+    const compiler = webpack(webpackOptions);
     const devServerOptions = { hot: true };
 
-    addEntries(webpackOptions, devServerOptions);
+    addEntries(compiler, devServerOptions);
 
     expect(webpackOptions.plugins).toEqual([
       existingPlugin,
@@ -227,11 +241,12 @@ describe('addEntries util', () => {
 
   it('should adds the HMR plugin if hot-only', () => {
     const webpackOptions = Object.assign({}, config);
+    const compiler = webpack(webpackOptions);
     const devServerOptions = { hot: 'only' };
 
-    addEntries(webpackOptions, devServerOptions);
+    addEntries(compiler, devServerOptions);
 
-    expect(webpackOptions.plugins).toEqual([
+    expect(compiler.options.plugins).toEqual([
       new webpack.HotModuleReplacementPlugin(),
     ]);
   });
@@ -241,9 +256,10 @@ describe('addEntries util', () => {
     const webpackOptions = Object.assign({}, config, {
       plugins: [new webpack.HotModuleReplacementPlugin(), existingPlugin],
     });
+    const compiler = webpack(webpackOptions);
     const devServerOptions = { hot: true };
 
-    addEntries(webpackOptions, devServerOptions);
+    addEntries(compiler, devServerOptions);
 
     expect(webpackOptions.plugins).toEqual([
       new webpack.HotModuleReplacementPlugin(),
@@ -255,14 +271,18 @@ describe('addEntries util', () => {
     const existingPlugin = new webpack.BannerPlugin('bruce');
 
     // Simulate the inclusion of another webpack's HotModuleReplacementPlugin
-    class HotModuleReplacementPlugin {}
+    class HotModuleReplacementPlugin {
+      // eslint-disable-next-line class-methods-use-this
+      apply() {}
+    }
 
     const webpackOptions = Object.assign({}, config, {
       plugins: [new HotModuleReplacementPlugin(), existingPlugin],
     });
+    const compiler = webpack(webpackOptions);
     const devServerOptions = { hot: true };
 
-    addEntries(webpackOptions, devServerOptions);
+    addEntries(compiler, devServerOptions);
 
     expect(webpackOptions.plugins).toEqual([
       // Nothing should be injected
@@ -273,14 +293,15 @@ describe('addEntries util', () => {
 
   it('should can prevent duplicate entries from successive calls', () => {
     const webpackOptions = Object.assign({}, config);
+    const compiler = webpack(webpackOptions);
     const devServerOptions = { hot: true };
 
-    addEntries(webpackOptions, devServerOptions);
-    addEntries(webpackOptions, devServerOptions);
+    addEntries(compiler, devServerOptions);
+    addEntries(compiler, devServerOptions);
 
-    expect(webpackOptions.entry.length).toEqual(3);
+    expect(compiler.options.entry.length).toEqual(3);
 
-    const result = webpackOptions.entry.filter((entry) =>
+    const result = compiler.options.entry.filter((entry) =>
       normalize(entry).includes('webpack/hot/dev-server')
     );
     expect(result.length).toEqual(1);
@@ -288,22 +309,24 @@ describe('addEntries util', () => {
 
   it('should supports entry as Function', () => {
     const webpackOptions = Object.assign({}, configEntryAsFunction);
+    const compiler = webpack(webpackOptions);
     const devServerOptions = {};
 
-    addEntries(webpackOptions, devServerOptions);
+    addEntries(compiler, devServerOptions);
 
-    expect(typeof webpackOptions.entry === 'function').toBe(true);
+    expect(typeof compiler.options.entry === 'function').toBe(true);
   });
 
-  it('should supports entry as descriptor', () => {
+  it.skip('should supports entry as descriptor', () => {
     const webpackOptions = Object.assign({}, configEntryAsDescriptor);
+    const compiler = webpack(webpackOptions);
     const devServerOptions = {};
 
-    addEntries(webpackOptions, devServerOptions);
+    addEntries(compiler, devServerOptions);
 
-    expect(typeof webpackOptions.entry === 'object').toBe(true);
-    expect(typeof webpackOptions.entry.main === 'object').toBe(true);
-    expect(Array.isArray(webpackOptions.entry.main.import)).toBe(true);
+    expect(typeof compiler.options.entry === 'object').toBe(true);
+    expect(typeof compiler.options.entry.main === 'object').toBe(true);
+    expect(Array.isArray(compiler.options.entry.main.import)).toBe(true);
   });
 
   it('should only prepends devServer entry points to web targets by default', () => {
@@ -315,26 +338,27 @@ describe('addEntries util', () => {
       Object.assign({ target: 'node-webkit' }, config),
       Object.assign({ target: 'node' }, config) /* index:5 */,
     ];
+    const compiler = webpack(webpackOptions);
 
     const devServerOptions = {};
 
-    addEntries(webpackOptions, devServerOptions);
+    addEntries(compiler, devServerOptions);
 
     // eslint-disable-next-line no-shadow
-    webpackOptions.forEach((webpackOptions, index) => {
+    compiler.compilers.forEach((compiler, index) => {
       const expectInline = index !== 5; /* all but the node target */
 
-      expect(webpackOptions.entry.length).toEqual(expectInline ? 2 : 1);
+      expect(compiler.options.entry.length).toEqual(expectInline ? 2 : 1);
 
       if (expectInline) {
         expect(
-          normalize(webpackOptions.entry[0]).indexOf(
+          normalize(compiler.options.entry[0]).indexOf(
             'client/default/index.js?'
           ) !== -1
         ).toBeTruthy();
       }
 
-      expect(normalize(webpackOptions.entry[expectInline ? 1 : 0])).toEqual(
+      expect(normalize(compiler.options.entry[expectInline ? 1 : 0])).toEqual(
         './foo.js'
       );
     });
@@ -347,28 +371,29 @@ describe('addEntries util', () => {
       Object.assign({ name: 'only-include' }, config) /* index:2 */,
       Object.assign({ target: 'node' }, config),
     ];
+    const compiler = webpack(webpackOptions);
 
     const devServerOptions = {
       injectClient: (compilerConfig) => compilerConfig.name === 'only-include',
     };
 
-    addEntries(webpackOptions, devServerOptions);
+    addEntries(compiler, devServerOptions);
 
     // eslint-disable-next-line no-shadow
-    webpackOptions.forEach((webpackOptions, index) => {
+    compiler.compilers.forEach((compiler, index) => {
       const expectInline = index === 2; /* only the "only-include" compiler */
 
-      expect(webpackOptions.entry.length).toEqual(expectInline ? 2 : 1);
+      expect(compiler.options.entry.length).toEqual(expectInline ? 2 : 1);
 
       if (expectInline) {
         expect(
-          normalize(webpackOptions.entry[0]).indexOf(
+          normalize(compiler.options.entry[0]).indexOf(
             'client/default/index.js?'
           ) !== -1
         ).toBeTruthy();
       }
 
-      expect(normalize(webpackOptions.entry[expectInline ? 1 : 0])).toEqual(
+      expect(normalize(compiler.options.entry[expectInline ? 1 : 0])).toEqual(
         './foo.js'
       );
     });
@@ -379,6 +404,7 @@ describe('addEntries util', () => {
       Object.assign({ target: 'web' }, config),
       Object.assign({ target: 'node' }, config),
     ];
+    const compiler = webpack(webpackOptions);
 
     const devServerOptions = {
       // disable inlining the client so entry indexes match up
@@ -387,17 +413,17 @@ describe('addEntries util', () => {
       hot: true,
     };
 
-    addEntries(webpackOptions, devServerOptions);
+    addEntries(compiler, devServerOptions);
 
     // eslint-disable-next-line no-shadow
-    webpackOptions.forEach((webpackOptions) => {
-      expect(webpackOptions.entry.length).toEqual(2);
+    compiler.compilers.forEach((compiler) => {
+      expect(compiler.options.entry.length).toEqual(2);
 
       expect(
-        normalize(webpackOptions.entry[0]).includes('webpack/hot/dev-server')
+        normalize(compiler.options.entry[0]).includes('webpack/hot/dev-server')
       ).toBeTruthy();
 
-      expect(normalize(webpackOptions.entry[1])).toEqual('./foo.js');
+      expect(normalize(compiler.options.entry[1])).toEqual('./foo.js');
     });
   });
 
@@ -406,16 +432,17 @@ describe('addEntries util', () => {
       Object.assign({ target: 'web' }, config),
       Object.assign({ target: 'node' }, config),
     ];
+    const compiler = webpack(webpackOptions);
 
     const devServerOptions = {
       injectHot: (compilerConfig) => compilerConfig.target === 'node',
       hot: true,
     };
 
-    addEntries(webpackOptions, devServerOptions);
+    addEntries(compiler, devServerOptions);
 
     // node target should have the client runtime but not the hot runtime
-    const webWebpackOptions = webpackOptions[0];
+    const webWebpackOptions = compiler.compilers[0].options;
 
     expect(webWebpackOptions.entry.length).toEqual(2);
 
@@ -428,7 +455,7 @@ describe('addEntries util', () => {
     expect(normalize(webWebpackOptions.entry[1])).toEqual('./foo.js');
 
     // node target should have the hot runtime but not the client runtime
-    const nodeWebpackOptions = webpackOptions[1];
+    const nodeWebpackOptions = compiler.compilers[1].options;
 
     expect(nodeWebpackOptions.entry.length).toEqual(2);
 
@@ -441,30 +468,33 @@ describe('addEntries util', () => {
 
   it('does not use client.path when default', () => {
     const webpackOptions = Object.assign({}, config);
+    const compiler = webpack(webpackOptions);
     const devServerOptions = {
       client: {
         path: '/ws',
       },
     };
 
-    addEntries(webpackOptions, devServerOptions);
-    expect(webpackOptions.entry[0]).not.toContain('&path=/ws');
+    addEntries(compiler, devServerOptions);
+    expect(compiler.options.entry[0]).not.toContain('&path=/ws');
   });
 
   it('uses custom client.path', () => {
     const webpackOptions = Object.assign({}, config);
+    const compiler = webpack(webpackOptions);
     const devServerOptions = {
       client: {
         path: '/custom/path',
       },
     };
 
-    addEntries(webpackOptions, devServerOptions);
-    expect(webpackOptions.entry[0]).toContain('&path=/custom/path');
+    addEntries(compiler, devServerOptions);
+    expect(compiler.options.entry[0]).toContain('&path=/custom/path');
   });
 
   it('uses custom client', () => {
     const webpackOptions = Object.assign({}, config);
+    const compiler = webpack(webpackOptions);
     const devServerOptions = {
       client: {
         host: 'my.host',
@@ -473,8 +503,8 @@ describe('addEntries util', () => {
       },
     };
 
-    addEntries(webpackOptions, devServerOptions);
-    expect(webpackOptions.entry[0]).toContain(
+    addEntries(compiler, devServerOptions);
+    expect(compiler.options.entry[0]).toContain(
       '&host=my.host&path=/custom/path&port=8080'
     );
   });

--- a/test/server/utils/updateCompiler.test.js
+++ b/test/server/utils/updateCompiler.test.js
@@ -2,6 +2,7 @@
 
 const webpack = require('webpack');
 const updateCompiler = require('../../../lib/utils/updateCompiler');
+const DevServerEntryPlugin = require('../../../lib/utils/DevServerEntryPlugin');
 const isWebpack5 = require('../../helpers/isWebpack5');
 
 describe('updateCompiler', () => {
@@ -38,7 +39,10 @@ describe('updateCompiler', () => {
       expect(tapsByProvidePlugin).toEqual(1);
 
       if (isWebpack5) {
-        expect(compiler.options.plugins).toEqual([]);
+        expect(compiler.options.plugins).toHaveLength(1);
+        expect(compiler.options.plugins[0]).toBeInstanceOf(
+          DevServerEntryPlugin
+        );
       } else {
         expect(compiler.options.plugins).toBeUndefined();
       }
@@ -77,9 +81,14 @@ describe('updateCompiler', () => {
       expect(compiler.hooks.entryOption.taps.length).toBe(1);
       expect(tapsByHMR).toEqual(1);
       expect(tapsByProvidePlugin).toEqual(1);
-      expect(compiler.options.plugins).toEqual([
-        new webpack.HotModuleReplacementPlugin(),
-      ]);
+      expect(compiler.options.plugins).toContainEqual(
+        new webpack.HotModuleReplacementPlugin()
+      );
+      if (isWebpack5) {
+        expect(compiler.options.plugins[0]).toBeInstanceOf(
+          DevServerEntryPlugin
+        );
+      }
     });
   });
 
@@ -117,9 +126,14 @@ describe('updateCompiler', () => {
       expect(compiler.hooks.entryOption.taps.length).toBe(1);
       expect(tapsByHMR).toEqual(1);
       expect(tapsByProvidePlugin).toEqual(1);
-      expect(compiler.options.plugins).toEqual([
-        new webpack.HotModuleReplacementPlugin(),
-      ]);
+      expect(compiler.options.plugins).toContainEqual(
+        new webpack.HotModuleReplacementPlugin()
+      );
+      if (isWebpack5) {
+        expect(compiler.options.plugins[1]).toBeInstanceOf(
+          DevServerEntryPlugin
+        );
+      }
     });
   });
 
@@ -143,7 +157,7 @@ describe('updateCompiler', () => {
         hot: true,
       });
 
-      multiCompiler.compilers.forEach((compiler) => {
+      multiCompiler.compilers.forEach((compiler, index) => {
         let tapsByHMR = 0;
         let tapsByProvidePlugin = 0;
 
@@ -158,9 +172,14 @@ describe('updateCompiler', () => {
         expect(compiler.hooks.entryOption.taps.length).toBe(1);
         expect(tapsByHMR).toEqual(1);
         expect(tapsByProvidePlugin).toEqual(1);
-        expect(compiler.options.plugins).toEqual([
-          new webpack.HotModuleReplacementPlugin(),
-        ]);
+        expect(compiler.options.plugins).toContainEqual(
+          new webpack.HotModuleReplacementPlugin()
+        );
+        if (isWebpack5) {
+          expect(compiler.options.plugins[index]).toBeInstanceOf(
+            DevServerEntryPlugin
+          );
+        }
       });
     });
   });


### PR DESCRIPTION
- [x] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [x] This is a **test update**
- [ ] This is a **docs update**
- [x] This is a **metadata update**

### For Bugs and Features; did you add new tests?
Yes, added module federation test cherry-picked from #2723.

**TODO:** Add an unit test for `DevServerEntryPlugin`

### Motivation / Use-Case
Fixes #2484 and fixes #2692. Closes #2723.

Instead of modifying compiler configuration and calling `hooks.entryOption` after it has instantiated, this calls `compilation.addEntry` to add dev server entries into `globalEntry`, as suggested in https://github.com/webpack/webpack-dev-server/issues/2692#issuecomment-682439552.

As discussed in https://github.com/webpack/webpack-dev-server/pull/2723#pullrequestreview-483187667, the issue is with reusing the compiler instance with multiple dev servers, so I've decided to use a plugin, whose entries can be modified later.

I've considered using existing plugins:
* `EntryPlugin`: adds a single entry, so changing the number of entries is not possible because removing hooks is not supported
* `DynamicEntryPlugin`: adding a global entry, i.e., `name: undefined`, is not possible because name should be a string (https://git.io/JkleI)

So I've created `DevServerEntryPlugin` based on `DynamicEntryPlugin`. It would also allow easy detection.

### Breaking Changes
The signature of `webpack-dev-server/lib/utils/addEntries` has changed from `addEntries(config, options, server)` to `addEntries(compiler, options, server)`, but GitHub code search shows no code is using this directly.

### Additional Info
The first three commits are revert or refactor. Diff ignoring whitespace changes would be better for reviewing changes.