### PR TITLE
fix(utils): use targetProperties for target detection

### DIFF
--- a/lib/utils/addEntries.js
+++ b/lib/utils/addEntries.js
@@ -148,7 +148,7 @@ function addEntries(compiler, options, server) {
         // eslint-disable-next-line no-undefined
         undefined,
         null,
-      ].includes(config.target);
+      ].includes(target);
     }
 
     /** @type {Entry} */

--- a/lib/utils/addEntries.js
+++ b/lib/utils/addEntries.js
@@ -120,16 +120,37 @@ function addEntries(compiler, options, server) {
   // eslint-disable-next-line no-shadow
   compilers.forEach((compiler) => {
     const config = compiler.options;
+    const target = config.target;
     /** @type {Boolean} */
-    const webTarget = [
-      'web',
-      'webworker',
-      'electron-renderer',
-      'node-webkit',
-      // eslint-disable-next-line no-undefined
-      undefined,
-      null,
-    ].includes(config.target);
+    let webTarget = false;
+    try {
+      // only available in webpack@5
+      const {
+        getTargetsProperties,
+        getTargetProperties,
+        // @ts-ignore
+        // eslint-disable-next-line import/no-unresolved
+      } = require('webpack/lib/config/target');
+      if (target) {
+        const targetProperties =
+          typeof target === 'string'
+            ? getTargetProperties(target, config.context)
+            : getTargetsProperties(target, config.context);
+        // optimistic
+        webTarget = targetProperties.web || targetProperties.web === null;
+      }
+    } catch (_) {
+      webTarget = [
+        'web',
+        'webworker',
+        'electron-renderer',
+        'node-webkit',
+        // eslint-disable-next-line no-undefined
+        undefined,
+        null,
+      ].includes(config.target);
+    }
+
     /** @type {Entry} */
     const additionalEntries = checkInject(
       options.injectClient,


### PR DESCRIPTION
- [x] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?
Yes.

### Motivation / Use-Case
Closes #2758.

Uses `targetProperties.web` to detect web target, if available.

### Breaking Changes
N/A

### Additional Info
