### PR TITLE
test: fix flaky tests

### DIFF
--- a/test/helpers/test-server.js
+++ b/test/helpers/test-server.js
@@ -20,9 +20,13 @@ function startFullSetup(config, options, done) {
 
   server = new Server(compiler, options);
 
-  const port = Object.prototype.hasOwnProperty.call(options, 'port')
-    ? options.port
-    : 8080;
+  let port;
+  if (Object.prototype.hasOwnProperty.call(options, 'port')) {
+    port = options.port;
+  } else {
+    console.warn('Using the default port for testing is not recommended');
+    port = 8080;
+  }
   const host = Object.prototype.hasOwnProperty.call(options, 'host')
     ? options.host
     : 'localhost';

--- a/test/server/proxy-option.test.js
+++ b/test/server/proxy-option.test.js
@@ -419,6 +419,7 @@ describe('proxy option', () => {
           proxy: {
             '**': proxyTarget,
           },
+          port: port3,
         },
         done
       );

--- a/test/server/proxy-option.test.js
+++ b/test/server/proxy-option.test.js
@@ -91,9 +91,19 @@ function startProxyServers() {
   listeners.push(proxy2.listen(port2));
 
   // return a function to shutdown proxy servers
-  return function proxy() {
-    listeners.forEach((listener) => {
-      listener.close();
+  return function proxy(done) {
+    Promise.all(
+      listeners.map(
+        (listener) =>
+          new Promise((resolve) => {
+            listener.close(() => {
+              // ignore errors
+              resolve();
+            });
+          })
+      )
+    ).then(() => {
+      done();
     });
   };
 }
@@ -123,8 +133,7 @@ describe('proxy option', () => {
 
     afterAll((done) => {
       testServer.close(() => {
-        closeProxyServers();
-        done();
+        closeProxyServers(done);
       });
     });
 
@@ -187,8 +196,7 @@ describe('proxy option', () => {
 
     afterAll((done) => {
       testServer.close(() => {
-        closeProxyServers();
-        done();
+        closeProxyServers(done);
       });
     });
 
@@ -221,8 +229,7 @@ describe('proxy option', () => {
 
     afterAll((done) => {
       testServer.close(() => {
-        closeProxyServers();
-        done();
+        closeProxyServers(done);
       });
     });
 
@@ -279,8 +286,7 @@ describe('proxy option', () => {
 
     afterAll((done) => {
       testServer.close(() => {
-        listener.close();
-        done();
+        listener.close(done);
       });
     });
 
@@ -428,8 +434,7 @@ describe('proxy option', () => {
 
     afterAll((done) => {
       testServer.close(() => {
-        listener.close();
-        done();
+        listener.close(done);
       });
     });
 

--- a/test/server/static-directory-option.test.js
+++ b/test/server/static-directory-option.test.js
@@ -296,6 +296,7 @@ describe('static.directory option', () => {
         config,
         {
           static: null,
+          port,
         },
         done
       );

--- a/test/server/static-publicPath-option.test.js
+++ b/test/server/static-publicPath-option.test.js
@@ -199,6 +199,7 @@ describe('static.publicPath option', () => {
           static: {
             publicPath: staticPublicPath,
           },
+          port,
         },
         done
       );


### PR DESCRIPTION
- [ ] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [x] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?
N/A

### Motivation / Use-Case
* Some tests were using the default port `8080`, causing `EADDRINUSE` on collision. Also, added a warning to prevent future mistakes.
  * https://github.com/webpack/webpack-dev-server/runs/1413577706
* Some `proxy-option` tests were ended before all servers were closed (not sure this would cause failures)

### Breaking Changes
N/A

### Additional Info
