### PR TITLE
fix(utils): remove `socket` status and log `options.dev.publicPath` only if specified

### DIFF
--- a/lib/utils/status.js
+++ b/lib/utils/status.js
@@ -3,7 +3,6 @@
 const colors = require('./colors');
 const runOpen = require('./runOpen');
 
-// TODO: don't emit logs when webpack-dev-server is used via Node.js API
 function status(uri, options, logger, useColor) {
   logger.info(`Project is running at ${colors.info(useColor, uri)}`);
 

--- a/lib/utils/status.js
+++ b/lib/utils/status.js
@@ -5,13 +5,7 @@ const runOpen = require('./runOpen');
 
 // TODO: don't emit logs when webpack-dev-server is used via Node.js API
 function status(uri, options, logger, useColor) {
-  if (options.socket) {
-    logger.info(
-      `Listening to socket at ${colors.info(useColor, options.socket)}`
-    );
-  } else {
-    logger.info(`Project is running at ${colors.info(useColor, uri)}`);
-  }
+  logger.info(`Project is running at ${colors.info(useColor, uri)}`);
 
   logger.info(
     `webpack output is served from ${colors.info(useColor, options.publicPath)}`

--- a/lib/utils/status.js
+++ b/lib/utils/status.js
@@ -7,9 +7,14 @@ const runOpen = require('./runOpen');
 function status(uri, options, logger, useColor) {
   logger.info(`Project is running at ${colors.info(useColor, uri)}`);
 
-  logger.info(
-    `webpack output is served from ${colors.info(useColor, options.publicPath)}`
-  );
+  if (options.dev && options.dev.publicPath) {
+    logger.info(
+      `webpack output is served from ${colors.info(
+        useColor,
+        options.dev.publicPath
+      )}`
+    );
+  }
 
   if (options.static && options.static.length > 0) {
     logger.info(


### PR DESCRIPTION
- [x] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?
N/A

### Motivation / Use-Case
- `socket` option was removed in #2669.
- `publicPath` option was moved to `dev` in #2660 and now respects webpack output path (#2671), so only log it when it is overridden via `options.dev.publicPath`. Fixes #2745.

### Breaking Changes
N/A

### Additional Info
