### PR TITLE
fix: use location.port as the client port by default

### DIFF
--- a/lib/utils/DevServerPlugin.js
+++ b/lib/utils/DevServerPlugin.js
@@ -28,15 +28,8 @@ class DevServerPlugin {
   apply(compiler) {
     const { options } = this;
 
-    // we're stubbing the app in this method as it's static and doesn't require
-    // a server to be supplied. createDomain requires an app with the
-    // address() signature.
     /** @type {string} */
-    const domain = createDomain(options, {
-      address() {
-        return { port: options.port };
-      },
-    });
+    const domain = createDomain(options);
     /** @type {string} */
     const host =
       options.client && options.client.host

--- a/test/e2e/ClientOptions.test.js
+++ b/test/e2e/ClientOptions.test.js
@@ -70,7 +70,7 @@ describe('sockjs client proxy', () => {
             page.waitFor(beforeBrowserCloseDelay).then(() => {
               browser.close().then(() => {
                 expect(requestObj.url()).toContain(
-                  `http://localhost:${port1}/ws`
+                  `http://localhost:${port2}/ws`
                 );
                 done();
               });

--- a/test/server/__snapshots__/Server.test.js.snap
+++ b/test/server/__snapshots__/Server.test.js.snap
@@ -6,7 +6,7 @@ Array [
     "client",
     "default",
     "index.js?http:",
-    "localhost:8100",
+    "localhost",
   ],
   Array [
     "node_modules",
@@ -26,7 +26,7 @@ Array [
     "client",
     "default",
     "index.js?http:",
-    "localhost:8100",
+    "localhost",
   ],
   Array [
     "node_modules",


### PR DESCRIPTION
- [x] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?
Modified existing tests.

### Motivation / Use-Case
https://github.com/webpack/webpack-dev-server/pull/2845#discussion_r527680818

### Breaking Changes
Yes, the client uses the port of the current location (`location.port`, equivalent to `sockPort: 'location'`), by default. To get existing behavior, set the `client.port` with the port you'd like to set to, e.g.:
```js
const server = new Server(compiler, {
  client: {
    port,
  }
});
server.listen(port, hostname);
```

### Additional Info
