### PR TITLE
feat(client): allow sock host to use browser location's host

### DIFF
--- a/client-src/default/utils/createSocketUrl.js
+++ b/client-src/default/utils/createSocketUrl.js
@@ -74,10 +74,13 @@ function getSocketUrl(urlParts, loc) {
   // all of these sock url params are optionally passed in through
   // resourceQuery, so we need to fall back to the default if
   // they are not provided
-  const sockHost = query.sockHost || hostname;
+  let sockHost = query.sockHost || hostname;
   const sockPath = query.sockPath || '/sockjs-node';
   let sockPort = query.sockPort || port;
 
+  if (sockHost === 'location') {
+    sockHost = loc.hostname;
+  }
   if (sockPort === 'location') {
     sockPort = loc.port;
   }

--- a/test/client/utils/createSocketUrl.test.js
+++ b/test/client/utils/createSocketUrl.test.js
@@ -127,6 +127,16 @@ describe('createSocketUrl', () => {
       'https://asdf/sockjs-node',
     ],
     [
+      '?http://example.com:8096&sockHost=location',
+      'http://something.com',
+      'http://something.com:8096/sockjs-node',
+    ],
+    [
+      '?http://0.0.0.0:8096&sockHost=location',
+      'http://something.com',
+      'http://something.com:8096/sockjs-node',
+    ],
+    [
       '?https://example.com?sockPort=34',
       'http://something.com',
       'https://example.com:34/sockjs-node',
@@ -150,6 +160,11 @@ describe('createSocketUrl', () => {
       '?http://0.0.0.0:8096&sockPort=location',
       'http://localhost:3000',
       'http://localhost:3000/sockjs-node',
+    ],
+    [
+      '?http://example.com:8096&sockHost=location&sockPort=location',
+      'http://something.com:3000',
+      'http://something.com:3000/sockjs-node',
     ],
   ];
   samples3.forEach(([scriptSrc, loc, expected]) => {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [ ] This is a **bugfix**
- [x] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

Yes!
<!-- Please note that we won't approve your changes if you don't add tests. -->

### Motivation / Use-Case

This is templated off of commit 0835a19c/#2341, but for the browser location's hostname instead of its port.

This is useful when webpack-dev-server is being accessed behind a reverse proxy with a hostname that's not known at build time.
<!--
  What existing problem does the pull request solve?

  Please explain the motivation or use-case for making this change.
  If this Pull Request addresses an issue, please link to the issue.
-->

### Breaking Changes

No breaking changes.
<!--
  If this PR introduces a breaking change, please describe the impact and a
  potential migration path for existing applications.
-->

### Additional Info

None