### PR TITLE
fix: client overlay socket write

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -521,6 +521,7 @@ class Server {
   createSocketServer() {
     this.socketServer = new this.SocketServerImplementation(this);
 
+    // TODO: add test to check sockets are written correctly
     this.socketServer.onConnection((connection, headers) => {
       if (!connection) {
         return;
@@ -567,8 +568,8 @@ class Server {
         this.sockWrite([connection], 'progress', this.options.client.progress);
       }
 
-      if (this.options.clientOverlay) {
-        this.sockWrite([connection], 'overlay', this.options.clientOverlay);
+      if (this.options.client.overlay) {
+        this.sockWrite([connection], 'overlay', this.options.client.overlay);
       }
 
       if (!this.stats) {


### PR DESCRIPTION
- [x] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?
TODO

### Motivation / Use-Case
The client overlay option is in `this.options.client.overlay` not `this.options.clientOverlay`.

### Breaking Changes
N/A

### Additional Info
I think we should add a type check or migrate to TypeScript.