### PR TITLE
fix(client): use location protocol on ipv6 any (::) host

### DIFF
--- a/client-src/default/utils/createSocketUrl.js
+++ b/client-src/default/utils/createSocketUrl.js
@@ -43,6 +43,8 @@ function getSocketUrl(urlParts, loc) {
   const { auth, query } = urlParts;
   let { hostname, protocol, port } = urlParts;
 
+  const isInaddrAny = hostname === '0.0.0.0' || hostname === '::';
+
   if (!port || port === '0') {
     port = loc.port;
   }
@@ -51,11 +53,7 @@ function getSocketUrl(urlParts, loc) {
   // why do we need this check?
   // hostname n/a for file protocol (example, when using electron, ionic)
   // see: https://github.com/webpack/webpack-dev-server/pull/384
-  if (
-    (hostname === '0.0.0.0' || hostname === '::') &&
-    loc.hostname &&
-    loc.protocol.indexOf('http') === 0
-  ) {
+  if (isInaddrAny && loc.hostname && loc.protocol.indexOf('http') === 0) {
     hostname = loc.hostname;
   }
 
@@ -66,7 +64,7 @@ function getSocketUrl(urlParts, loc) {
   if (
     hostname &&
     hostname !== '127.0.0.1' &&
-    (loc.protocol === 'https:' || urlParts.hostname === '0.0.0.0')
+    (loc.protocol === 'https:' || isInaddrAny)
   ) {
     protocol = loc.protocol;
   }

--- a/test/client/utils/createSocketUrl.test.js
+++ b/test/client/utils/createSocketUrl.test.js
@@ -43,6 +43,7 @@ describe('createSocketUrl', () => {
     ['http://127.0.0.1', 'https://something.com', 'http://127.0.0.1/ws'],
     ['http://0.0.0.0', 'https://something.com', 'https://something.com/ws'],
     ['http://0.0.0.0', 'http://something.com', 'http://something.com/ws'],
+    ['http://[::]', 'https://something.com', 'https://something.com/ws'],
     ['http://example.com', 'http://something.com', 'http://example.com/ws'],
     ['https://example.com', 'http://something.com', 'https://example.com/ws'],
   ];
@@ -69,6 +70,7 @@ describe('createSocketUrl', () => {
     ['?http://127.0.0.1', 'https://something.com', 'http://127.0.0.1/ws'],
     ['?http://0.0.0.0', 'https://something.com', 'https://something.com/ws'],
     ['?http://0.0.0.0', 'http://something.com', 'http://something.com/ws'],
+    ['?http://[::]', 'https://something.com', 'https://something.com/ws'],
     ['?http://example.com', 'http://something.com', 'http://example.com/ws'],
     ['?https://example.com', 'http://something.com', 'https://example.com/ws'],
     [


### PR DESCRIPTION
- [x] This is a **bugfix**
- [ ] This is a **feature**
- [x] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?
Yes.

### Motivation / Use-Case
The location protocol was used on the ipv4 `INADDR_ANY` (0.0.0.0) host but not on the ipv6 one (::).

### Breaking Changes
N/A

### Additional Info
