### PR TITLE
feat(client): respect infrastructureLogging.level on Browser side as well

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -551,8 +551,13 @@ class Server {
         }
       });
 
-      if (this.options.client.logging) {
-        this.sockWrite([connection], 'logging', this.options.client.logging);
+      const clientLogLevel =
+        this.options.client.logging ||
+        (this.compiler.options.infrastructureLogging &&
+          this.compiler.options.infrastructureLogging.level);
+
+      if (clientLogLevel) {
+        this.sockWrite([connection], 'logging', clientLogLevel);
       }
 
       if (this.options.hot === true || this.options.hot === 'only') {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [ ] This is a **bugfix**
- [x] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

<!-- Please note that we won't approve your changes if you don't add tests. -->

### Motivation / Use-Case

I think the existence of both infrastructureLogging.level and client.logger is confusing. So if client.logger is empty but infrastructureLogging.level is set, we should respect infrastructureLogging.level on Browser side as well.

This is my proposal so what do you think? @alexander-akait 
If you agree with this, I'll add tests.

https://github.com/webpack/webpack-dev-server/issues/2887

<!--
  What existing problem does the pull request solve?

  Please explain the motivation or use-case for making this change.
  If this Pull Request addresses an issue, please link to the issue.
-->

### Breaking Changes

no

<!--
  If this PR introduces a breaking change, please describe the impact and a
  potential migration path for existing applications.
-->

### Additional Info
