### PR TITLE
feat: consider file URLs in WebSocket URL creation

### DIFF
--- a/client-src/clients/WebsocketClient.js
+++ b/client-src/clients/WebsocketClient.js
@@ -8,7 +8,14 @@ const BaseClient = require('./BaseClient');
 module.exports = class WebsocketClient extends BaseClient {
   constructor(url) {
     super();
-    this.client = new WebSocket(url.replace(/^http/, 'ws'));
+    this.client = new WebSocket(
+      ((urlToChange) => {
+        let wsUrl = urlToChange;
+        wsUrl = wsUrl.replace(/^http/, 'ws');
+        wsUrl = wsUrl.replace(/^file/, 'ws');
+        return wsUrl;
+      })(url)
+    );
 
     this.client.onerror = (err) => {
       log.error(err);

--- a/client-src/clients/WebsocketClient.js
+++ b/client-src/clients/WebsocketClient.js
@@ -8,14 +8,7 @@ const BaseClient = require('./BaseClient');
 module.exports = class WebsocketClient extends BaseClient {
   constructor(url) {
     super();
-    this.client = new WebSocket(
-      ((urlToChange) => {
-        let wsUrl = urlToChange;
-        wsUrl = wsUrl.replace(/^http/, 'ws');
-        wsUrl = wsUrl.replace(/^file/, 'ws');
-        return wsUrl;
-      })(url)
-    );
+    this.client = new WebSocket(url.replace(/^(?:http|file)/, 'ws'));
 
     this.client.onerror = (err) => {
       log.error(err);


### PR DESCRIPTION
- [ ] This is a **bugfix**
- [x] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

No.

However here's a test repo <https://github.com/kroko/webpacktest-devserver-v4-case03> which shows

* when index.html is opened via file system currently devserver fails
* when index.html is opened via file system proposed changes would  allow for devserver to work (including HMR)

### Motivation / Use-Case

The use case is not easy to explain in short, but
* we face need to run webpack-dev-server on DOOH stands for a _remote validation and changes_
* the client's infrastructure for those devices is set up so that stuff is run from file system, basically everything is done by Chrome and `--allow-file-access-from-files`, ` --disable-web-security`, ` --autoplay-policy=no-user-gesture-required`, etc.
* This addition would allow to run webpack-dev-server when HTML is opened in browser from filesystem (`file://` protocol, that is browser opens i.e. `file:///some/path/to/public/index.html`)
* I do not see any downsides in introducing replacement also for `file://` protocol 😄 

### Breaking Changes

None

### Additional Info
