### PR TITLE
fix: multi compiler mode with proxy

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -200,8 +200,12 @@ class Server {
             return level;
           };
 
+          const configs = getCompilerConfigArray(this.compiler);
+          const configWithDevServer =
+            configs.find((config) => config.devServer) || configs[0];
+
           proxyOptions.logLevel = getLogLevelForProxy(
-            this.compiler.options.infrastructureLogging.level
+            configWithDevServer.infrastructureLogging.level
           );
           proxyOptions.logProvider = () => this.logger;
 

--- a/test/server/proxy-option.test.js
+++ b/test/server/proxy-option.test.js
@@ -474,4 +474,42 @@ describe('proxy option', () => {
       req.delete('/delete').expect(200, 'DELETE method from proxy', done);
     });
   });
+
+  describe.only('should work in multi compiler mode', () => {
+    let server;
+    let req;
+    let closeProxyServers;
+
+    beforeAll((done) => {
+      closeProxyServers = startProxyServers();
+      server = testServer.start(
+        [config, config],
+        {
+          static: {
+            directory: contentBase,
+            watch: false,
+          },
+          proxy: {
+            '*': {
+              context: () => true,
+              target: `http://localhost:${port1}`,
+            },
+          },
+          port: port3,
+        },
+        done
+      );
+      req = request(server.app);
+    });
+
+    afterAll((done) => {
+      testServer.close(() => {
+        closeProxyServers(done);
+      });
+    });
+
+    it('respects a proxy option', (done) => {
+      req.get('/proxy1').expect(200, 'from proxy1', done);
+    });
+  });
 });

--- a/test/server/proxy-option.test.js
+++ b/test/server/proxy-option.test.js
@@ -475,7 +475,7 @@ describe('proxy option', () => {
     });
   });
 
-  describe.only('should work in multi compiler mode', () => {
+  describe('should work in multi compiler mode', () => {
     let server;
     let req;
     let closeProxyServers;


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [x] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [x] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

Yes

### Motivation / Use-Case

fixes #2891

### Breaking Changes

No

### Additional Info

it is dirtly fix, because developer can have two configs with the `devServer` option, but in v3 and v4 we have limitation - only one configuration can have `devServer`, otherwise we use `0` index for configurations, we will fix it after refactor it to plugin (I think v5 or v4 after stable release)