### PR TITLE
fix: open option for CLI without arguments

### DIFF
--- a/bin/cli-flags.js
+++ b/bin/cli-flags.js
@@ -62,7 +62,7 @@ module.exports = {
     },
     {
       name: 'open',
-      type: String,
+      type: [String, Boolean],
       describe:
         'Open the default browser, or optionally specify a browser name',
     },


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [x] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

No, but tests will be added on webpack-cli side

### Motivation / Use-Case

fixes https://github.com/webpack/webpack-cli/issues/2001

### Breaking Changes

No

### Additional Info

No