### PR TITLE
refactor: rename describe property to description for cli-flags

### DIFF
--- a/bin/cli-flags.js
+++ b/bin/cli-flags.js
@@ -12,19 +12,19 @@ module.exports = {
     {
       name: 'host',
       type: String,
-      describe: 'The hostname/ip address the server will bind to',
+      description: 'The hostname/ip address the server will bind to',
       group: CONNECTION_GROUP,
     },
     {
       name: 'port',
       type: Number,
-      describe: 'The port',
+      description: 'The port',
       group: CONNECTION_GROUP,
     },
     {
       name: 'static',
       type: [String, Boolean],
-      describe: 'A directory to serve static content from.',
+      description: 'A directory to serve static content from.',
       group: RESPONSE_GROUP,
       multiple: true,
       negative: true,
@@ -32,30 +32,30 @@ module.exports = {
     {
       name: 'live-reload',
       type: Boolean,
-      describe: 'Enables/Disables live reloading on changing files',
+      description: 'Enables/Disables live reloading on changing files',
       negative: true,
     },
     {
       name: 'https',
       type: Boolean,
       group: SSL_GROUP,
-      describe: 'HTTPS',
+      description: 'HTTPS',
     },
     {
       name: 'http2',
       type: Boolean,
       group: SSL_GROUP,
-      describe: 'HTTP/2, must be used with HTTPS',
+      description: 'HTTP/2, must be used with HTTPS',
     },
     {
       name: 'bonjour',
       type: Boolean,
-      describe: 'Broadcasts the server via ZeroConf networking on start',
+      description: 'Broadcasts the server via ZeroConf networking on start',
     },
     {
       name: 'client-progress',
       type: Boolean,
-      describe: 'Print compilation progress in percentage in the browser',
+      description: 'Print compilation progress in percentage in the browser',
       group: BASIC_GROUP,
       processor(opts) {
         opts.client = opts.client || {};
@@ -66,7 +66,7 @@ module.exports = {
     {
       name: 'hot-only',
       type: Boolean,
-      describe: 'Do not refresh page if HMR fails',
+      description: 'Do not refresh page if HMR fails',
       group: ADVANCED_GROUP,
       processor(opts) {
         opts.hot = 'only';
@@ -76,7 +76,7 @@ module.exports = {
     {
       name: 'setup-exit-signals',
       type: Boolean,
-      describe: 'Close and exit the process on SIGINT and SIGTERM',
+      description: 'Close and exit the process on SIGINT and SIGTERM',
       group: ADVANCED_GROUP,
       defaultValue: true,
       negative: true,
@@ -84,30 +84,30 @@ module.exports = {
     {
       name: 'stdin',
       type: Boolean,
-      describe: 'close when stdin ends',
+      description: 'close when stdin ends',
     },
     {
       name: 'open',
       type: [String, Boolean],
-      describe:
+      description:
         'Open the default browser, or optionally specify a browser name',
     },
     {
       name: 'use-local-ip',
       type: Boolean,
-      describe: 'Open default browser with local IP',
+      description: 'Open default browser with local IP',
     },
     {
       name: 'open-page',
       type: String,
-      describe: 'Open default browser with the specified page',
+      description: 'Open default browser with the specified page',
       multiple: true,
     },
     {
       name: 'client-logging',
       type: String,
       group: DISPLAY_GROUP,
-      describe:
+      description:
         'Log level in the browser (none, error, warn, info, log, verbose)',
       processor(opts) {
         opts.client = opts.client || {};
@@ -118,25 +118,25 @@ module.exports = {
     {
       name: 'history-api-fallback',
       type: Boolean,
-      describe: 'Fallback to /index.html for Single Page Applications.',
+      description: 'Fallback to /index.html for Single Page Applications.',
       group: RESPONSE_GROUP,
     },
     {
       name: 'compress',
       type: Boolean,
-      describe: 'Enable gzip compression',
+      description: 'Enable gzip compression',
       group: RESPONSE_GROUP,
     },
     {
       name: 'public',
       type: String,
-      describe: 'The public hostname/ip address of the server',
+      description: 'The public hostname/ip address of the server',
       group: CONNECTION_GROUP,
     },
     {
       name: 'firewall',
       type: String,
-      describe:
+      description:
         'Enable/disable firewall, or set hosts that are allowed to access the dev server',
       group: CONNECTION_GROUP,
       multiple: true,


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [ ] This is a **bugfix**
- [ ] This is a **feature**
- [x] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?
no
<!-- Please note that we won't approve your changes if you don't add tests. -->

### Motivation / Use-Case
need use `description` instead of `describe` because `webpack` and `webpack-cli` both uses `description` property for options.

This is helpful in the `webpack --help` output. 

https://github.com/webpack/webpack-cli/blob/4dc1a05046aeaf5a17de878a9e595697852bcd32/packages/webpack-cli/lib/webpack-cli.js#L139-L141

<!--
  What existing problem does the pull request solve?

  Please explain the motivation or use-case for making this change.
  If this Pull Request addresses an issue, please link to the issue.
-->

### Breaking Changes
no
<!--
  If this PR introduces a breaking change, please describe the impact and a
  potential migration path for existing applications.
-->

### Additional Info
no