### PR TITLE
fix: support file: and chrome-extension: protocols in client

### DIFF
--- a/client-src/clients/SockJSClient.js
+++ b/client-src/clients/SockJSClient.js
@@ -7,7 +7,8 @@ const BaseClient = require('./BaseClient');
 module.exports = class SockJSClient extends BaseClient {
   constructor(url) {
     super();
-    this.sock = new SockJS(url);
+    const sockUrl = url.replace(/^(?:chrome-extension|file)/i, 'http');
+    this.sock = new SockJS(sockUrl);
 
     this.sock.onerror = (err) => {
       log.error(err);

--- a/client-src/clients/WebsocketClient.js
+++ b/client-src/clients/WebsocketClient.js
@@ -8,7 +8,8 @@ const BaseClient = require('./BaseClient');
 module.exports = class WebsocketClient extends BaseClient {
   constructor(url) {
     super();
-    this.client = new WebSocket(url.replace(/^http/, 'ws'));
+    const wsUrl = url.replace(/^(?:http|chrome-extension|file)/i, 'ws');
+    this.client = new WebSocket(wsUrl);
 
     this.client.onerror = (err) => {
       log.error(err);

--- a/test/client/clients/SockJSClient.test.js
+++ b/test/client/clients/SockJSClient.test.js
@@ -72,6 +72,16 @@ describe('SockJSClient', () => {
         done();
       }, 3000);
     });
+    it('should change the protocol from chrome-extension to http', (done) => {
+      const client = new SockJSClient('chrome-extension://localhost');
+      expect(client.sock.url).toEqual('http://localhost');
+      done();
+    });
+    it('should change the protocol from file to http', (done) => {
+      const client = new SockJSClient('file://localhost');
+      expect(client.sock.url).toEqual('http://localhost');
+      done();
+    });
   });
 
   afterAll((done) => {

--- a/test/client/clients/WebsocketClient.test.js
+++ b/test/client/clients/WebsocketClient.test.js
@@ -65,6 +65,16 @@ describe('WebsocketClient', () => {
         done();
       }, 3000);
     });
+    it('should change the protocol from chrome-extension to http', (done) => {
+      const client = new WebsocketClient('chrome-extension://localhost/');
+      expect(client.client.url).toEqual('ws://localhost/');
+      done();
+    });
+    it('should change the protocol from file to http', (done) => {
+      const client = new WebsocketClient('file://localhost/');
+      expect(client.client.url).toEqual('ws://localhost/');
+      done();
+    });
   });
 
   afterAll((done) => {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [x] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

<!-- Please note that we won't approve your changes if you don't add tests. -->
Yes, I added tests to check if the protocol was changed, it is poking at variables inside of WebSocket and SockJS though, this is probably not the most stable way to do this, but I am not sure how to mock those or if that is even necessary.

### Motivation / Use-Case

<!--
  What existing problem does the pull request solve?

  Please explain the motivation or use-case for making this change.
  If this Pull Request addresses an issue, please link to the issue.
-->
When using node-webkit, or electron, the protocol can be `file:` or `chrome-extension:`, causing the websocket or sockjs to try to connect to an incorrect url, for example: `file://localhost:8080/ws` or `chrome-extension://localhost:8080/ws`.

This PR changes it to the correct behaviour.

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  potential migration path for existing applications.
-->

This PR should not be a breaking change.

### Additional Info

I just noticed I also replace `https` with `ws`, this should probably be an extra case where it is replaced with `wss`.
**EDIT: I removed the https case**
