### PR TITLE
fix: options.overlay forget assign to options.clientOverlay

### DIFF
--- a/lib/utils/normalizeOptions.js
+++ b/lib/utils/normalizeOptions.js
@@ -73,6 +73,9 @@ function normalizeOptions(compiler, options) {
   options.liveReload =
     typeof options.liveReload !== 'undefined' ? options.liveReload : true;
 
+  options.clientOverlay =
+    typeof options.overlay !== 'undefined' ? options.overlay : false;
+
   // normalize transportMode option
   if (typeof options.transportMode === 'undefined') {
     options.transportMode = {


### PR DESCRIPTION
<!--
 

  Please place an x, no spaces, in all [ ] that apply
-->

- [x] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

<!-- Please note that we won't approve your changes if you don't add tests. -->

### Motivation / Use-Case

<!--
  What existing problem does the pull request solve?

  Please explain the motivation or use-case for making this change.
  If this Pull Request addresses an issue, please link to the issue.
-->

overlay option is not work on V4. I spent some time debugging and find the reason that overlay option is not assign clientOverlay

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  potential migration path for existing applications.
-->

no Breaking Changes

### Additional Info
