### PR TITLE
Add support of injectHot and injectClient on specific chunks

### DIFF
--- a/lib/options.json
+++ b/lib/options.json
@@ -161,6 +161,13 @@
           "type": "boolean"
         },
         {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1
+        },
+        {
           "instanceof": "Function"
         }
       ]
@@ -169,6 +176,13 @@
       "anyOf": [
         {
           "type": "boolean"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1
         },
         {
           "instanceof": "Function"
@@ -451,8 +465,8 @@
       "http2": "should be {Boolean} (https://webpack.js.org/configuration/dev-server/#devserverhttp2)",
       "https": "should be {Object|Boolean} (https://webpack.js.org/configuration/dev-server/#devserverhttps)",
       "index": "should be {String} (https://webpack.js.org/configuration/dev-server/#devserverindex)",
-      "injectClient": "should be {Boolean|Function} (https://webpack.js.org/configuration/dev-server/#devserverinjectclient)",
-      "injectHot": "should be {Boolean|Function} (https://webpack.js.org/configuration/dev-server/#devserverinjecthot)",
+      "injectClient": "should be {Boolean|String[]|Function} (https://webpack.js.org/configuration/dev-server/#devserverinjectclient)",
+      "injectHot": "should be {Boolean|String[]|Function} (https://webpack.js.org/configuration/dev-server/#devserverinjecthot)",
       "inline": "should be {Boolean} (https://webpack.js.org/configuration/dev-server/#devserverinline)",
       "key": "should be {String|Buffer}",
       "lazy": "should be {Boolean} (https://webpack.js.org/configuration/dev-server/#devserverlazy-)",

--- a/lib/utils/addEntries.js
+++ b/lib/utils/addEntries.js
@@ -9,6 +9,13 @@ const createDomain = require('./createDomain');
  */
 
 /**
+ * Additional entry to add to specific chunk
+ * @typedef {Object} AdditionalChunkEntry
+ * @property {Entry} entry
+ * @property {string[]} [chunks]
+ */
+
+/**
  * Add entries Method
  * @param {?Object} config - Webpack config
  * @param {?Object} options - Dev-Server options
@@ -51,7 +58,7 @@ function addEntries(config, options, server) {
     /**
      * prependEntry Method
      * @param {Entry} originalEntry
-     * @param {Entry} additionalEntries
+     * @param {AdditionalChunkEntry[]} additionalEntries
      * @returns {Entry}
      */
     const prependEntry = (originalEntry, additionalEntries) => {
@@ -68,13 +75,17 @@ function addEntries(config, options, server) {
 
         Object.keys(originalEntry).forEach((key) => {
           // entry[key] should be a string here
+          const chunkAdditionalEntries = additionalEntries.filter((additionalEntry) => {
+            return (!additionalEntry.chunks || additionalEntry.chunks.includes(key));
+          })
+
           const entryDescription = originalEntry[key];
           if (typeof entryDescription === 'object' && entryDescription.import) {
             clone[key] = Object.assign({}, entryDescription, {
-              import: prependEntry(entryDescription.import, additionalEntries),
+              import: prependEntry(entryDescription.import, chunkAdditionalEntries),
             });
           } else {
-            clone[key] = prependEntry(entryDescription, additionalEntries);
+            clone[key] = prependEntry(entryDescription, chunkAdditionalEntries);
           }
         });
 
@@ -84,13 +95,15 @@ function addEntries(config, options, server) {
       // in this case, entry is a string or an array.
       // make sure that we do not add duplicates.
       /** @type {Entry} */
-      const entriesClone = additionalEntries.slice(0);
+      const newEntries = additionalEntries.map((additionalEntry) => {
+        return additionalEntry.entry;
+      });
       [].concat(originalEntry).forEach((newEntry) => {
-        if (!entriesClone.includes(newEntry)) {
-          entriesClone.push(newEntry);
+        if (!newEntries.includes(newEntry)) {
+          newEntries.push(newEntry);
         }
       });
-      return entriesClone;
+      return newEntries;
     };
 
     /**
@@ -98,19 +111,20 @@ function addEntries(config, options, server) {
      * Description of the option for checkInject method
      * @typedef {Function} checkInjectOptionsParam
      * @param {Object} _config - compilerConfig
-     * @return {Boolean}
+     * @return {Boolean | string[]}
      */
 
     /**
      *
-     * @param {Boolean | checkInjectOptionsParam} option - inject(Hot|Client) it is Boolean | fn => Boolean
+     * @param {Boolean | string[] | checkInjectOptionsParam} option - inject(Hot|Client) it is Boolean | fn => Boolean
      * @param {Object} _config
      * @param {Boolean} defaultValue
-     * @return {Boolean}
+     * @return {Boolean | string[]}
      */
     // eslint-disable-next-line no-shadow
     const checkInject = (option, _config, defaultValue) => {
       if (typeof option === 'boolean') return option;
+      if (Array.isArray(option)) return option;
       if (typeof option === 'function') return option(_config);
       return defaultValue;
     };
@@ -126,17 +140,25 @@ function addEntries(config, options, server) {
         undefined, // eslint-disable-line
         null,
       ].includes(config.target);
-      /** @type {Entry} */
-      const additionalEntries = checkInject(
-        options.injectClient,
-        config,
-        webTarget
-      )
-        ? [clientEntry]
-        : [];
+      /** @type {AdditionalChunkEntry[]} */
+      const additionalEntries = []
 
-      if (hotEntry && checkInject(options.injectHot, config, true)) {
-        additionalEntries.push(hotEntry);
+      const checkInjectClientResult = checkInject(options.injectClient, config, webTarget);
+      if (checkInjectClientResult) {
+        additionalEntries.push({
+          entry: clientEntry,
+          chunks: Array.isArray(checkInjectClientResult) ? checkInjectClientResult : null
+        });
+      }
+
+      if (hotEntry) {
+        const checkInjectHotResult = checkInject(options.injectHot, config, true);
+        if (checkInjectHotResult) {
+          additionalEntries.push({
+            entry: hotEntry,
+            chunks: Array.isArray(checkInjectHotResult) ? checkInjectHotResult : null
+          });
+        }
       }
 
       config.entry = prependEntry(config.entry || './src', additionalEntries);

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -208,11 +208,11 @@ describe('options', () => {
         failure: [false],
       },
       injectClient: {
-        success: [true, () => {}],
+        success: [true, ['a'], () => {}],
         failure: [''],
       },
       injectHot: {
-        success: [true, () => {}],
+        success: [true, ['a'], () => {}],
         failure: [''],
       },
       inline: {

--- a/test/server/utils/addEntries.test.js
+++ b/test/server/utils/addEntries.test.js
@@ -366,6 +366,42 @@ describe('addEntries util', () => {
     });
   });
 
+  it('should allows selecting chunks to inline the client into', () => {
+    const webpackOptions = [
+      Object.assign({}, config, {
+        entry: {
+          chunk1: './foo.js',
+          chunk2: './foo.js',
+          chunk3: './foo.js'
+        }
+      })
+    ];
+
+    const devServerOptions = {
+      injectClient: ['chunk1', 'chunk3']
+    };
+
+    addEntries(webpackOptions, devServerOptions);
+
+    // eslint-disable-next-line no-shadow
+    webpackOptions.forEach((webpackOptions) => {
+      expect(Object.keys(webpackOptions.entry).length).toEqual(3);
+      expect(webpackOptions.entry.chunk1.length).toEqual(2);
+      expect(webpackOptions.entry.chunk2.length).toEqual(1);
+      expect(webpackOptions.entry.chunk3.length).toEqual(2);
+
+      expect(
+        normalize(webpackOptions.entry.chunk1[0]).indexOf('client/index.js?') !== -1
+      ).toBeTruthy();
+      expect(normalize(webpackOptions.entry.chunk2[0])).toEqual(
+        './foo.js'
+      );
+      expect(
+        normalize(webpackOptions.entry.chunk3[0]).indexOf('client/index.js?') !== -1
+      ).toBeTruthy();
+    });
+  });
+
   it('should prepends the hot runtime to all targets by default (when hot)', () => {
     const webpackOptions = [
       Object.assign({ target: 'web' }, config),


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [ ] This is a **bugfix**
- [x] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?
yes

<!-- Please note that we won't approve your changes if you don't add tests. -->

### Motivation / Use-Case
In case of application with multiple iframes, only the top level frame has to listen socket for refresh
This PR add the support of chunk target in the injectClient and injectHot options. You are able to limit the client injection only in specific chunks   

<!--
  What existing problem does the pull request solve?

  Please explain the motivation or use-case for making this change.
  If this Pull Request addresses an issue, please link to the issue.
-->
Resolving of #2969

### Breaking Changes
none
<!--
  If this PR introduces a breaking change, please describe the impact and a
  potential migration path for existing applications.
-->

### Additional Info
