### PR TITLE
docs: fixed casing

### DIFF
--- a/bin/cli-flags.js
+++ b/bin/cli-flags.js
@@ -68,7 +68,7 @@ module.exports = {
     {
       name: 'stdin',
       type: Boolean,
-      description: 'close when stdin ends',
+      description: 'Close when stdin ends',
     },
     {
       name: 'open',


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [ ] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [X] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

N/A

### Motivation / Use-Case

The existing output of `webpack serve --help` lists descriptions beginning in a capital letter. The description for `stdin` does _not_ begin with a capital letter.

### Breaking Changes

N/A

### Additional Info

N/A