### PR TITLE
test(e2e): fix DevServer test

### DIFF
--- a/test/e2e/DevServer.test.js
+++ b/test/e2e/DevServer.test.js
@@ -49,9 +49,6 @@ describe('DevServer', () => {
       './test/fixtures/entry-as-descriptor/webpack.config'
     )
       .then((output) => {
-        if (!output.stdout.trim()) {
-          console.log(output);
-        }
         expect(output.exitCode).toEqual(0);
         expect(output.stdout).toContain('foo.js');
         done();

--- a/test/e2e/DevServer.test.js
+++ b/test/e2e/DevServer.test.js
@@ -7,7 +7,7 @@ describe('DevServer', () => {
   const webpack5Test = isWebpack5 ? it : it.skip;
 
   it('should add devServer entry points to a single entry point', (done) => {
-    testBin('--config ./test/fixtures/dev-server/default-config.js')
+    testBin(null, './test/fixtures/dev-server/default-config.js')
       .then((output) => {
         expect(output.exitCode).toEqual(0);
         expect(output.stdout).toContain('client/default/index.js?');
@@ -19,9 +19,7 @@ describe('DevServer', () => {
   webpack5Test(
     'should add devServer entry points to a multi entry point object',
     (done) => {
-      testBin(
-        '--config ./test/fixtures/dev-server/multi-entry.js --stats=verbose'
-      )
+      testBin('--stats=verbose', './test/fixtures/dev-server/multi-entry.js')
         .then((output) => {
           expect(output.exitCode).toEqual(0);
           expect(output.stdout).toContain('client/default/index.js?');
@@ -35,7 +33,7 @@ describe('DevServer', () => {
   webpack5Test(
     'should add devServer entry points to an empty entry object',
     (done) => {
-      testBin('--config ./test/fixtures/dev-server/empty-entry.js')
+      testBin(null, './test/fixtures/dev-server/empty-entry.js')
         .then((output) => {
           expect(output.exitCode).toEqual(0);
           expect(output.stdout).toContain('client/default/index.js?');
@@ -47,9 +45,13 @@ describe('DevServer', () => {
 
   webpack5Test('should supports entry as descriptor', (done) => {
     testBin(
-      '--config ./test/fixtures/entry-as-descriptor/webpack.config --stats detailed'
+      '--stats detailed',
+      './test/fixtures/entry-as-descriptor/webpack.config'
     )
       .then((output) => {
+        if (!output.stdout.trim()) {
+          console.log(output);
+        }
         expect(output.exitCode).toEqual(0);
         expect(output.stdout).toContain('foo.js');
         done();
@@ -58,9 +60,7 @@ describe('DevServer', () => {
   });
 
   it('should only prepends devServer entry points to "web" target', (done) => {
-    testBin(
-      '--config ./test/fixtures/dev-server/default-config.js --target web'
-    )
+    testBin('--target web', './test/fixtures/dev-server/default-config.js')
       .then((output) => {
         expect(output.exitCode).toEqual(0);
         expect(output.stdout).toContain('client/default/index.js?');
@@ -71,9 +71,7 @@ describe('DevServer', () => {
   });
 
   it('should not prepend devServer entry points to "node" target', (done) => {
-    testBin(
-      '--config ./test/fixtures/dev-server/default-config.js --target node'
-    )
+    testBin('--target node', './test/fixtures/dev-server/default-config.js')
       .then((output) => {
         expect(output.exitCode).toEqual(0);
         expect(output.stdout).not.toContain('client/default/index.js?');
@@ -85,7 +83,8 @@ describe('DevServer', () => {
 
   it('should prepends the hot runtime to "node" target as well', (done) => {
     testBin(
-      '--config ./test/fixtures/dev-server/default-config.js --target node --hot'
+      '--target node --hot',
+      './test/fixtures/dev-server/default-config.js'
     )
       .then((output) => {
         expect(output.exitCode).toEqual(0);
@@ -96,7 +95,7 @@ describe('DevServer', () => {
   });
 
   it('does not use client.path when default', (done) => {
-    testBin('--config ./test/fixtures/dev-server/client-default-path-config.js')
+    testBin(null, './test/fixtures/dev-server/client-default-path-config.js')
       .then((output) => {
         expect(output.exitCode).toEqual(0);
         expect(output.stdout).not.toContain('&path=/ws');
@@ -106,7 +105,7 @@ describe('DevServer', () => {
   });
 
   it('should use client.path when custom', (done) => {
-    testBin('--config ./test/fixtures/dev-server/client-custom-path-config.js')
+    testBin(null, './test/fixtures/dev-server/client-custom-path-config.js')
       .then((output) => {
         expect(output.exitCode).toEqual(0);
         expect(output.stdout).toContain('&path=/custom/path');
@@ -118,7 +117,7 @@ describe('DevServer', () => {
   webpack5Test(
     'should prepend devServer entry points depending on targetProperties',
     (done) => {
-      testBin('--config ./test/fixtures/dev-server/target-config.js')
+      testBin(null, './test/fixtures/dev-server/target-config.js')
         .then((output) => {
           expect(output.exitCode).toEqual(0);
           expect(output.stdout).toContain('client/default/index.js');

--- a/test/fixtures/cli/webpack.config.js
+++ b/test/fixtures/cli/webpack.config.js
@@ -1,21 +1,11 @@
 'use strict';
 
+const ExitOnDonePlugin = require('../../helpers/ExitOnDonePlugin');
+
 module.exports = {
   mode: 'development',
   stats: 'detailed',
   context: __dirname,
   entry: './foo.js',
-  plugins: [
-    {
-      apply(compiler) {
-        compiler.hooks.done.tap('webpack-dev-server', (stats) => {
-          let exitCode = 0;
-          if (stats.hasErrors()) {
-            exitCode = 1;
-          }
-          setTimeout(() => process.exit(exitCode));
-        });
-      },
-    },
-  ],
+  plugins: [ExitOnDonePlugin],
 };

--- a/test/fixtures/dev-server/client-custom-path-config.js
+++ b/test/fixtures/dev-server/client-custom-path-config.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { resolve } = require('path');
+const ExitOnDonePlugin = require('../../helpers/ExitOnDonePlugin');
 
 module.exports = {
   mode: 'development',
@@ -15,4 +16,5 @@ module.exports = {
       client: 'sockjs',
     },
   },
+  plugins: [ExitOnDonePlugin],
 };

--- a/test/fixtures/dev-server/client-default-path-config.js
+++ b/test/fixtures/dev-server/client-default-path-config.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { resolve } = require('path');
+const ExitOnDonePlugin = require('../../helpers/ExitOnDonePlugin');
 
 module.exports = {
   mode: 'development',
@@ -15,4 +16,5 @@ module.exports = {
       client: 'sockjs',
     },
   },
+  plugins: [ExitOnDonePlugin],
 };

--- a/test/fixtures/dev-server/default-config.js
+++ b/test/fixtures/dev-server/default-config.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { resolve } = require('path');
+const ExitOnDonePlugin = require('../../helpers/ExitOnDonePlugin');
 
 module.exports = {
   mode: 'development',
@@ -15,4 +16,5 @@ module.exports = {
       client: 'sockjs',
     },
   },
+  plugins: [ExitOnDonePlugin],
 };

--- a/test/fixtures/dev-server/empty-entry.js
+++ b/test/fixtures/dev-server/empty-entry.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const ExitOnDonePlugin = require('../../helpers/ExitOnDonePlugin');
+
 module.exports = {
   mode: 'development',
   stats: 'detailed',
@@ -10,4 +12,5 @@ module.exports = {
       client: 'sockjs',
     },
   },
+  plugins: [ExitOnDonePlugin],
 };

--- a/test/fixtures/dev-server/empty-entry.js
+++ b/test/fixtures/dev-server/empty-entry.js
@@ -4,7 +4,7 @@ const ExitOnDonePlugin = require('../../helpers/ExitOnDonePlugin');
 
 module.exports = {
   mode: 'development',
-  stats: 'detailed',
+  stats: { orphanModules: true, preset: 'detailed' },
   entry: {},
   devServer: {
     transportMode: {

--- a/test/fixtures/dev-server/multi-entry.js
+++ b/test/fixtures/dev-server/multi-entry.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { resolve } = require('path');
+const ExitOnDonePlugin = require('../../helpers/ExitOnDonePlugin');
 
 module.exports = {
   mode: 'development',
@@ -16,4 +17,5 @@ module.exports = {
       client: 'sockjs',
     },
   },
+  plugins: [ExitOnDonePlugin],
 };

--- a/test/fixtures/dev-server/target-config.js
+++ b/test/fixtures/dev-server/target-config.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { resolve } = require('path');
+const ExitOnDonePlugin = require('../../helpers/ExitOnDonePlugin');
 
 module.exports = {
   mode: 'development',
@@ -21,4 +22,5 @@ module.exports = {
       client: 'sockjs',
     },
   },
+  plugins: [ExitOnDonePlugin],
 };

--- a/test/fixtures/entry-as-descriptor/webpack.config.js
+++ b/test/fixtures/entry-as-descriptor/webpack.config.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const ExitOnDonePlugin = require('../../helpers/ExitOnDonePlugin');
+
 module.exports = {
   mode: 'development',
   context: __dirname,
@@ -8,19 +10,7 @@ module.exports = {
       import: './foo.js',
     },
   },
-  plugins: [
-    {
-      apply(compiler) {
-        compiler.hooks.done.tap('webpack-dev-server', (stats) => {
-          let exitCode = 0;
-          if (stats.hasErrors()) {
-            exitCode = 1;
-          }
-          setTimeout(() => process.exit(exitCode));
-        });
-      },
-    },
-  ],
+  plugins: [ExitOnDonePlugin],
   infrastructureLogging: {
     level: 'warn',
   },

--- a/test/helpers/ExitOnDonePlugin.js
+++ b/test/helpers/ExitOnDonePlugin.js
@@ -1,0 +1,13 @@
+'use strict';
+
+module.exports = {
+  apply(compiler) {
+    compiler.hooks.done.tap('webpack-dev-server', (stats) => {
+      let exitCode = 0;
+      if (stats.hasErrors()) {
+        exitCode = 1;
+      }
+      setTimeout(() => process.exit(exitCode));
+    });
+  },
+};


### PR DESCRIPTION
- [ ] This is a **bugfix**
- [ ] This is a **feature**
- [x] This is a **code refactor**
- [x] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

N/A

### Motivation / Use-Case

`testBin` sets the config path if the second argument is not provided: https://github.com/webpack/webpack-dev-server/blob/1dde6622bf21007b5b2af44790d14481a064027d/test/helpers/test-bin.js#L15-L20

If the config path is set via the first argument (`testArgs`), it'll result in multiple config paths, leading to flaky tests and invalid results, e.g.:
```
  ● DevServer › should supports entry as descriptor

    expect(received).toContain(expected) // indexOf

    Expected substring: "foo.js"
    Received string:    ""

      52 |       .then((output) => {
      53 |         expect(output.exitCode).toEqual(0);
    > 54 |         expect(output.stdout).toContain('foo.js');
         |                               ^
      55 |         done();
      56 |       })
      57 |       .catch(done);

      at test/e2e/DevServer.test.js:54:31
          at runMicrotasks (<anonymous>)
```

### Breaking Changes

N/A

### Additional Info
