### PR TITLE
fix: syncronize cli-flags for `webpack-cli < v4.6.0`

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,9 @@ Options:
   --http2                    Use HTTP/2, must be used with HTTPS.
   --no-http2                 Do not use HTTP/2.
   --bonjour                  Broadcasts the server via ZeroConf networking on start.
-  --no-bonjour               Negative 'bonjour' option.
+  --no-bonjour               Do not broadcast the server via ZeroConf networking on start.
   --client-progress          Print compilation progress in percentage in the browser.
+  --no-client-progress       Do not print compilation progress in percentage in the browser.
   --client-overlay           Show a full-screen overlay in the browser when there are compiler errors or warnings.
   --no-client-overlay        Do not show a full-screen overlay in the browser when there are compiler errors or warnings.
   --setup-exit-signals       Close and exit the process on SIGINT and SIGTERM.

--- a/README.md
+++ b/README.md
@@ -132,8 +132,10 @@ binaries without having to be concerned about their full paths. Simply define a
 script as such:
 
 ```json
-"scripts": {
-  "start:dev": "webpack serve"
+{
+  "scripts": {
+    "serve": "webpack serve"
+  }
 }
 ```
 

--- a/bin/cli-flags.js
+++ b/bin/cli-flags.js
@@ -82,6 +82,9 @@ module.exports = {
         },
       ],
       description: 'Broadcasts the server via ZeroConf networking on start.',
+      negatedDescription:
+        'Do not broadcast the server via ZeroConf networking on start.',
+      negative: true,
     },
     {
       name: 'client-progress',
@@ -92,6 +95,9 @@ module.exports = {
         },
       ],
       description: 'Print compilation progress in percentage in the browser.',
+      negatedDescription:
+        'Do not print compilation progress in percentage in the browser.',
+      negative: true,
       processor(opts) {
         opts.client = opts.client || {};
         opts.client.progress = opts.clientProgress;
@@ -110,6 +116,7 @@ module.exports = {
         'Show a full-screen overlay in the browser when there are compiler errors or warnings.',
       negatedDescription:
         'Do not show a full-screen overlay in the browser when there are compiler errors or warnings.',
+      negative: true,
       processor(opts) {
         opts.client = opts.client || {};
         opts.client.overlay = opts.clientOverlay;
@@ -144,6 +151,7 @@ module.exports = {
       ],
       description: 'Open the default browser.',
       negatedDescription: 'Do not open the default browser.',
+      negative: true,
     },
     {
       name: 'open-app',
@@ -179,6 +187,7 @@ module.exports = {
       },
       negatedDescription: 'Do not open specified route in browser.',
       multiple: true,
+      negative: true,
     },
     {
       name: 'client-logging',

--- a/test/cli/__snapshots__/cli.test.js.snap.webpack4
+++ b/test/cli/__snapshots__/cli.test.js.snap.webpack4
@@ -115,10 +115,12 @@ Options:
   --no-http2                 Do not use HTTP/2.
   --bonjour                  Broadcasts the server via ZeroConf networking on
                              start.
-  --no-bonjour               Negative 'bonjour' option.
+  --no-bonjour               Do not broadcast the server via ZeroConf
+                             networking on start.
   --client-progress          Print compilation progress in percentage in the
                              browser.
-  --no-client-progress       Negative 'client-progress' option.
+  --no-client-progress       Do not print compilation progress in percentage in
+                             the browser.
   --client-overlay           Show a full-screen overlay in the browser when
                              there are compiler errors or warnings.
   --no-client-overlay        Do not show a full-screen overlay in the browser

--- a/test/cli/__snapshots__/cli.test.js.snap.webpack5
+++ b/test/cli/__snapshots__/cli.test.js.snap.webpack5
@@ -117,10 +117,12 @@ Options:
   --no-http2                 Do not use HTTP/2.
   --bonjour                  Broadcasts the server via ZeroConf networking on
                              start.
-  --no-bonjour               Negative 'bonjour' option.
+  --no-bonjour               Do not broadcast the server via ZeroConf
+                             networking on start.
   --client-progress          Print compilation progress in percentage in the
                              browser.
-  --no-client-progress       Negative 'client-progress' option.
+  --no-client-progress       Do not print compilation progress in percentage in
+                             the browser.
   --client-overlay           Show a full-screen overlay in the browser when
                              there are compiler errors or warnings.
   --no-client-overlay        Do not show a full-screen overlay in the browser


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [x] This is a **bugfix**
- [ ] This is a **feature**
- [x] This is a **code refactor**
- [ ] This is a **test update**
- [x] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?
No
<!-- Please note that we won't approve your changes if you don't add tests. -->

### Motivation / Use-Case

We have some additional flags currently present only with webpack-cli v4.6.0 -

`--no-bonjour`
`--no-client-progress`
`--no-open`
`--no-open-target`

<!--
  What existing problem does the pull request solve?

  Please explain the motivation or use-case for making this change.
  If this Pull Request addresses an issue, please link to the issue.
-->

### Breaking Changes
None
<!--
  If this PR introduces a breaking change, please describe the impact and a
  potential migration path for existing applications.
-->

### Additional Info
No