### PR TITLE
fix: respect client.needHotEntry and client.needClientEntry

### DIFF
--- a/lib/utils/DevServerPlugin.js
+++ b/lib/utils/DevServerPlugin.js
@@ -158,14 +158,21 @@ class DevServerPlugin {
 
     /** @type {Entry} */
     const additionalEntries = checkInject(
-      options.injectClient,
+      options.client ? options.client.needClientEntry : null,
       compilerOptions,
       isWebTarget
     )
       ? [clientEntry]
       : [];
 
-    if (hotEntry && checkInject(options.injectHot, compilerOptions, true)) {
+    if (
+      hotEntry &&
+      checkInject(
+        options.client ? options.client.needHotEntry : null,
+        compilerOptions,
+        true
+      )
+    ) {
       additionalEntries.push(hotEntry);
     }
 

--- a/test/server/clientOptions-option.test.js
+++ b/test/server/clientOptions-option.test.js
@@ -69,4 +69,46 @@ describe('client option', () => {
       req.get(path).expect(200, done);
     });
   });
+
+  describe('configure client entry', () => {
+    it('disables client entry', (done) => {
+      server = testServer.start(
+        config,
+        {
+          client: {
+            needClientEntry: false,
+          },
+          port,
+        },
+        () => {
+          request(server.app)
+            .get('/main.js')
+            .then((res) => {
+              expect(res.text).not.toMatch(/client\/index\.js/);
+            })
+            .then(done, done);
+        }
+      );
+    });
+
+    it('disables hot entry', (done) => {
+      server = testServer.start(
+        config,
+        {
+          client: {
+            needHotEntry: false,
+          },
+          port,
+        },
+        () => {
+          request(server.app)
+            .get('/main.js')
+            .then((res) => {
+              expect(res.text).not.toMatch(/webpack\/hot\/dev-server\.js/);
+            })
+            .then(done, done);
+        }
+      );
+    });
+  });
 });


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [x] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

Yes

<!-- Please note that we won't approve your changes if you don't add tests. -->

### Motivation / Use-Case

In version `4.0.0-beta.2` it still uses old option `injectHot` and `injectClient` to determine whether to inject dev server client, this PR corrects that by respecting new option `client.needHotEntry` and `client.needClientEntry`. 

<!--
  What existing problem does the pull request solve?

  Please explain the motivation or use-case for making this change.
  If this Pull Request addresses an issue, please link to the issue.
-->

### Breaking Changes

No

<!--
  If this PR introduces a breaking change, please describe the impact and a
  potential migration path for existing applications.
-->

### Additional Info

N/A
