### PR TITLE
fix: overlay with warnings

### DIFF
--- a/client-src/overlay.js
+++ b/client-src/overlay.js
@@ -27,6 +27,7 @@ ansiHTML.setColors(colors);
 
 function createOverlayIframe(onIframeLoad) {
   const iframe = document.createElement('iframe');
+
   iframe.id = 'webpack-dev-server-client-overlay';
   iframe.src = 'about:blank';
   iframe.style.position = 'fixed';
@@ -39,11 +40,13 @@ function createOverlayIframe(onIframeLoad) {
   iframe.style.border = 'none';
   iframe.style.zIndex = 9999999999;
   iframe.onload = onIframeLoad;
+
   return iframe;
 }
 
 function addOverlayDivTo(iframe) {
   const div = iframe.contentDocument.createElement('div');
+
   div.id = 'webpack-dev-server-client-overlay-div';
   div.style.position = 'fixed';
   div.style.boxSizing = 'border-box';
@@ -61,7 +64,9 @@ function addOverlayDivTo(iframe) {
   div.style.lineHeight = '1.2';
   div.style.whiteSpace = 'pre-wrap';
   div.style.overflow = 'auto';
+
   iframe.contentDocument.body.appendChild(div);
+
   return div;
 }
 
@@ -103,6 +108,7 @@ function clear() {
 
   // Clean up and reset internal state.
   document.body.removeChild(overlayIframe);
+
   overlayDiv = null;
   overlayIframe = null;
   lastOnOverlayDivReady = null;

--- a/client-src/socket.js
+++ b/client-src/socket.js
@@ -5,8 +5,7 @@
   camelcase
 */
 
-// this WebsocketClient is here as a default fallback,
-//  in case the client is not injected
+// this WebsocketClient is here as a default fallback, in case the client is not injected
 const Client =
   typeof __webpack_dev_server_client__ !== 'undefined'
     ? __webpack_dev_server_client__
@@ -47,9 +46,10 @@ const socket = function initSocket(url, handlers) {
   });
 
   client.onMessage((data) => {
-    const msg = JSON.parse(data);
-    if (handlers[msg.type]) {
-      handlers[msg.type](msg.data);
+    const message = JSON.parse(data);
+
+    if (handlers[message.type]) {
+      handlers[message.type](message.data);
     }
   });
 };

--- a/client-src/utils/sendMessage.js
+++ b/client-src/utils/sendMessage.js
@@ -9,13 +9,7 @@ function sendMsg(type, data) {
     (typeof WorkerGlobalScope === 'undefined' ||
       !(self instanceof WorkerGlobalScope))
   ) {
-    self.postMessage(
-      {
-        type: `webpack${type}`,
-        data,
-      },
-      '*'
-    );
+    self.postMessage({ type: `webpack${type}`, data }, '*');
   }
 }
 

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -986,17 +986,20 @@ class Server {
     }
   }
 
-  // send stats to a socket or multiple sockets
+  // Send stats to a socket or multiple sockets
   sendStats(sockets, stats, force) {
     const shouldEmit =
       !force &&
       stats &&
       (!stats.errors || stats.errors.length === 0) &&
+      (!stats.warnings || stats.warnings.length === 0) &&
       stats.assets &&
       stats.assets.every((asset) => !asset.emitted);
 
     if (shouldEmit) {
-      return this.sockWrite(sockets, 'still-ok');
+      this.sockWrite(sockets, 'still-ok');
+
+      return;
     }
 
     this.sockWrite(sockets, 'hash', stats.hash);

--- a/test/client/__snapshots__/index.test.js.snap.webpack4
+++ b/test/client/__snapshots__/index.test.js.snap.webpack4
@@ -49,9 +49,8 @@ Object {
   "initial": false,
   "liveReload": false,
   "logging": "info",
-  "useErrorOverlay": false,
-  "useProgress": false,
-  "useWarningOverlay": false,
+  "overlay": false,
+  "progress": false,
 }
 `;
 

--- a/test/client/__snapshots__/index.test.js.snap.webpack5
+++ b/test/client/__snapshots__/index.test.js.snap.webpack5
@@ -49,9 +49,8 @@ Object {
   "initial": false,
   "liveReload": false,
   "logging": "info",
-  "useErrorOverlay": false,
-  "useProgress": false,
-  "useWarningOverlay": false,
+  "overlay": false,
+  "progress": false,
 }
 `;
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [x] This is a **bugfix**
- [ ] This is a **feature**
- [x] This is a **code refactor**
- [x] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

bug, existing

### Motivation / Use-Case

When we set `overlay: true` we mean `overlay: { warnings: true, errors: true }`, but current logic is not show warnings in overlay by defualt, also we have bug when we show warning and invalidate code warnings just hide

### Breaking Changes

In theory no, because `overlay: true` should show warnings and errors

### Additional Info

No