### PR TITLE
feat: add more `https` option related cli flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,13 @@ Options:
   --no-live-reload                 Disables live reloading on changing files.
   --https                          Use HTTPS protocol.
   --no-https                       Do not use HTTPS protocol.
+  --https-passphrase <value>       Passphrase for a pfx file.
+  --https-key <value>              Path to an SSL key.
+  --https-pfx <value>              Path to an SSL pfx file.
+  --https-cert <value>             Path to an SSL certificate.
+  --https-cacert <value>           Path to an SSL CA certificate.
+  --https-request-cert             Request for an SSL certificate.
+  --no-https-request-cert          Do not request for an SSL certificate.
   --http2                          Use HTTP/2, must be used with HTTPS.
   --no-http2                       Do not use HTTP/2.
   --bonjour                        Broadcasts the server via ZeroConf networking on start.

--- a/bin/cli-flags.js
+++ b/bin/cli-flags.js
@@ -189,6 +189,36 @@ module.exports = {
       },
     },
     {
+      name: 'https-cacert',
+      type: String,
+      configs: [
+        {
+          type: 'string',
+        },
+      ],
+      description: 'Path to an SSL CA certificate.',
+      processor(opts) {
+        opts.https = opts.https || {};
+        opts.https.cacert = opts.httpsCacert;
+        delete opts.httpsCacert;
+      },
+    },
+    {
+      name: 'https-request-cert',
+      type: Boolean,
+      configs: [
+        {
+          type: 'boolean',
+        },
+      ],
+      description: 'Request for an SSL certificate.',
+      processor(opts) {
+        opts.https = opts.https || {};
+        opts.https.requestCert = opts.httpsRequestCert;
+        delete opts.httpsRequestCert;
+      },
+    },
+    {
       name: 'http2',
       type: Boolean,
       configs: [

--- a/bin/cli-flags.js
+++ b/bin/cli-flags.js
@@ -212,6 +212,7 @@ module.exports = {
         },
       ],
       description: 'Request for an SSL certificate.',
+      negatedDescription: 'Do not request for an SSL certificate.',
       processor(opts) {
         opts.https = opts.https || {};
         opts.https.requestCert = opts.httpsRequestCert;

--- a/bin/cli-flags.js
+++ b/bin/cli-flags.js
@@ -139,8 +139,8 @@ module.exports = {
       description: 'Passphrase for a pfx file.',
       processor(opts) {
         opts.https = opts.https || {};
-        opts.https.key = opts.httpsKey;
-        delete opts.httpsKey;
+        opts.https.passphrase = opts.httpsPassphrase;
+        delete opts.httpsPassphrase;
       },
     },
     {

--- a/bin/cli-flags.js
+++ b/bin/cli-flags.js
@@ -129,6 +129,21 @@ module.exports = {
       negative: true,
     },
     {
+      name: 'https-passphrase',
+      type: String,
+      configs: [
+        {
+          type: 'string',
+        },
+      ],
+      description: 'Passphrase for a pfx file.',
+      processor(opts) {
+        opts.https = opts.https || {};
+        opts.https.key = opts.httpsKey;
+        delete opts.httpsKey;
+      },
+    },
+    {
       name: 'https-key',
       type: String,
       configs: [

--- a/bin/cli-flags.js
+++ b/bin/cli-flags.js
@@ -129,6 +129,51 @@ module.exports = {
       negative: true,
     },
     {
+      name: 'https-key',
+      type: String,
+      configs: [
+        {
+          type: 'string',
+        },
+      ],
+      description: 'Path to an SSL key.',
+      processor(opts) {
+        opts.https = opts.https || {};
+        opts.https.key = opts.httpsKey;
+        delete opts.httpsKey;
+      },
+    },
+    {
+      name: 'https-pfx',
+      type: String,
+      configs: [
+        {
+          type: 'string',
+        },
+      ],
+      description: 'Path to an SSL pfx file.',
+      processor(opts) {
+        opts.https = opts.https || {};
+        opts.https.pfx = opts.httpsPfx;
+        delete opts.httpsPfx;
+      },
+    },
+    {
+      name: 'https-cert',
+      type: String,
+      configs: [
+        {
+          type: 'string',
+        },
+      ],
+      description: 'Path to an SSL certificate.',
+      processor(opts) {
+        opts.https = opts.https || {};
+        opts.https.cert = opts.httpsCert;
+        delete opts.httpsCert;
+      },
+    },
+    {
       name: 'http2',
       type: Boolean,
       configs: [

--- a/test/cli/__snapshots__/cli.test.js.snap.webpack4
+++ b/test/cli/__snapshots__/cli.test.js.snap.webpack4
@@ -116,6 +116,14 @@ exports[`CLI --https 1`] = `
 <i> [webpack-dev-server] Content not from webpack is served from '<cwd>/public' directory"
 `;
 
+exports[`CLI --https-request-cert 1`] = `
+"<i> [webpack-dev-server] Project is running at:
+<i> [webpack-dev-server] Loopback: https://localhost:<port>/
+<i> [webpack-dev-server] On Your Network (IPv4): https://<network-ip-v4>:<port>/
+<i> [webpack-dev-server] On Your Network (IPv6): https://[<network-ip-v6>]:<port>/
+<i> [webpack-dev-server] Content not from webpack is served from '<cwd>/public' directory"
+`;
+
 exports[`CLI --no-bonjour 1`] = `
 "<i> [webpack-dev-server] Project is running at:
 <i> [webpack-dev-server] Loopback: http://localhost:<port>/
@@ -145,6 +153,22 @@ exports[`CLI --no-https 1`] = `
 <i> [webpack-dev-server] Loopback: http://localhost:<port>/
 <i> [webpack-dev-server] On Your Network (IPv4): http://<network-ip-v4>:<port>/
 <i> [webpack-dev-server] On Your Network (IPv6): http://[<network-ip-v6>]:<port>/
+<i> [webpack-dev-server] Content not from webpack is served from '<cwd>/public' directory"
+`;
+
+exports[`CLI --no-https-request-cert 1`] = `
+"<i> [webpack-dev-server] Project is running at:
+<i> [webpack-dev-server] Loopback: https://localhost:<port>/
+<i> [webpack-dev-server] On Your Network (IPv4): https://<network-ip-v4>:<port>/
+<i> [webpack-dev-server] On Your Network (IPv6): https://[<network-ip-v6>]:<port>/
+<i> [webpack-dev-server] Content not from webpack is served from '<cwd>/public' directory"
+`;
+
+exports[`CLI https options 1`] = `
+"<i> [webpack-dev-server] Project is running at:
+<i> [webpack-dev-server] Loopback: https://localhost:<port>/
+<i> [webpack-dev-server] On Your Network (IPv4): https://<network-ip-v4>:<port>/
+<i> [webpack-dev-server] On Your Network (IPv6): https://[<network-ip-v6>]:<port>/
 <i> [webpack-dev-server] Content not from webpack is served from '<cwd>/public' directory"
 `;
 
@@ -199,6 +223,13 @@ Options:
   --no-live-reload                 Disables live reloading on changing files.
   --https                          Use HTTPS protocol.
   --no-https                       Do not use HTTPS protocol.
+  --https-passphrase <value>       Passphrase for a pfx file.
+  --https-key <value>              Path to an SSL key.
+  --https-pfx <value>              Path to an SSL pfx file.
+  --https-cert <value>             Path to an SSL certificate.
+  --https-cacert <value>           Path to an SSL CA certificate.
+  --https-request-cert             Request for an SSL certificate.
+  --no-https-request-cert          Do not request for an SSL certificate.
   --http2                          Use HTTP/2, must be used with HTTPS.
   --no-http2                       Do not use HTTP/2.
   --bonjour                        Broadcasts the server via ZeroConf

--- a/test/cli/__snapshots__/cli.test.js.snap.webpack5
+++ b/test/cli/__snapshots__/cli.test.js.snap.webpack5
@@ -116,6 +116,14 @@ exports[`CLI --https 1`] = `
 <i> [webpack-dev-server] Content not from webpack is served from '<cwd>/public' directory"
 `;
 
+exports[`CLI --https-request-cert 1`] = `
+"<i> [webpack-dev-server] Project is running at:
+<i> [webpack-dev-server] Loopback: https://localhost:<port>/
+<i> [webpack-dev-server] On Your Network (IPv4): https://<network-ip-v4>:<port>/
+<i> [webpack-dev-server] On Your Network (IPv6): https://[<network-ip-v6>]:<port>/
+<i> [webpack-dev-server] Content not from webpack is served from '<cwd>/public' directory"
+`;
+
 exports[`CLI --no-bonjour 1`] = `
 "<i> [webpack-dev-server] Project is running at:
 <i> [webpack-dev-server] Loopback: http://localhost:<port>/
@@ -145,6 +153,14 @@ exports[`CLI --no-https 1`] = `
 <i> [webpack-dev-server] Loopback: http://localhost:<port>/
 <i> [webpack-dev-server] On Your Network (IPv4): http://<network-ip-v4>:<port>/
 <i> [webpack-dev-server] On Your Network (IPv6): http://[<network-ip-v6>]:<port>/
+<i> [webpack-dev-server] Content not from webpack is served from '<cwd>/public' directory"
+`;
+
+exports[`CLI --no-https-request-cert 1`] = `
+"<i> [webpack-dev-server] Project is running at:
+<i> [webpack-dev-server] Loopback: https://localhost:<port>/
+<i> [webpack-dev-server] On Your Network (IPv4): https://<network-ip-v4>:<port>/
+<i> [webpack-dev-server] On Your Network (IPv6): https://[<network-ip-v6>]:<port>/
 <i> [webpack-dev-server] Content not from webpack is served from '<cwd>/public' directory"
 `;
 

--- a/test/cli/__snapshots__/cli.test.js.snap.webpack5
+++ b/test/cli/__snapshots__/cli.test.js.snap.webpack5
@@ -201,6 +201,13 @@ Options:
   --no-live-reload                 Disables live reloading on changing files.
   --https                          Use HTTPS protocol.
   --no-https                       Do not use HTTPS protocol.
+  --https-passphrase <value>       Passphrase for a pfx file.
+  --https-key <value>              Path to an SSL key.
+  --https-pfx <value>              Path to an SSL pfx file.
+  --https-cert <value>             Path to an SSL certificate.
+  --https-cacert <value>           Path to an SSL CA certificate.
+  --https-request-cert             Request for an SSL certificate.
+  --no-https-request-cert          Do not request for an SSL certificate.
   --http2                          Use HTTP/2, must be used with HTTPS.
   --no-http2                       Do not use HTTP/2.
   --bonjour                        Broadcasts the server via ZeroConf

--- a/test/cli/__snapshots__/cli.test.js.snap.webpack5
+++ b/test/cli/__snapshots__/cli.test.js.snap.webpack5
@@ -164,6 +164,14 @@ exports[`CLI --no-https-request-cert 1`] = `
 <i> [webpack-dev-server] Content not from webpack is served from '<cwd>/public' directory"
 `;
 
+exports[`CLI https options 1`] = `
+"<i> [webpack-dev-server] Project is running at:
+<i> [webpack-dev-server] Loopback: https://localhost:<port>/
+<i> [webpack-dev-server] On Your Network (IPv4): https://<network-ip-v4>:<port>/
+<i> [webpack-dev-server] On Your Network (IPv6): https://[<network-ip-v6>]:<port>/
+<i> [webpack-dev-server] Content not from webpack is served from '<cwd>/public' directory"
+`;
+
 exports[`CLI should generate correct cli flags 1`] = `
 "Usage: webpack serve|s [entries...] [options]
 

--- a/test/cli/cli.test.js
+++ b/test/cli/cli.test.js
@@ -183,7 +183,7 @@ describe('CLI', () => {
       .then((output) => {
         expect(output.exitCode).toEqual(0);
         expect(
-          normalizeStderr(output.stderr, { ipv6: true })
+          normalizeStderr(output.stderr, { ipv6: true, https: true })
         ).toMatchSnapshot();
 
         done();

--- a/test/cli/cli.test.js
+++ b/test/cli/cli.test.js
@@ -9,6 +9,11 @@ const { testBin, normalizeStderr } = require('../helpers/test-bin');
 const localIPv4 = internalIp.v4.sync();
 const localIPv6 = internalIp.v6.sync();
 
+const httpsCertificateDirectory = path.resolve(
+  __dirname,
+  '../fixtures/https-certificate'
+);
+
 describe('CLI', () => {
   it('--hot', (done) => {
     testBin('--hot --stats=detailed')
@@ -128,6 +133,27 @@ describe('CLI', () => {
 
   it('--https', (done) => {
     testBin('--https')
+      .then((output) => {
+        expect(output.exitCode).toEqual(0);
+        expect(
+          normalizeStderr(output.stderr, { ipv6: true, https: true })
+        ).toMatchSnapshot();
+
+        done();
+      })
+      .catch(done);
+  });
+
+  it('https options', (done) => {
+    const pfxFile = path.join(httpsCertificateDirectory, 'server.pfx');
+    const key = path.join(httpsCertificateDirectory, 'server.key');
+    const cert = path.join(httpsCertificateDirectory, 'server.crt');
+    const cacert = path.join(httpsCertificateDirectory, 'ca.pem');
+    const passphrase = 'webpack-dev-server';
+
+    testBin(
+      `--https-key ${key} --https-pfx ${pfxFile} --https-passphrase ${passphrase} --https-cert ${cert} --https-cacert ${cacert}`
+    )
       .then((output) => {
         expect(output.exitCode).toEqual(0);
         expect(

--- a/test/cli/cli.test.js
+++ b/test/cli/cli.test.js
@@ -139,6 +139,32 @@ describe('CLI', () => {
       .catch(done);
   });
 
+  it('--https-request-cert', (done) => {
+    testBin('--https-request-cert')
+      .then((output) => {
+        expect(output.exitCode).toEqual(0);
+        expect(
+          normalizeStderr(output.stderr, { ipv6: true, https: true })
+        ).toMatchSnapshot();
+
+        done();
+      })
+      .catch(done);
+  });
+
+  it('--no-https-request-cert', (done) => {
+    testBin('--no-https-request-cert')
+      .then((output) => {
+        expect(output.exitCode).toEqual(0);
+        expect(
+          normalizeStderr(output.stderr, { ipv6: true })
+        ).toMatchSnapshot();
+
+        done();
+      })
+      .catch(done);
+  });
+
   it('--no-https', (done) => {
     testBin('--no-https')
       .then((output) => {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [ ] This is a **bugfix**
- [x] This is a **feature**
- [ ] This is a **code refactor**
- [x] This is a **test update**
- [x] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?
Yep WIP
<!-- Please note that we won't approve your changes if you don't add tests. -->

### Motivation / Use-Case

Fixes https://github.com/webpack/webpack-dev-server/issues/2996

Allow following flags - 

-  `--https-passphrase <value>` 
-  `--https-key <value>`           
-  `--https-pfx <value>`          
-  `--https-cert <value>` 
-  `--https-cacert <value>`        
-  `--https-request-cert`      
-  `--no-https-request-cert`        

<!--
  What existing problem does the pull request solve?

  Please explain the motivation or use-case for making this change.
  If this Pull Request addresses an issue, please link to the issue.
-->

### Breaking Changes

None
<!--
  If this PR introduces a breaking change, please describe the impact and a
  potential migration path for existing applications.
-->

### Additional Info
No