### PR TITLE
fix: respect `logLevel` and `logProvider` option for proxy

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -220,10 +220,15 @@ class Server {
           const configWithDevServer =
             configs.find((config) => config.devServer) || configs[0];
 
-          proxyOptions.logLevel = getLogLevelForProxy(
-            configWithDevServer.infrastructureLogging.level
-          );
-          proxyOptions.logProvider = () => this.logger;
+          if (typeof proxyOptions.logLevel === 'undefined') {
+            proxyOptions.logLevel = getLogLevelForProxy(
+              configWithDevServer.infrastructureLogging.level
+            );
+          }
+
+          if (typeof proxyOptions.logProvider === 'undefined') {
+            proxyOptions.logProvider = () => this.logger;
+          }
 
           return proxyOptions;
         });

--- a/test/cli/__snapshots__/cli.test.js.snap.webpack4
+++ b/test/cli/__snapshots__/cli.test.js.snap.webpack4
@@ -195,6 +195,7 @@ Options:
                                    webpack e.g. ./dist/.
   -t, --target <value>             Sets the build target e.g. node.
   -d, --devtool <value>            Determine source maps to use.
+  --no-devtool                     Do not generate source maps.
   --mode <value>                   Defines the mode to pass to webpack.
   --name <value>                   Name of the configuration. Used when loading
                                    multiple configurations.

--- a/test/server/proxy-option.test.js
+++ b/test/server/proxy-option.test.js
@@ -305,6 +305,7 @@ describe('proxy option', () => {
     let responseMessage;
 
     const transportModes = ['sockjs', 'ws'];
+
     transportModes.forEach((transportMode) => {
       describe(`with transportMode: ${transportMode}`, () => {
         beforeAll((done) => {
@@ -510,6 +511,220 @@ describe('proxy option', () => {
 
     it('respects a proxy option', (done) => {
       req.get('/proxy1').expect(200, 'from proxy1', done);
+    });
+  });
+
+  describe('should work and respect `logProvider` and `logLevel` options', () => {
+    let server;
+    let req;
+    let closeProxyServers;
+    let customLogProvider;
+
+    beforeAll((done) => {
+      customLogProvider = {
+        log: jest.fn(),
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+      };
+
+      closeProxyServers = startProxyServers();
+      server = testServer.start(
+        config,
+        {
+          static: {
+            directory: contentBase,
+            watch: false,
+          },
+          proxy: {
+            '/my-path': {
+              target: 'http://unknown:1234',
+              logProvider: () => customLogProvider,
+              logLevel: 'error',
+            },
+          },
+          port: port3,
+        },
+        done
+      );
+      req = request(server.app);
+    });
+
+    afterAll((done) => {
+      testServer.close(() => {
+        closeProxyServers(done);
+      });
+    });
+
+    describe('target', () => {
+      it('respects a proxy option when a request path is matched', (done) => {
+        req.get('/my-path').expect(504, () => {
+          expect(customLogProvider.error).toHaveBeenCalledTimes(1);
+
+          done();
+        });
+      });
+    });
+  });
+
+  describe('should work and respect the `logLevel` option with `silent` value', () => {
+    let server;
+    let req;
+    let closeProxyServers;
+    let customLogProvider;
+
+    beforeAll((done) => {
+      customLogProvider = {
+        log: jest.fn(),
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+      };
+
+      closeProxyServers = startProxyServers();
+      server = testServer.start(
+        config,
+        {
+          static: {
+            directory: contentBase,
+            watch: false,
+          },
+          proxy: {
+            '/my-path': {
+              target: 'http://unknown:1234',
+              logProvider: () => customLogProvider,
+              logLevel: 'silent',
+            },
+          },
+          port: port3,
+        },
+        done
+      );
+      req = request(server.app);
+    });
+
+    afterAll((done) => {
+      testServer.close(() => {
+        closeProxyServers(done);
+      });
+    });
+
+    describe('target', () => {
+      it('respects a proxy option when a request path is matched', (done) => {
+        req.get('/my-path').expect(504, () => {
+          expect(customLogProvider.error).toHaveBeenCalledTimes(0);
+
+          done();
+        });
+      });
+    });
+  });
+
+  describe('should work and respect the `infrastructureLogging.level` option', () => {
+    let server;
+    let req;
+    let closeProxyServers;
+    let customLogProvider;
+
+    beforeAll((done) => {
+      customLogProvider = {
+        log: jest.fn(),
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+      };
+
+      closeProxyServers = startProxyServers();
+      server = testServer.start(
+        { ...config, infrastructureLogging: { level: 'error' } },
+        {
+          static: {
+            directory: contentBase,
+            watch: false,
+          },
+          proxy: {
+            '/my-path': {
+              target: 'http://unknown:1234',
+              logProvider: () => customLogProvider,
+            },
+          },
+          port: port3,
+        },
+        done
+      );
+      req = request(server.app);
+    });
+
+    afterAll((done) => {
+      testServer.close(() => {
+        closeProxyServers(done);
+      });
+    });
+
+    describe('target', () => {
+      it('respects a proxy option when a request path is matched', (done) => {
+        req.get('/my-path').expect(504, () => {
+          expect(customLogProvider.error).toHaveBeenCalledTimes(1);
+
+          done();
+        });
+      });
+    });
+  });
+
+  describe('should work and respect the `infrastructureLogging.level` option with `none` value', () => {
+    let server;
+    let req;
+    let closeProxyServers;
+    let customLogProvider;
+
+    beforeAll((done) => {
+      customLogProvider = {
+        log: jest.fn(),
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+      };
+
+      closeProxyServers = startProxyServers();
+      server = testServer.start(
+        { ...config, infrastructureLogging: { level: 'none' } },
+        {
+          static: {
+            directory: contentBase,
+            watch: false,
+          },
+          proxy: {
+            '/my-path': {
+              target: 'http://unknown:1234',
+              logProvider: () => customLogProvider,
+            },
+          },
+          port: port3,
+        },
+        done
+      );
+      req = request(server.app);
+    });
+
+    afterAll((done) => {
+      testServer.close(() => {
+        closeProxyServers(done);
+      });
+    });
+
+    describe('target', () => {
+      it('respects a proxy option when a request path is matched', (done) => {
+        req.get('/my-path').expect(504, () => {
+          expect(customLogProvider.error).toHaveBeenCalledTimes(0);
+
+          done();
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [x] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [x] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

fixes #3234

### Motivation / Use-Case

respect `logLevel` and `logProvider` option for proxy

### Breaking Changes

No

### Additional Info

No