### PR TITLE
Fix HMR/Live Reloading when running against webpack v5 and have an array of targets when using webpack-dev-server v3

### DIFF
--- a/lib/utils/addEntries.js
+++ b/lib/utils/addEntries.js
@@ -117,15 +117,24 @@ function addEntries(config, options, server) {
 
     // eslint-disable-next-line no-shadow
     [].concat(config).forEach((config) => {
+      // In webpack v5 target can be a string, an array of strings, null, or undefined
+      /** @type {Array<string>} */
+      const targets = Array.isArray(config.target)
+        ? config.target
+        : [config.target];
+
       /** @type {Boolean} */
-      const webTarget = [
-        'web',
-        'webworker',
-        'electron-renderer',
-        'node-webkit',
-        undefined, // eslint-disable-line
-        null,
-      ].includes(config.target);
+      const webTarget = targets.some((target) => {
+        return [
+          'web',
+          'webworker',
+          'electron-renderer',
+          'node-webkit',
+          undefined, // eslint-disable-line
+          null,
+        ].includes(target);
+      });
+
       /** @type {Entry} */
       const additionalEntries = checkInject(
         options.injectClient,

--- a/test/server/utils/addEntries.test.js
+++ b/test/server/utils/addEntries.test.js
@@ -307,9 +307,11 @@ describe('addEntries util', () => {
       Object.assign({}, config),
       Object.assign({ target: 'web' }, config),
       Object.assign({ target: 'webworker' }, config),
+      Object.assign({ target: ['web', 'webworker'] }, config),
+      Object.assign({ target: ['web', 'es5'] }, config),
       Object.assign({ target: 'electron-renderer' }, config),
       Object.assign({ target: 'node-webkit' }, config),
-      Object.assign({ target: 'node' }, config) /* index:5 */,
+      Object.assign({ target: 'node' }, config) /* index:7 */,
     ];
 
     const devServerOptions = {};
@@ -318,7 +320,7 @@ describe('addEntries util', () => {
 
     // eslint-disable-next-line no-shadow
     webpackOptions.forEach((webpackOptions, index) => {
-      const expectInline = index !== 5; /* all but the node target */
+      const expectInline = index !== 7; /* all but the node target */
 
       expect(webpackOptions.entry.length).toEqual(expectInline ? 2 : 1);
 


### PR DESCRIPTION
- [X] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [X] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

<!-- Please note that we won't approve your changes if you don't add tests. -->
Updated the existing `addEntries` web targets test

### Motivation / Use-Case

<!--
  What existing problem does the pull request solve?

  Please explain the motivation or use-case for making this change.
  If this Pull Request addresses an issue, please link to the issue.
-->

Since v4 is not out yet (where this issue is fixed) this fixes the live reload issue https://github.com/webpack/webpack-dev-server/issues/2758 that occurs when a user is using webpack v5.

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  potential migration path for existing applications.
-->

None

### Additional Info

Tested against the examples and my own private webpack v5 config to confirm that it detected that the config was a web config.

Looking at the fix in the v4 branch I suspect this will not work as well as that change. Specifically if someone uses the new `browserlists` target option this change won't detect that as a web config. Since this change only needs to hold people over until v4 is released I believe its okay since in the example above the user could just add `web` to their target array.
