### PR TITLE
fix: host can't be null or empty string

### DIFF
--- a/lib/options.json
+++ b/lib/options.json
@@ -375,14 +375,8 @@
       "description": "When using the HTML5 History API, the index.html page will likely have to be served in place of any 404 responses. https://webpack.js.org/configuration/dev-server/#devserverhistoryapifallback"
     },
     "host": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
+      "type": "string",
+      "minLength": 1,
       "description": "Specify a host to use. If you want your server to be accessible externally. https://webpack.js.org/configuration/dev-server/#devserverhost"
     },
     "hot": {

--- a/lib/utils/DevServerPlugin.js
+++ b/lib/utils/DevServerPlugin.js
@@ -50,7 +50,7 @@ class DevServerPlugin {
       host = options.webSocketServer.options.host;
     }
     // The `host` option is specified
-    else if (typeof this.options.host !== 'undefined' && this.options.host) {
+    else if (typeof this.options.host !== 'undefined') {
       host = this.options.host;
     }
     // The `port` option is not specified

--- a/test/__snapshots__/validate-options.test.js.snap.webpack4
+++ b/test/__snapshots__/validate-options.test.js.snap.webpack4
@@ -190,14 +190,22 @@ exports[`options validate should throw an error on the "historyApiFallback" opti
       object { … }"
 `;
 
+exports[`options validate should throw an error on the "host" option with '' value 1`] = `
+"ValidationError: Invalid configuration object. Object has been initialized using a configuration object that does not match the API schema.
+ - configuration.host should be an non-empty string.
+   -> Specify a host to use. If you want your server to be accessible externally. https://webpack.js.org/configuration/dev-server/#devserverhost"
+`;
+
 exports[`options validate should throw an error on the "host" option with 'false' value 1`] = `
 "ValidationError: Invalid configuration object. Object has been initialized using a configuration object that does not match the API schema.
- - configuration.host should be one of these:
-   string | null
-   -> Specify a host to use. If you want your server to be accessible externally. https://webpack.js.org/configuration/dev-server/#devserverhost
-   Details:
-    * configuration.host should be a string.
-    * configuration.host should be a null."
+ - configuration.host should be a non-empty string.
+   -> Specify a host to use. If you want your server to be accessible externally. https://webpack.js.org/configuration/dev-server/#devserverhost"
+`;
+
+exports[`options validate should throw an error on the "host" option with 'null' value 1`] = `
+"ValidationError: Invalid configuration object. Object has been initialized using a configuration object that does not match the API schema.
+ - configuration.host should be a non-empty string.
+   -> Specify a host to use. If you want your server to be accessible externally. https://webpack.js.org/configuration/dev-server/#devserverhost"
 `;
 
 exports[`options validate should throw an error on the "hot" option with '' value 1`] = `

--- a/test/__snapshots__/validate-options.test.js.snap.webpack5
+++ b/test/__snapshots__/validate-options.test.js.snap.webpack5
@@ -190,14 +190,22 @@ exports[`options validate should throw an error on the "historyApiFallback" opti
       object { … }"
 `;
 
+exports[`options validate should throw an error on the "host" option with '' value 1`] = `
+"ValidationError: Invalid configuration object. Object has been initialized using a configuration object that does not match the API schema.
+ - configuration.host should be an non-empty string.
+   -> Specify a host to use. If you want your server to be accessible externally. https://webpack.js.org/configuration/dev-server/#devserverhost"
+`;
+
 exports[`options validate should throw an error on the "host" option with 'false' value 1`] = `
 "ValidationError: Invalid configuration object. Object has been initialized using a configuration object that does not match the API schema.
- - configuration.host should be one of these:
-   string | null
-   -> Specify a host to use. If you want your server to be accessible externally. https://webpack.js.org/configuration/dev-server/#devserverhost
-   Details:
-    * configuration.host should be a string.
-    * configuration.host should be a null."
+ - configuration.host should be a non-empty string.
+   -> Specify a host to use. If you want your server to be accessible externally. https://webpack.js.org/configuration/dev-server/#devserverhost"
+`;
+
+exports[`options validate should throw an error on the "host" option with 'null' value 1`] = `
+"ValidationError: Invalid configuration object. Object has been initialized using a configuration object that does not match the API schema.
+ - configuration.host should be a non-empty string.
+   -> Specify a host to use. If you want your server to be accessible externally. https://webpack.js.org/configuration/dev-server/#devserverhost"
 `;
 
 exports[`options validate should throw an error on the "hot" option with '' value 1`] = `

--- a/test/server/host-option.test.js
+++ b/test/server/host-option.test.js
@@ -78,37 +78,6 @@ describe('host option', () => {
     afterAll(testServer.close);
   });
 
-  describe('is null', () => {
-    beforeAll((done) => {
-      server = testServer.start(
-        config,
-        {
-          static: {
-            directory: staticDirectory,
-            watch: false,
-          },
-          host: null,
-          port,
-        },
-        done
-      );
-      req = request(server.app);
-    });
-
-    it('server address', () => {
-      const address = server.server.address();
-
-      expect(address.address).toBe('::');
-      expect(address.port).toBe(port);
-    });
-
-    it('Request to index', (done) => {
-      req.get('/').expect(200, done);
-    });
-
-    afterAll(testServer.close);
-  });
-
   describe('is 127.0.0.1 (IPv4)', () => {
     beforeAll((done) => {
       server = testServer.start(

--- a/test/validate-options.test.js
+++ b/test/validate-options.test.js
@@ -175,8 +175,8 @@ const tests = {
     failure: [''],
   },
   host: {
-    success: ['', 'localhost', '::', '::1', null],
-    failure: [false],
+    success: ['localhost', '::', '::1'],
+    failure: [false, '', null],
   },
   hot: {
     success: [true, 'only'],


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [x] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [x] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

No need

### Motivation / Use-Case

If you want to use `0.0.0.0` (i.e. default) just don't set the `host` option or set it to `0.0.0.0` (same for IPv6)

### Breaking Changes

Yes

### Additional Info

No