### PR TITLE
feat: allow string value for `port`

### DIFF
--- a/lib/options.json
+++ b/lib/options.json
@@ -296,7 +296,15 @@
                   "description": "Tells clients connected to devServer to use the provided host."
                 },
                 "port": {
-                  "type": "number",
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  ],
                   "description": "Tells clients connected to devServer to use the provided port."
                 },
                 "path": {

--- a/lib/utils/normalizeOptions.js
+++ b/lib/utils/normalizeOptions.js
@@ -103,8 +103,10 @@ function normalizeOptions(compiler, options, logger) {
       },
     };
 
-    if (typeof options.webSocketServer.port === 'string') {
-      options.webSocketServer.port = Number(options.webSocketServer.port);
+    if (typeof options.webSocketServer.options.port === 'string') {
+      options.webSocketServer.options.port = Number(
+        options.webSocketServer.options.port
+      );
     }
   }
 
@@ -123,10 +125,8 @@ function normalizeOptions(compiler, options, logger) {
       path: parsedURL.pathname,
     };
   } else if (typeof options.client.webSocketURL.port === 'string') {
-      options.client.webSocketURL.port = Number(
-        options.client.webSocketURL.port
-      );
-    }
+    options.client.webSocketURL.port = Number(options.client.webSocketURL.port);
+  }
 
   // Enable client overlay by default
   if (typeof options.client.overlay === 'undefined') {

--- a/lib/utils/normalizeOptions.js
+++ b/lib/utils/normalizeOptions.js
@@ -95,15 +95,6 @@ function normalizeOptions(compiler, options, logger) {
       options: defaultWebSocketServerOptions,
     };
   } else {
-    if (
-      options.webSocketServer.options &&
-      typeof options.webSocketServer.options.port === 'string'
-    ) {
-      options.webSocketServer.options.port = Number(
-        options.webSocketServer.options.port
-      );
-    }
-
     options.webSocketServer = {
       type: options.webSocketServer.type || defaultWebSocketServerType,
       options: {
@@ -111,6 +102,10 @@ function normalizeOptions(compiler, options, logger) {
         ...options.webSocketServer.options,
       },
     };
+
+    if (typeof options.webSocketServer.port === 'string') {
+      options.webSocketServer.port = Number(options.webSocketServer.port);
+    }
   }
 
   if (!options.client) {
@@ -127,12 +122,11 @@ function normalizeOptions(compiler, options, logger) {
       port: Number(parsedURL.port),
       path: parsedURL.pathname,
     };
-  } else if (
-    typeof options.client.webSocketURL === 'object' &&
-    typeof options.client.webSocketURL.port === 'string'
-  ) {
-    options.client.webSocketURL.port = Number(options.client.webSocketURL.port);
-  }
+  } else if (typeof options.client.webSocketURL.port === 'string') {
+      options.client.webSocketURL.port = Number(
+        options.client.webSocketURL.port
+      );
+    }
 
   // Enable client overlay by default
   if (typeof options.client.overlay === 'undefined') {

--- a/lib/utils/normalizeOptions.js
+++ b/lib/utils/normalizeOptions.js
@@ -74,6 +74,10 @@ function normalizeOptions(compiler, options, logger) {
   options.liveReload =
     typeof options.liveReload !== 'undefined' ? options.liveReload : true;
 
+  if (typeof options.port === 'string' && options.port !== 'auto') {
+    options.port = Number(options.port);
+  }
+
   const defaultWebSocketServerType = 'ws';
   const defaultWebSocketServerOptions = { path: '/ws' };
 
@@ -91,6 +95,15 @@ function normalizeOptions(compiler, options, logger) {
       options: defaultWebSocketServerOptions,
     };
   } else {
+    if (
+      options.webSocketServer.options &&
+      typeof options.webSocketServer.options.port === 'string'
+    ) {
+      options.webSocketServer.options.port = Number(
+        options.webSocketServer.options.port
+      );
+    }
+
     options.webSocketServer = {
       type: options.webSocketServer.type || defaultWebSocketServerType,
       options: {
@@ -111,9 +124,14 @@ function normalizeOptions(compiler, options, logger) {
 
     options.client.webSocketURL = {
       host: parsedURL.hostname,
-      port: parsedURL.port,
+      port: Number(parsedURL.port),
       path: parsedURL.pathname,
     };
+  } else if (
+    typeof options.client.webSocketURL === 'object' &&
+    typeof options.client.webSocketURL.port === 'string'
+  ) {
+    options.client.webSocketURL.port = Number(options.client.webSocketURL.port);
   }
 
   // Enable client overlay by default

--- a/test/__snapshots__/validate-options.test.js.snap.webpack4
+++ b/test/__snapshots__/validate-options.test.js.snap.webpack4
@@ -150,14 +150,21 @@ exports[`options validate should throw an error on the "client" option with '{"w
 
 exports[`options validate should throw an error on the "client" option with '{"webSocketURL":{"port":""}}' value 1`] = `
 "ValidationError: Invalid configuration object. Object has been initialized using a configuration object that does not match the API schema.
- - configuration.client.webSocketURL.port should be a number.
-   -> Tells clients connected to devServer to use the provided port."
+ - configuration.client.webSocketURL.port should be an non-empty string."
 `;
 
 exports[`options validate should throw an error on the "client" option with '{"webSocketURL":{"port":true}}' value 1`] = `
 "ValidationError: Invalid configuration object. Object has been initialized using a configuration object that does not match the API schema.
- - configuration.client.webSocketURL.port should be a number.
-   -> Tells clients connected to devServer to use the provided port."
+ - configuration.client.webSocketURL should be one of these:
+   non-empty string | object { host?, port?, path? }
+   -> When using dev server and you're proxying dev-server, the client script does not always know where to connect to.
+   Details:
+    * configuration.client.webSocketURL.port should be one of these:
+      number | non-empty string
+      -> Tells clients connected to devServer to use the provided port.
+      Details:
+       * configuration.client.webSocketURL.port should be a number.
+       * configuration.client.webSocketURL.port should be a non-empty string."
 `;
 
 exports[`options validate should throw an error on the "client" option with 'whoops!' value 1`] = `

--- a/test/__snapshots__/validate-options.test.js.snap.webpack5
+++ b/test/__snapshots__/validate-options.test.js.snap.webpack5
@@ -150,14 +150,21 @@ exports[`options validate should throw an error on the "client" option with '{"w
 
 exports[`options validate should throw an error on the "client" option with '{"webSocketURL":{"port":""}}' value 1`] = `
 "ValidationError: Invalid configuration object. Object has been initialized using a configuration object that does not match the API schema.
- - configuration.client.webSocketURL.port should be a number.
-   -> Tells clients connected to devServer to use the provided port."
+ - configuration.client.webSocketURL.port should be an non-empty string."
 `;
 
 exports[`options validate should throw an error on the "client" option with '{"webSocketURL":{"port":true}}' value 1`] = `
 "ValidationError: Invalid configuration object. Object has been initialized using a configuration object that does not match the API schema.
- - configuration.client.webSocketURL.port should be a number.
-   -> Tells clients connected to devServer to use the provided port."
+ - configuration.client.webSocketURL should be one of these:
+   non-empty string | object { host?, port?, path? }
+   -> When using dev server and you're proxying dev-server, the client script does not always know where to connect to.
+   Details:
+    * configuration.client.webSocketURL.port should be one of these:
+      number | non-empty string
+      -> Tells clients connected to devServer to use the provided port.
+      Details:
+       * configuration.client.webSocketURL.port should be a number.
+       * configuration.client.webSocketURL.port should be a non-empty string."
 `;
 
 exports[`options validate should throw an error on the "client" option with 'whoops!' value 1`] = `

--- a/test/e2e/web-socket-server-and-url.test.js
+++ b/test/e2e/web-socket-server-and-url.test.js
@@ -316,6 +316,41 @@ for (const webSocketServerType of webSocketServerTypes) {
     });
   });
 
+  describe('should work with custom client port as string', () => {
+    beforeAll((done) => {
+      const options = {
+        webSocketServer: webSocketServerType,
+        port: port2,
+        host: '0.0.0.0',
+        client: {
+          webSocketURL: {
+            port: `${port3}`,
+          },
+        },
+      };
+
+      testServer.startAwaitingCompilation(config, options, done);
+    });
+
+    afterAll(testServer.close);
+
+    describe('browser client', () => {
+      it('uses correct port and path', (done) => {
+        runBrowser().then(({ page, browser }) => {
+          waitForTest(browser, page, /ws/, (websocketUrl) => {
+            expect(websocketUrl).toContain(
+              `${websocketUrlProtocol}://localhost:${port3}/ws`
+            );
+
+            done();
+          });
+
+          page.goto(`http://localhost:${port2}/main`);
+        });
+      });
+    });
+  });
+
   describe('should work with custom client host', () => {
     beforeAll((done) => {
       const options = {

--- a/test/e2e/web-socket-server-and-url.test.js
+++ b/test/e2e/web-socket-server-and-url.test.js
@@ -351,6 +351,47 @@ for (const webSocketServerType of webSocketServerTypes) {
     });
   });
 
+  describe('should work with custom client.webSocketURL.port and webSocketServer.options.port both as string', () => {
+    beforeAll((done) => {
+      const options = {
+        webSocketServer: {
+          type: webSocketServerType,
+          options: {
+            host: '0.0.0.0',
+            port: `${port2}`,
+          },
+        },
+        port: port2,
+        host: '0.0.0.0',
+        client: {
+          webSocketURL: {
+            port: `${port3}`,
+          },
+        },
+      };
+
+      testServer.startAwaitingCompilation(config, options, done);
+    });
+
+    afterAll(testServer.close);
+
+    describe('browser client', () => {
+      it('uses correct port and path', (done) => {
+        runBrowser().then(({ page, browser }) => {
+          waitForTest(browser, page, /ws/, (websocketUrl) => {
+            expect(websocketUrl).toContain(
+              `${websocketUrlProtocol}://localhost:${port3}/ws`
+            );
+
+            done();
+          });
+
+          page.goto(`http://localhost:${port2}/main`);
+        });
+      });
+    });
+  });
+
   describe('should work with custom client host', () => {
     beforeAll((done) => {
       const options = {

--- a/test/server/utils/__snapshots__/normalizeOptions.test.js.snap.webpack4
+++ b/test/server/utils/__snapshots__/normalizeOptions.test.js.snap.webpack4
@@ -1,4 +1,4 @@
-git// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`normalizeOptions allowedHosts is set should set correct options 1`] = `
 Object {
@@ -72,6 +72,44 @@ Object {
 `;
 
 exports[`normalizeOptions client host and port should set correct options 1`] = `
+Object {
+  "allowedHosts": "auto",
+  "client": Object {
+    "hotEntry": true,
+    "overlay": true,
+    "webSocketURL": Object {
+      "host": "my.host",
+      "port": 9000,
+    },
+  },
+  "compress": true,
+  "devMiddleware": Object {},
+  "hot": true,
+  "liveReload": true,
+  "setupExitSignals": true,
+  "static": Array [
+    Object {
+      "directory": "CWD",
+      "publicPath": Array [
+        "/",
+      ],
+      "serveIndex": Object {
+        "icons": true,
+      },
+      "staticOptions": Object {},
+      "watch": Object {},
+    },
+  ],
+  "webSocketServer": Object {
+    "options": Object {
+      "path": "/ws",
+    },
+    "type": "ws",
+  },
+}
+`;
+
+exports[`normalizeOptions client host and string port should set correct options 1`] = `
 Object {
   "allowedHosts": "auto",
   "client": Object {
@@ -219,12 +257,6 @@ Object {
 }
 `;
 
-<<<<<<< HEAD
-exports[`normalizeOptions client.transport ws string and webSocketServer ws string should set correct options 1`] = `
-=======
-<<<<<<< HEAD
-exports[`normalizeOptions client.transport ws string should set correct options 1`] = `
-=======
 exports[`normalizeOptions client.transport ws string and webSocketServer object should set correct options 1`] = `
 Object {
   "allowedHosts": "auto",
@@ -302,8 +334,6 @@ Object {
 `;
 
 exports[`normalizeOptions client.transport ws string and webSocketServer ws string should set correct options 1`] = `
->>>>>>> 8b6c9cf... fix: normalize port
->>>>>>> feat: allow string value for `port`
 Object {
   "allowedHosts": "auto",
   "client": Object {

--- a/test/server/utils/__snapshots__/normalizeOptions.test.js.snap.webpack4
+++ b/test/server/utils/__snapshots__/normalizeOptions.test.js.snap.webpack4
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+git// Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`normalizeOptions allowedHosts is set should set correct options 1`] = `
 Object {
@@ -219,7 +219,91 @@ Object {
 }
 `;
 
+<<<<<<< HEAD
 exports[`normalizeOptions client.transport ws string and webSocketServer ws string should set correct options 1`] = `
+=======
+<<<<<<< HEAD
+exports[`normalizeOptions client.transport ws string should set correct options 1`] = `
+=======
+exports[`normalizeOptions client.transport ws string and webSocketServer object should set correct options 1`] = `
+Object {
+  "allowedHosts": "auto",
+  "client": Object {
+    "hotEntry": true,
+    "overlay": true,
+    "transport": "ws",
+    "webSocketURL": Object {},
+  },
+  "compress": true,
+  "devMiddleware": Object {},
+  "hot": true,
+  "liveReload": true,
+  "setupExitSignals": true,
+  "static": Array [
+    Object {
+      "directory": "CWD",
+      "publicPath": Array [
+        "/",
+      ],
+      "serveIndex": Object {
+        "icons": true,
+      },
+      "staticOptions": Object {},
+      "watch": Object {},
+    },
+  ],
+  "webSocketServer": Object {
+    "options": Object {
+      "host": "myhost",
+      "path": "/ws",
+      "port": 8080,
+    },
+    "type": "ws",
+  },
+}
+`;
+
+exports[`normalizeOptions client.transport ws string and webSocketServer object with port as string should set correct options 1`] = `
+Object {
+  "allowedHosts": "auto",
+  "client": Object {
+    "hotEntry": true,
+    "overlay": true,
+    "transport": "ws",
+    "webSocketURL": Object {},
+  },
+  "compress": true,
+  "devMiddleware": Object {},
+  "hot": true,
+  "liveReload": true,
+  "setupExitSignals": true,
+  "static": Array [
+    Object {
+      "directory": "CWD",
+      "publicPath": Array [
+        "/",
+      ],
+      "serveIndex": Object {
+        "icons": true,
+      },
+      "staticOptions": Object {},
+      "watch": Object {},
+    },
+  ],
+  "webSocketServer": Object {
+    "options": Object {
+      "host": "myhost",
+      "path": "/ws",
+      "port": 8080,
+    },
+    "type": "ws",
+  },
+}
+`;
+
+exports[`normalizeOptions client.transport ws string and webSocketServer ws string should set correct options 1`] = `
+>>>>>>> 8b6c9cf... fix: normalize port
+>>>>>>> feat: allow string value for `port`
 Object {
   "allowedHosts": "auto",
   "client": Object {
@@ -552,6 +636,42 @@ Object {
   "devMiddleware": Object {},
   "hot": true,
   "liveReload": true,
+  "setupExitSignals": true,
+  "static": Array [
+    Object {
+      "directory": "CWD",
+      "publicPath": Array [
+        "/",
+      ],
+      "serveIndex": Object {
+        "icons": true,
+      },
+      "staticOptions": Object {},
+      "watch": Object {},
+    },
+  ],
+  "webSocketServer": Object {
+    "options": Object {
+      "path": "/ws",
+    },
+    "type": "ws",
+  },
+}
+`;
+
+exports[`normalizeOptions port string should set correct options 1`] = `
+Object {
+  "allowedHosts": "auto",
+  "client": Object {
+    "hotEntry": true,
+    "overlay": true,
+    "webSocketURL": Object {},
+  },
+  "compress": true,
+  "devMiddleware": Object {},
+  "hot": true,
+  "liveReload": true,
+  "port": 9000,
   "setupExitSignals": true,
   "static": Array [
     Object {

--- a/test/server/utils/__snapshots__/normalizeOptions.test.js.snap.webpack5
+++ b/test/server/utils/__snapshots__/normalizeOptions.test.js.snap.webpack5
@@ -109,6 +109,44 @@ Object {
 }
 `;
 
+exports[`normalizeOptions client host and string port should set correct options 1`] = `
+Object {
+  "allowedHosts": "auto",
+  "client": Object {
+    "hotEntry": true,
+    "overlay": true,
+    "webSocketURL": Object {
+      "host": "my.host",
+      "port": 9000,
+    },
+  },
+  "compress": true,
+  "devMiddleware": Object {},
+  "hot": true,
+  "liveReload": true,
+  "setupExitSignals": true,
+  "static": Array [
+    Object {
+      "directory": "CWD",
+      "publicPath": Array [
+        "/",
+      ],
+      "serveIndex": Object {
+        "icons": true,
+      },
+      "staticOptions": Object {},
+      "watch": Object {},
+    },
+  ],
+  "webSocketServer": Object {
+    "options": Object {
+      "path": "/ws",
+    },
+    "type": "ws",
+  },
+}
+`;
+
 exports[`normalizeOptions client path should set correct options 1`] = `
 Object {
   "allowedHosts": "auto",
@@ -219,12 +257,6 @@ Object {
 }
 `;
 
-<<<<<<< HEAD
-exports[`normalizeOptions client.transport ws string and webSocketServer ws string should set correct options 1`] = `
-=======
-<<<<<<< HEAD
-exports[`normalizeOptions client.transport ws string should set correct options 1`] = `
-=======
 exports[`normalizeOptions client.transport ws string and webSocketServer object should set correct options 1`] = `
 Object {
   "allowedHosts": "auto",
@@ -302,8 +334,6 @@ Object {
 `;
 
 exports[`normalizeOptions client.transport ws string and webSocketServer ws string should set correct options 1`] = `
->>>>>>> 8b6c9cf... fix: normalize port
->>>>>>> feat: allow string value for `port`
 Object {
   "allowedHosts": "auto",
   "client": Object {

--- a/test/server/utils/__snapshots__/normalizeOptions.test.js.snap.webpack5
+++ b/test/server/utils/__snapshots__/normalizeOptions.test.js.snap.webpack5
@@ -219,7 +219,91 @@ Object {
 }
 `;
 
+<<<<<<< HEAD
 exports[`normalizeOptions client.transport ws string and webSocketServer ws string should set correct options 1`] = `
+=======
+<<<<<<< HEAD
+exports[`normalizeOptions client.transport ws string should set correct options 1`] = `
+=======
+exports[`normalizeOptions client.transport ws string and webSocketServer object should set correct options 1`] = `
+Object {
+  "allowedHosts": "auto",
+  "client": Object {
+    "hotEntry": true,
+    "overlay": true,
+    "transport": "ws",
+    "webSocketURL": Object {},
+  },
+  "compress": true,
+  "devMiddleware": Object {},
+  "hot": true,
+  "liveReload": true,
+  "setupExitSignals": true,
+  "static": Array [
+    Object {
+      "directory": "CWD",
+      "publicPath": Array [
+        "/",
+      ],
+      "serveIndex": Object {
+        "icons": true,
+      },
+      "staticOptions": Object {},
+      "watch": Object {},
+    },
+  ],
+  "webSocketServer": Object {
+    "options": Object {
+      "host": "myhost",
+      "path": "/ws",
+      "port": 8080,
+    },
+    "type": "ws",
+  },
+}
+`;
+
+exports[`normalizeOptions client.transport ws string and webSocketServer object with port as string should set correct options 1`] = `
+Object {
+  "allowedHosts": "auto",
+  "client": Object {
+    "hotEntry": true,
+    "overlay": true,
+    "transport": "ws",
+    "webSocketURL": Object {},
+  },
+  "compress": true,
+  "devMiddleware": Object {},
+  "hot": true,
+  "liveReload": true,
+  "setupExitSignals": true,
+  "static": Array [
+    Object {
+      "directory": "CWD",
+      "publicPath": Array [
+        "/",
+      ],
+      "serveIndex": Object {
+        "icons": true,
+      },
+      "staticOptions": Object {},
+      "watch": Object {},
+    },
+  ],
+  "webSocketServer": Object {
+    "options": Object {
+      "host": "myhost",
+      "path": "/ws",
+      "port": 8080,
+    },
+    "type": "ws",
+  },
+}
+`;
+
+exports[`normalizeOptions client.transport ws string and webSocketServer ws string should set correct options 1`] = `
+>>>>>>> 8b6c9cf... fix: normalize port
+>>>>>>> feat: allow string value for `port`
 Object {
   "allowedHosts": "auto",
   "client": Object {
@@ -552,6 +636,42 @@ Object {
   "devMiddleware": Object {},
   "hot": true,
   "liveReload": true,
+  "setupExitSignals": true,
+  "static": Array [
+    Object {
+      "directory": "CWD",
+      "publicPath": Array [
+        "/",
+      ],
+      "serveIndex": Object {
+        "icons": true,
+      },
+      "staticOptions": Object {},
+      "watch": Object {},
+    },
+  ],
+  "webSocketServer": Object {
+    "options": Object {
+      "path": "/ws",
+    },
+    "type": "ws",
+  },
+}
+`;
+
+exports[`normalizeOptions port string should set correct options 1`] = `
+Object {
+  "allowedHosts": "auto",
+  "client": Object {
+    "hotEntry": true,
+    "overlay": true,
+    "webSocketURL": Object {},
+  },
+  "compress": true,
+  "devMiddleware": Object {},
+  "hot": true,
+  "liveReload": true,
+  "port": 9000,
   "setupExitSignals": true,
   "static": Array [
     Object {

--- a/test/server/utils/normalizeOptions.test.js
+++ b/test/server/utils/normalizeOptions.test.js
@@ -13,6 +13,14 @@ describe('normalizeOptions', () => {
       optionsResults: null,
     },
     {
+      title: 'port string',
+      multiCompiler: false,
+      options: {
+        port: '9000',
+      },
+      optionsResults: null,
+    },
+    {
       title: 'client.transport sockjs string',
       multiCompiler: false,
       options: {
@@ -60,6 +68,43 @@ describe('normalizeOptions', () => {
       optionsResults: null,
     },
     {
+      title: 'client.transport ws string and webSocketServer object',
+      multiCompiler: false,
+      options: {
+        client: {
+          transport: 'ws',
+        },
+        webSocketServer: {
+          type: 'ws',
+          options: {
+            host: 'myhost',
+            port: 8080,
+            path: '/ws',
+          },
+        },
+      },
+      optionsResults: null,
+    },
+    {
+      title:
+        'client.transport ws string and webSocketServer object with port as string',
+      multiCompiler: false,
+      options: {
+        client: {
+          transport: 'ws',
+        },
+        webSocketServer: {
+          type: 'ws',
+          options: {
+            host: 'myhost',
+            port: '8080',
+            path: '/ws',
+          },
+        },
+      },
+      optionsResults: null,
+    },
+    {
       title: 'client custom transport path',
       multiCompiler: false,
       options: {
@@ -77,6 +122,19 @@ describe('normalizeOptions', () => {
           webSocketURL: {
             host: 'my.host',
             port: 9000,
+          },
+        },
+      },
+      optionsResults: null,
+    },
+    {
+      title: 'client host and string port',
+      multiCompiler: false,
+      options: {
+        client: {
+          webSocketURL: {
+            host: 'my.host',
+            port: '9000',
           },
         },
       },

--- a/test/validate-options.test.js
+++ b/test/validate-options.test.js
@@ -92,6 +92,9 @@ const tests = {
         webSocketURL: { port: 8080 },
       },
       {
+        webSocketURL: { port: '8080' },
+      },
+      {
         webSocketURL: { path: '' },
       },
       {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [ ] This is a **bugfix**
- [X] This is a **feature**
- [ ] This is a **code refactor**
- [X] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

<!-- Please note that we won't approve your changes if you don't add tests. -->

### Motivation / Use-Case

Allow string for `client.webSocketURL.port`
<!--
  What existing problem does the pull request solve?

  Please explain the motivation or use-case for making this change.
  If this Pull Request addresses an issue, please link to the issue.
-->

### Breaking Changes
None
<!--
  If this PR introduces a breaking change, please describe the impact and a
  potential migration path for existing applications.
-->

### Additional Info
No