### PR TITLE
fix: do not allow empty string for `port`

### DIFF
--- a/lib/options.json
+++ b/lib/options.json
@@ -523,7 +523,8 @@
           "type": "number"
         },
         {
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         {
           "enum": ["auto"]

--- a/test/__snapshots__/validate-options.test.js.snap.webpack4
+++ b/test/__snapshots__/validate-options.test.js.snap.webpack4
@@ -414,25 +414,30 @@ exports[`options validate should throw an error on the "open" option with '{"tar
        * configuration.open.target should be a non-empty string."
 `;
 
+exports[`options validate should throw an error on the "port" option with '' value 1`] = `
+"ValidationError: Invalid configuration object. Object has been initialized using a configuration object that does not match the API schema.
+ - configuration.port should be an non-empty string."
+`;
+
 exports[`options validate should throw an error on the "port" option with 'false' value 1`] = `
 "ValidationError: Invalid configuration object. Object has been initialized using a configuration object that does not match the API schema.
  - configuration.port should be one of these:
-   number | string | \\"auto\\"
+   number | non-empty string | \\"auto\\"
    -> Specify a port number to listen for requests on. https://webpack.js.org/configuration/dev-server/#devserverport
    Details:
     * configuration.port should be a number.
-    * configuration.port should be a string.
+    * configuration.port should be a non-empty string.
     * configuration.port should be \\"auto\\"."
 `;
 
 exports[`options validate should throw an error on the "port" option with 'null' value 1`] = `
 "ValidationError: Invalid configuration object. Object has been initialized using a configuration object that does not match the API schema.
  - configuration.port should be one of these:
-   number | string | \\"auto\\"
+   number | non-empty string | \\"auto\\"
    -> Specify a port number to listen for requests on. https://webpack.js.org/configuration/dev-server/#devserverport
    Details:
     * configuration.port should be a number.
-    * configuration.port should be a string.
+    * configuration.port should be a non-empty string.
     * configuration.port should be \\"auto\\"."
 `;
 

--- a/test/__snapshots__/validate-options.test.js.snap.webpack5
+++ b/test/__snapshots__/validate-options.test.js.snap.webpack5
@@ -414,25 +414,30 @@ exports[`options validate should throw an error on the "open" option with '{"tar
        * configuration.open.target should be a non-empty string."
 `;
 
+exports[`options validate should throw an error on the "port" option with '' value 1`] = `
+"ValidationError: Invalid configuration object. Object has been initialized using a configuration object that does not match the API schema.
+ - configuration.port should be an non-empty string."
+`;
+
 exports[`options validate should throw an error on the "port" option with 'false' value 1`] = `
 "ValidationError: Invalid configuration object. Object has been initialized using a configuration object that does not match the API schema.
  - configuration.port should be one of these:
-   number | string | \\"auto\\"
+   number | non-empty string | \\"auto\\"
    -> Specify a port number to listen for requests on. https://webpack.js.org/configuration/dev-server/#devserverport
    Details:
     * configuration.port should be a number.
-    * configuration.port should be a string.
+    * configuration.port should be a non-empty string.
     * configuration.port should be \\"auto\\"."
 `;
 
 exports[`options validate should throw an error on the "port" option with 'null' value 1`] = `
 "ValidationError: Invalid configuration object. Object has been initialized using a configuration object that does not match the API schema.
  - configuration.port should be one of these:
-   number | string | \\"auto\\"
+   number | non-empty string | \\"auto\\"
    -> Specify a port number to listen for requests on. https://webpack.js.org/configuration/dev-server/#devserverport
    Details:
     * configuration.port should be a number.
-    * configuration.port should be a string.
+    * configuration.port should be a non-empty string.
     * configuration.port should be \\"auto\\"."
 `;
 

--- a/test/validate-options.test.js
+++ b/test/validate-options.test.js
@@ -258,8 +258,8 @@ const tests = {
     failure: ['', [], { foo: 'bar' }, { target: 90 }, { app: true }],
   },
   port: {
-    success: ['', 0, 'auto'],
-    failure: [false, null],
+    success: ['8080', 8080, 'auto'],
+    failure: [false, null, ''],
   },
   proxy: {
     success: [


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [X] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [X] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?
Yes
<!-- Please note that we won't approve your changes if you don't add tests. -->

### Motivation / Use-Case

Don't allow empty strings for the `port` option.
<!--
  What existing problem does the pull request solve?

  Please explain the motivation or use-case for making this change.
  If this Pull Request addresses an issue, please link to the issue.
-->

### Breaking Changes
None
<!--
  If this PR introduces a breaking change, please describe the impact and a
  potential migration path for existing applications.
-->

### Additional Info
No