### PR TITLE
fix: pass own logger in historyApiFallback

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -252,7 +252,7 @@ class Server {
     const historyApiFallback = require('connect-history-api-fallback');
 
     const options =
-      typeof this.options.historyApiFallback !== 'undefined'
+      typeof this.options.historyApiFallback !== 'boolean'
         ? this.options.historyApiFallback
         : {};
 

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -256,8 +256,19 @@ class Server {
         ? this.options.historyApiFallback
         : null;
 
+    let logger;
+    if (fallback) {
+      // respect when user supplies their own logger
+      if (fallback.logger) {
+        logger = fallback.logger;
+      } else if (fallback.verbose) {
+        // enable logs using own logger when verbose is supplied
+        logger = this.logger.log;
+      }
+    }
+
     // Fall back to /index.html if nothing else matches.
-    this.app.use(historyApiFallback(fallback));
+    this.app.use(historyApiFallback({ ...fallback, logger }));
   }
 
   setupStaticFeature() {

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -251,24 +251,22 @@ class Server {
   setupHistoryApiFallbackFeature() {
     const historyApiFallback = require('connect-history-api-fallback');
 
-    const fallback =
-      typeof this.options.historyApiFallback === 'object'
+    const options =
+      typeof this.options.historyApiFallback !== 'undefined'
         ? this.options.historyApiFallback
-        : null;
+        : {};
 
     let logger;
-    if (fallback) {
-      // respect when user supplies their own logger
-      if (fallback.logger) {
-        logger = fallback.logger;
-      } else if (fallback.verbose) {
-        // enable logs using own logger when verbose is supplied
-        logger = this.logger.log;
-      }
+
+    if (typeof options.verbose === 'undefined') {
+      logger = this.logger.log.bind(
+        this.logger,
+        '[connect-history-api-fallback]'
+      );
     }
 
     // Fall back to /index.html if nothing else matches.
-    this.app.use(historyApiFallback({ ...fallback, logger }));
+    this.app.use(historyApiFallback({ logger, ...options }));
   }
 
   setupStaticFeature() {

--- a/test/server/historyApiFallback-option.test.js
+++ b/test/server/historyApiFallback-option.test.js
@@ -178,6 +178,102 @@ describe('historyApiFallback option', () => {
     });
   });
 
+  describe('as object with the "verbose" option', () => {
+    let consoleSpy;
+
+    beforeAll((done) => {
+      consoleSpy = jest.spyOn(global.console, 'log');
+
+      server = testServer.start(
+        config,
+        {
+          historyApiFallback: {
+            index: '/bar.html',
+            verbose: true,
+          },
+          port,
+        },
+        done
+      );
+      req = request(server.app);
+    });
+
+    afterAll(() => {
+      consoleSpy.mockRestore();
+    });
+
+    it('request to directory and log', (done) => {
+      req
+        .get('/foo')
+        .accept('html')
+        .expect(200, /Foobar/, (error) => {
+          if (error) {
+            done(error);
+
+            return;
+          }
+
+          expect(consoleSpy).toHaveBeenCalledWith(
+            'Rewriting',
+            'GET',
+            '/foo',
+            'to',
+            '/bar.html'
+          );
+
+          done();
+        });
+    });
+  });
+
+  describe('as object with the "logger" option', () => {
+    let consoleSpy;
+
+    beforeAll((done) => {
+      consoleSpy = jest.spyOn(global.console, 'log');
+
+      server = testServer.start(
+        config,
+        {
+          historyApiFallback: {
+            index: '/bar.html',
+            logger: consoleSpy,
+          },
+          port,
+        },
+        done
+      );
+      req = request(server.app);
+    });
+
+    afterAll(() => {
+      consoleSpy.mockRestore();
+    });
+
+    it('request to directory and log', (done) => {
+      req
+        .get('/foo')
+        .accept('html')
+        .expect(200, /Foobar/, (error) => {
+          if (error) {
+            done(error);
+
+            return;
+          }
+
+          expect(consoleSpy).toHaveBeenCalledWith(
+            'Rewriting',
+            'GET',
+            '/foo',
+            'to',
+            '/bar.html'
+          );
+
+          done();
+        });
+    });
+  });
+
   describe('in-memory files', () => {
     beforeAll((done) => {
       server = testServer.start(


### PR DESCRIPTION

- [ ] This is a **bugfix**
- [x] This is a **feature**
- [ ] This is a **code refactor**
- [x] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?
wip on tests

### Motivation / Use-Case
when user enables logs we use inbuilt logger to log the stats

### Breaking Changes
no

### Additional Info
