### PR TITLE
fix: `--port` flag parsing

### DIFF
--- a/bin/cli-flags.js
+++ b/bin/cli-flags.js
@@ -16,10 +16,17 @@ module.exports = {
     },
     {
       name: 'port',
-      type: Number,
+      type: [Number, String],
       configs: [
         {
           type: 'number',
+        },
+        {
+          type: 'string',
+        },
+        {
+          type: 'enum',
+          values: ['auto'],
         },
       ],
       description: 'The port server will listen to.',

--- a/test/cli/__snapshots__/cli.test.js.snap.webpack4
+++ b/test/cli/__snapshots__/cli.test.js.snap.webpack4
@@ -164,6 +164,23 @@ exports[`CLI --no-https-request-cert 1`] = `
 <i> [webpack-dev-server] Content not from webpack is served from '<cwd>/public' directory"
 `;
 
+exports[`CLI --port is auto: stderr 1`] = `
+"<i> [webpack-dev-server] Project is running at:
+<i> [webpack-dev-server] Loopback: http://localhost:<port>/
+<i> [webpack-dev-server] On Your Network (IPv4): http://<network-ip-v4>:<port>/
+<i> [webpack-dev-server] On Your Network (IPv6): http://[<network-ip-v6>]:<port>/
+<i> [webpack-dev-server] Content not from webpack is served from '<cwd>/public' directory"
+`;
+
+exports[`CLI --port is string: stderr 1`] = `
+"<w> [webpack-dev-server] The \\"port\\" specified in options is different from the port passed as an argument. Will be used from arguments.
+<i> [webpack-dev-server] Project is running at:
+<i> [webpack-dev-server] Loopback: http://localhost:<port>/
+<i> [webpack-dev-server] On Your Network (IPv4): http://<network-ip-v4>:<port>/
+<i> [webpack-dev-server] On Your Network (IPv6): http://[<network-ip-v6>]:<port>/
+<i> [webpack-dev-server] Content not from webpack is served from '<cwd>/public' directory"
+`;
+
 exports[`CLI https and other related options 1`] = `
 "<i> [webpack-dev-server] Project is running at:
 <i> [webpack-dev-server] Loopback: https://localhost:<port>/

--- a/test/cli/__snapshots__/cli.test.js.snap.webpack5
+++ b/test/cli/__snapshots__/cli.test.js.snap.webpack5
@@ -164,6 +164,23 @@ exports[`CLI --no-https-request-cert 1`] = `
 <i> [webpack-dev-server] Content not from webpack is served from '<cwd>/public' directory"
 `;
 
+exports[`CLI --port is auto: stderr 1`] = `
+"<i> [webpack-dev-server] Project is running at:
+<i> [webpack-dev-server] Loopback: http://localhost:<port>/
+<i> [webpack-dev-server] On Your Network (IPv4): http://<network-ip-v4>:<port>/
+<i> [webpack-dev-server] On Your Network (IPv6): http://[<network-ip-v6>]:<port>/
+<i> [webpack-dev-server] Content not from webpack is served from '<cwd>/public' directory"
+`;
+
+exports[`CLI --port is string: stderr 1`] = `
+"<w> [webpack-dev-server] The \\"port\\" specified in options is different from the port passed as an argument. Will be used from arguments.
+<i> [webpack-dev-server] Project is running at:
+<i> [webpack-dev-server] Loopback: http://localhost:<port>/
+<i> [webpack-dev-server] On Your Network (IPv4): http://<network-ip-v4>:<port>/
+<i> [webpack-dev-server] On Your Network (IPv6): http://[<network-ip-v6>]:<port>/
+<i> [webpack-dev-server] Content not from webpack is served from '<cwd>/public' directory"
+`;
+
 exports[`CLI https and other related options 1`] = `
 "<i> [webpack-dev-server] Project is running at:
 <i> [webpack-dev-server] Loopback: https://localhost:<port>/

--- a/test/cli/cli.test.js
+++ b/test/cli/cli.test.js
@@ -432,6 +432,32 @@ describe('CLI', () => {
       .catch(done);
   });
 
+  it('--port is string', (done) => {
+    testBin(`--port "8080"`)
+      .then((output) => {
+        expect(output.exitCode).toEqual(0);
+        expect(normalizeStderr(output.stderr, { ipv6: true })).toMatchSnapshot(
+          'stderr'
+        );
+
+        done();
+      })
+      .catch(done);
+  });
+
+  it(`--port is auto`, (done) => {
+    testBin(`--port auto`)
+      .then((output) => {
+        expect(output.exitCode).toEqual(0);
+        expect(normalizeStderr(output.stderr, { ipv6: true })).toMatchSnapshot(
+          'stderr'
+        );
+
+        done();
+      })
+      .catch(done);
+  });
+
   it('--open', (done) => {
     testBin('--open')
       .then((output) => {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [X] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [X] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

No
<!-- Please note that we won't approve your changes if you don't add tests. -->

### Motivation / Use-Case

allow string values to be accepted by `--port`.
<!--
  What existing problem does the pull request solve?

  Please explain the motivation or use-case for making this change.
  If this Pull Request addresses an issue, please link to the issue.
-->

### Breaking Changes

None
<!--
  If this PR introduces a breaking change, please describe the impact and a
  potential migration path for existing applications.
-->

### Additional Info
No