### PR TITLE
feat: allow to set `client.webSocketURL.protocol`

### DIFF
--- a/client-src/utils/createSocketURL.js
+++ b/client-src/utils/createSocketURL.js
@@ -24,8 +24,12 @@ function createSocketURL(parsedURL) {
     hostname = self.location.hostname;
   }
 
+  if (protocol === 'auto:') {
+    protocol = self.location.protocol;
+  }
+
   // `hostname` can be empty when the script path is relative. In that case, specifying a protocol would result in an invalid URL.
-  // When https is used in the app, secure websockets are always necessary because the browser doesn't accept non-secure websockets.
+  // When https is used in the app, secure web sockets are always necessary because the browser doesn't accept non-secure web sockets.
   if (hostname && isInAddrAny && self.location.protocol === 'https:') {
     protocol = self.location.protocol;
   }

--- a/lib/options.json
+++ b/lib/options.json
@@ -290,6 +290,18 @@
               "type": "object",
               "additionalProperties": false,
               "properties": {
+                "protocol": {
+                  "anyOf": [
+                    {
+                      "enum": ["auto"]
+                    },
+                    {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  ],
+                  "description": "Tells clients connected to devServer to use the provided protocol."
+                },
                 "host": {
                   "type": "string",
                   "minLength": 1,

--- a/lib/utils/DevServerPlugin.js
+++ b/lib/utils/DevServerPlugin.js
@@ -28,8 +28,15 @@ class DevServerPlugin {
   apply(compiler) {
     const { options } = this;
 
-    /** @type {"ws" | "wss"} */
-    const protocol = options.https ? 'wss' : 'ws';
+    /** @type {"ws:" | "wss:" | "http:" | "https:" | "auto:"} */
+    let protocol;
+
+    // We are proxying dev server and need to specify custom `host`
+    if (typeof options.client.webSocketURL.protocol !== 'undefined') {
+      protocol = options.client.webSocketURL.protocol;
+    } else {
+      protocol = options.https ? 'wss:' : 'ws:';
+    }
 
     /** @type {string} */
     let host;
@@ -111,7 +118,7 @@ class DevServerPlugin {
 
     const webSocketURL = encodeURIComponent(
       new URL(
-        `${protocol}://${ipaddr.IPv6.isIPv6(host) ? `[${host}]` : host}${
+        `${protocol}//${ipaddr.IPv6.isIPv6(host) ? `[${host}]` : host}${
           port ? `:${port}` : ''
         }${path || '/'}${
           Object.keys(searchParams).length > 0

--- a/lib/utils/normalizeOptions.js
+++ b/lib/utils/normalizeOptions.js
@@ -120,8 +120,9 @@ function normalizeOptions(compiler, options, logger) {
     const parsedURL = new URL(options.client.webSocketURL);
 
     options.client.webSocketURL = {
+      protocol: parsedURL.protocol,
       host: parsedURL.hostname,
-      port: Number(parsedURL.port),
+      port: parsedURL.port.length > 0 ? Number(parsedURL.port) : '',
       path: parsedURL.pathname,
     };
   } else if (typeof options.client.webSocketURL.port === 'string') {

--- a/test/__snapshots__/validate-options.test.js.snap.webpack4
+++ b/test/__snapshots__/validate-options.test.js.snap.webpack4
@@ -156,7 +156,7 @@ exports[`options validate should throw an error on the "client" option with '{"w
 exports[`options validate should throw an error on the "client" option with '{"webSocketURL":{"port":true}}' value 1`] = `
 "ValidationError: Invalid configuration object. Object has been initialized using a configuration object that does not match the API schema.
  - configuration.client.webSocketURL should be one of these:
-   non-empty string | object { host?, port?, path? }
+   non-empty string | object { protocol?, host?, port?, path? }
    -> When using dev server and you're proxying dev-server, the client script does not always know where to connect to.
    Details:
     * configuration.client.webSocketURL.port should be one of these:

--- a/test/__snapshots__/validate-options.test.js.snap.webpack5
+++ b/test/__snapshots__/validate-options.test.js.snap.webpack5
@@ -156,7 +156,7 @@ exports[`options validate should throw an error on the "client" option with '{"w
 exports[`options validate should throw an error on the "client" option with '{"webSocketURL":{"port":true}}' value 1`] = `
 "ValidationError: Invalid configuration object. Object has been initialized using a configuration object that does not match the API schema.
  - configuration.client.webSocketURL should be one of these:
-   non-empty string | object { host?, port?, path? }
+   non-empty string | object { protocol?, host?, port?, path? }
    -> When using dev server and you're proxying dev-server, the client script does not always know where to connect to.
    Details:
     * configuration.client.webSocketURL.port should be one of these:

--- a/test/e2e/web-socket-server-and-url.test.js
+++ b/test/e2e/web-socket-server-and-url.test.js
@@ -245,7 +245,216 @@ for (const webSocketServerType of webSocketServerTypes) {
     });
   });
 
-  describe('should work with custom client port and path', () => {
+  describe('should work with the "client.webSocketURL.protocol" option', () => {
+    beforeAll((done) => {
+      const options = {
+        webSocketServer: webSocketServerType,
+        port: port2,
+        host: '0.0.0.0',
+        client: {
+          webSocketURL: {
+            protocol: 'ws:',
+          },
+        },
+      };
+
+      testServer.startAwaitingCompilation(config, options, done);
+    });
+
+    afterAll(testServer.close);
+
+    describe('browser client', () => {
+      it('should work', (done) => {
+        runBrowser().then(({ page, browser }) => {
+          waitForTest(browser, page, /ws/, (websocketUrl) => {
+            expect(websocketUrl).toContain(
+              `${websocketUrlProtocol}://localhost:${port2}/ws`
+            );
+
+            done();
+          });
+
+          page.goto(`http://localhost:${port2}/main`);
+        });
+      });
+    });
+  });
+
+  describe('should work with the "client.webSocketURL.protocol" option using "auto:" value', () => {
+    beforeAll((done) => {
+      const options = {
+        webSocketServer: webSocketServerType,
+        port: port2,
+        host: '0.0.0.0',
+        client: {
+          webSocketURL: {
+            protocol: 'auto:',
+          },
+        },
+      };
+
+      testServer.startAwaitingCompilation(config, options, done);
+    });
+
+    afterAll(testServer.close);
+
+    describe('browser client', () => {
+      it('should work', (done) => {
+        runBrowser().then(({ page, browser }) => {
+          waitForTest(browser, page, /ws/, (websocketUrl) => {
+            expect(websocketUrl).toContain(
+              `${websocketUrlProtocol}://localhost:${port2}/ws`
+            );
+
+            done();
+          });
+
+          page.goto(`http://localhost:${port2}/main`);
+        });
+      });
+    });
+  });
+
+  describe('should work with the "client.webSocketURL.protocol" option using "http:" value and covert to "ws"', () => {
+    beforeAll((done) => {
+      const options = {
+        webSocketServer: webSocketServerType,
+        port: port2,
+        host: '0.0.0.0',
+        client: {
+          webSocketURL: {
+            protocol: 'http:',
+          },
+        },
+      };
+
+      testServer.startAwaitingCompilation(config, options, done);
+    });
+
+    afterAll(testServer.close);
+
+    describe('browser client', () => {
+      it('should work', (done) => {
+        runBrowser().then(({ page, browser }) => {
+          waitForTest(browser, page, /ws/, (websocketUrl) => {
+            expect(websocketUrl).toContain(
+              `${websocketUrlProtocol}://localhost:${port2}/ws`
+            );
+
+            done();
+          });
+
+          page.goto(`http://localhost:${port2}/main`);
+        });
+      });
+    });
+  });
+
+  describe('should work with the "client.webSocketURL.host" option', () => {
+    beforeAll((done) => {
+      const options = {
+        webSocketServer: webSocketServerType,
+        port: port2,
+        host: '0.0.0.0',
+        client: {
+          webSocketURL: {
+            host: 'myhost.test',
+          },
+        },
+      };
+      testServer.startAwaitingCompilation(config, options, done);
+    });
+
+    afterAll(testServer.close);
+
+    describe('browser client', () => {
+      it('should work', (done) => {
+        runBrowser().then(({ page, browser }) => {
+          waitForTest(browser, page, /ws/, (websocketUrl) => {
+            expect(websocketUrl).toContain(
+              `${websocketUrlProtocol}://myhost.test:${port2}/ws`
+            );
+
+            done();
+          });
+
+          page.goto(`http://localhost:${port2}/main`);
+        });
+      });
+    });
+  });
+
+  describe('should work with the "client.webSocketURL.port" option', () => {
+    beforeAll((done) => {
+      const options = {
+        webSocketServer: webSocketServerType,
+        port: port2,
+        host: '0.0.0.0',
+        client: {
+          webSocketURL: {
+            port: port3,
+          },
+        },
+      };
+
+      testServer.startAwaitingCompilation(config, options, done);
+    });
+
+    afterAll(testServer.close);
+
+    describe('browser client', () => {
+      it('should work', (done) => {
+        runBrowser().then(({ page, browser }) => {
+          waitForTest(browser, page, /ws/, (websocketUrl) => {
+            expect(websocketUrl).toContain(
+              `${websocketUrlProtocol}://localhost:${port3}/ws`
+            );
+
+            done();
+          });
+
+          page.goto(`http://localhost:${port2}/main`);
+        });
+      });
+    });
+  });
+
+  describe('should work with the "client.webSocketURL.port" option as "string"', () => {
+    beforeAll((done) => {
+      const options = {
+        webSocketServer: webSocketServerType,
+        port: port2,
+        host: '0.0.0.0',
+        client: {
+          webSocketURL: {
+            port: `${port3}`,
+          },
+        },
+      };
+
+      testServer.startAwaitingCompilation(config, options, done);
+    });
+
+    afterAll(testServer.close);
+
+    describe('browser client', () => {
+      it('should work', (done) => {
+        runBrowser().then(({ page, browser }) => {
+          waitForTest(browser, page, /ws/, (websocketUrl) => {
+            expect(websocketUrl).toContain(
+              `${websocketUrlProtocol}://localhost:${port3}/ws`
+            );
+
+            done();
+          });
+
+          page.goto(`http://localhost:${port2}/main`);
+        });
+      });
+    });
+  });
+
+  describe('should work with "client.webSocketURL.port" and "client.webSocketURL.path" options', () => {
     beforeAll((done) => {
       const options = {
         webSocketServer: webSocketServerType,
@@ -265,7 +474,7 @@ for (const webSocketServerType of webSocketServerTypes) {
     afterAll(testServer.close);
 
     describe('browser client', () => {
-      it('uses correct port and path', (done) => {
+      it('should work', (done) => {
         runBrowser().then(({ page, browser }) => {
           waitForTest(browser, page, /foo\/test\/bar/, (websocketUrl) => {
             expect(websocketUrl).toContain(
@@ -281,77 +490,7 @@ for (const webSocketServerType of webSocketServerTypes) {
     });
   });
 
-  describe('should work with custom client port', () => {
-    beforeAll((done) => {
-      const options = {
-        webSocketServer: webSocketServerType,
-        port: port2,
-        host: '0.0.0.0',
-        client: {
-          webSocketURL: {
-            port: port3,
-          },
-        },
-      };
-
-      testServer.startAwaitingCompilation(config, options, done);
-    });
-
-    afterAll(testServer.close);
-
-    describe('browser client', () => {
-      it('uses correct port and path', (done) => {
-        runBrowser().then(({ page, browser }) => {
-          waitForTest(browser, page, /ws/, (websocketUrl) => {
-            expect(websocketUrl).toContain(
-              `${websocketUrlProtocol}://localhost:${port3}/ws`
-            );
-
-            done();
-          });
-
-          page.goto(`http://localhost:${port2}/main`);
-        });
-      });
-    });
-  });
-
-  describe('should work with custom client port as string', () => {
-    beforeAll((done) => {
-      const options = {
-        webSocketServer: webSocketServerType,
-        port: port2,
-        host: '0.0.0.0',
-        client: {
-          webSocketURL: {
-            port: `${port3}`,
-          },
-        },
-      };
-
-      testServer.startAwaitingCompilation(config, options, done);
-    });
-
-    afterAll(testServer.close);
-
-    describe('browser client', () => {
-      it('uses correct port and path', (done) => {
-        runBrowser().then(({ page, browser }) => {
-          waitForTest(browser, page, /ws/, (websocketUrl) => {
-            expect(websocketUrl).toContain(
-              `${websocketUrlProtocol}://localhost:${port3}/ws`
-            );
-
-            done();
-          });
-
-          page.goto(`http://localhost:${port2}/main`);
-        });
-      });
-    });
-  });
-
-  describe('should work with custom client.webSocketURL.port and webSocketServer.options.port both as string', () => {
+  describe('should work with "client.webSocketURL.port" and "webSocketServer.options.port" options as string', () => {
     beforeAll((done) => {
       const options = {
         webSocketServer: {
@@ -376,7 +515,7 @@ for (const webSocketServerType of webSocketServerTypes) {
     afterAll(testServer.close);
 
     describe('browser client', () => {
-      it('uses correct port and path', (done) => {
+      it('should work', (done) => {
         runBrowser().then(({ page, browser }) => {
           waitForTest(browser, page, /ws/, (websocketUrl) => {
             expect(websocketUrl).toContain(
@@ -392,41 +531,7 @@ for (const webSocketServerType of webSocketServerTypes) {
     });
   });
 
-  describe('should work with custom client host', () => {
-    beforeAll((done) => {
-      const options = {
-        webSocketServer: webSocketServerType,
-        port: port2,
-        host: '0.0.0.0',
-        client: {
-          webSocketURL: {
-            host: 'myhost.test',
-          },
-        },
-      };
-      testServer.startAwaitingCompilation(config, options, done);
-    });
-
-    afterAll(testServer.close);
-
-    describe('browser client', () => {
-      it('uses correct host', (done) => {
-        runBrowser().then(({ page, browser }) => {
-          waitForTest(browser, page, /ws/, (websocketUrl) => {
-            expect(websocketUrl).toContain(
-              `${websocketUrlProtocol}://myhost.test:${port2}/ws`
-            );
-
-            done();
-          });
-
-          page.goto(`http://localhost:${port2}/main`);
-        });
-      });
-    });
-  });
-
-  describe('should work with custom client host, port, and path', () => {
+  describe('should work with "client.webSocketURL.host", "webSocketServer.options.port" and "webSocketServer.options.path" options', () => {
     beforeAll((done) => {
       const options = {
         webSocketServer: webSocketServerType,
@@ -463,7 +568,7 @@ for (const webSocketServerType of webSocketServerTypes) {
     });
   });
 
-  describe('should work with the "client.webSocketURL" option and custom client path', () => {
+  describe('should work with the "client.webSocketURL" option as "string"', () => {
     beforeAll((done) => {
       const options = {
         webSocketServer: webSocketServerType,
@@ -480,7 +585,7 @@ for (const webSocketServerType of webSocketServerTypes) {
     afterAll(testServer.close);
 
     describe('browser client', () => {
-      it('uses the correct webSocketURL hostname and path', (done) => {
+      it('should work', (done) => {
         runBrowser().then(({ page, browser }) => {
           waitForTest(browser, page, /foo\/test\/bar/, (websocketUrl) => {
             expect(websocketUrl).toContain(


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [ ] This is a **bugfix**
- [x] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

WIP on tests

### Motivation / Use-Case

When you proxy webpack dev server and proxy uses https you can't change protocol of web socket client URL without this feature

### Breaking Changes

No

### Additional Info

No