### PR TITLE
refactor: manage web socket connections from base server class

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -202,7 +202,7 @@ class Server {
       }
 
       this.sendMessage(
-        this.webSocketServer.webSocketConnections,
+        this.webSocketServer && this.webSocketServer.webSocketConnections,
         'progress-update',
         {
           percent,
@@ -226,7 +226,10 @@ class Server {
   setupHooks() {
     // Listening for events
     const invalidPlugin = () => {
-      this.sendMessage(this.webSocketServer.webSocketConnections, 'invalid');
+      this.sendMessage(
+        this.webSocketServer && this.webSocketServer.webSocketConnections,
+        'invalid'
+      );
     };
 
     const addHooks = (compiler) => {
@@ -236,7 +239,7 @@ class Server {
       invalid.tap('webpack-dev-server', invalidPlugin);
       done.tap('webpack-dev-server', (stats) => {
         this.sendStats(
-          this.webSocketServer.webSocketConnections,
+          this.webSocketServer && this.webSocketServer.webSocketConnections,
           this.getStats(stats)
         );
         this.stats = stats;
@@ -1104,6 +1107,7 @@ class Server {
   }
 
   sendMessage(webSocketConnections, type, data) {
+    if (!webSocketConnections) return;
     webSocketConnections.forEach((webSocketConnection) => {
       this.webSocketServer.send(
         webSocketConnection,
@@ -1206,7 +1210,7 @@ class Server {
     if (this.options.liveReload) {
       watcher.on('change', (item) => {
         this.sendMessage(
-          this.webSocketServer.webSocketConnections,
+          this.webSocketServer && this.webSocketServer.webSocketConnections,
           'static-changed',
           item
         );

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -32,7 +32,6 @@ class Server {
     this.compiler = compiler;
     this.options = options;
     this.logger = this.compiler.getInfrastructureLogger('webpack-dev-server');
-    this.webSocketConnections = [];
     this.staticWatchers = [];
     // Keep track of websocket proxies for external websocket upgrade.
     this.webSocketProxies = [];
@@ -202,11 +201,15 @@ class Server {
         msg = `${msg} (${addInfo})`;
       }
 
-      this.sendMessage(this.webSocketConnections, 'progress-update', {
-        percent,
-        msg,
-        pluginName,
-      });
+      this.sendMessage(
+        this.webSocketServer.webSocketConnections,
+        'progress-update',
+        {
+          percent,
+          msg,
+          pluginName,
+        }
+      );
 
       if (this.server) {
         this.server.emit('progress-update', { percent, msg, pluginName });
@@ -223,7 +226,7 @@ class Server {
   setupHooks() {
     // Listening for events
     const invalidPlugin = () => {
-      this.sendMessage(this.webSocketConnections, 'invalid');
+      this.sendMessage(this.webSocketServer.webSocketConnections, 'invalid');
     };
 
     const addHooks = (compiler) => {
@@ -232,7 +235,10 @@ class Server {
       compile.tap('webpack-dev-server', invalidPlugin);
       invalid.tap('webpack-dev-server', invalidPlugin);
       done.tap('webpack-dev-server', (stats) => {
-        this.sendStats(this.webSocketConnections, this.getStats(stats));
+        this.sendStats(
+          this.webSocketServer.webSocketConnections,
+          this.getStats(stats)
+        );
         this.stats = stats;
       });
     };
@@ -604,13 +610,14 @@ class Server {
         return;
       }
 
-      this.webSocketConnections.push(connection);
+      this.webSocketServer.webSocketConnections.push(connection);
 
       this.webSocketServer.onConnectionClose(connection, () => {
-        const idx = this.webSocketConnections.indexOf(connection);
+        const idx =
+          this.webSocketServer.webSocketConnections.indexOf(connection);
 
         if (idx >= 0) {
-          this.webSocketConnections.splice(idx, 1);
+          this.webSocketServer.webSocketConnections.splice(idx, 1);
         }
       });
 
@@ -958,7 +965,7 @@ class Server {
   close(callback) {
     if (this.webSocketServer) {
       this.webSocketServer.close();
-      this.webSocketConnections = [];
+      this.webSocketServer.webSocketConnections = [];
     }
 
     const prom = Promise.all(
@@ -1198,7 +1205,11 @@ class Server {
     // disabling refreshing on changing the content
     if (this.options.liveReload) {
       watcher.on('change', (item) => {
-        this.sendMessage(this.webSocketConnections, 'static-changed', item);
+        this.sendMessage(
+          this.webSocketServer.webSocketConnections,
+          'static-changed',
+          item
+        );
       });
     }
 

--- a/lib/servers/BaseServer.js
+++ b/lib/servers/BaseServer.js
@@ -5,5 +5,7 @@
 module.exports = class BaseServer {
   constructor(server) {
     this.server = server;
+
+    this.webSocketConnections = [];
   }
 };

--- a/lib/servers/SockJSServer.js
+++ b/lib/servers/SockJSServer.js
@@ -73,7 +73,7 @@ module.exports = class SockJSServer extends BaseServer {
   }
 
   close(callback) {
-    [...this.server.webSocketConnections].forEach((socket) => {
+    [...this.webSocketConnections].forEach((socket) => {
       this.closeConnection(socket);
     });
 

--- a/test/server/webSocketServer-option.test.js
+++ b/test/server/webSocketServer-option.test.js
@@ -226,7 +226,7 @@ describe('webSocketServer', () => {
                 }
 
                 close(callback) {
-                  [...this.server.webSocketConnections].forEach((socket) => {
+                  [...this.webSocketConnections].forEach((socket) => {
                     this.closeConnection(socket);
                   });
 
@@ -317,7 +317,7 @@ describe('webSocketServer', () => {
                 }
 
                 close(callback) {
-                  [...this.server.webSocketConnections].forEach((socket) => {
+                  [...this.webSocketConnections].forEach((socket) => {
                     this.closeConnection(socket);
                   });
 
@@ -427,7 +427,7 @@ describe('webSocketServer', () => {
                 }
 
                 close(callback) {
-                  [...this.server.webSocketConnections].forEach((socket) => {
+                  [...this.webSocketConnections].forEach((socket) => {
                     this.closeConnection(socket);
                   });
 


### PR DESCRIPTION
- [ ] This is a **bugfix**
- [ ] This is a **feature**
- [x] This is a **code refactor**
- [x] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

existing 

### Motivation / Use-Case
we'll manage all socket connection and events from the base server class

### Breaking Changes
no

### Additional Info

move `this.(web)sockets` from `dev` server + `servers` and move into `WebsocketServer`