### PR TITLE
refactor: exlcude `hot` for cli

### DIFF
--- a/bin/cli-flags.js
+++ b/bin/cli-flags.js
@@ -374,30 +374,6 @@ module.exports = {
     simpleType: 'string',
     multiple: false,
   },
-  hot: {
-    configs: [
-      {
-        type: 'boolean',
-        multiple: false,
-        description:
-          'Enables Hot Module Replacement. https://webpack.js.org/configuration/dev-server/#devserverhot',
-        path: 'hot',
-      },
-      {
-        type: 'enum',
-        values: ['only'],
-        multiple: false,
-        description:
-          'Enables Hot Module Replacement. https://webpack.js.org/configuration/dev-server/#devserverhot',
-        path: 'hot',
-      },
-    ],
-    description:
-      'Enables Hot Module Replacement. https://webpack.js.org/configuration/dev-server/#devserverhot',
-    negatedDescription: 'Disables Hot Module Replacement.',
-    simpleType: 'string',
-    multiple: false,
-  },
   http2: {
     configs: [
       {

--- a/lib/options.json
+++ b/lib/options.json
@@ -306,7 +306,10 @@
           "enum": ["only"]
         }
       ],
-      "description": "Enables Hot Module Replacement. https://webpack.js.org/configuration/dev-server/#devserverhot"
+      "description": "Enables Hot Module Replacement. https://webpack.js.org/configuration/dev-server/#devserverhot",
+      "cli": {
+        "exclude": true
+      }
     },
     "IPC": {
       "anyOf": [


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [X] This is a **bugfix**
- [ ] This is a **feature**
- [X] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?
Already present, CI should be green.
<!-- Please note that we won't approve your changes if you don't add tests. -->

### Motivation / Use-Case

`webpack-cli` already defines `--hot`, so it is kind of just duplicate code.

Also right now it shows `--hot` two times because of this in suggestions on passing a wrong cli option.

## Before 
<img width="636" alt="Screenshot 2021-07-12 at 5 35 42 PM" src="https://user-images.githubusercontent.com/46647141/125285306-25fddd00-e338-11eb-8c00-430b5a85e6ab.png">

## After
<img width="585" alt="Screenshot 2021-07-12 at 5 35 51 PM" src="https://user-images.githubusercontent.com/46647141/125285297-226a5600-e338-11eb-8a7a-79d8379291fa.png">


<!--
  What existing problem does the pull request solve?

  Please explain the motivation or use-case for making this change.
  If this Pull Request addresses an issue, please link to the issue.
-->

### Breaking Changes
None
<!--
  If this PR introduces a breaking change, please describe the impact and a
  potential migration path for existing applications.
-->

### Additional Info
No