### PR TITLE
refactor: remove `client.transport` in favor of `client.webSocketTransport`

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Options:
   --no-client-overlay-warnings              Negative 'client-overlay-warnings' option.
   --client-progress                         Prints compilation progress in percentage in the browser.
   --no-client-progress                      Negative 'client-progress' option.
-  --client-transport <value>                Allows to set custom transport to communicate with dev server.
+  --client-web-socket-transport <value>     Allows to set custom web socket transport to communicate with dev server.
   --client-web-socket-url <value>           Allows to specify URL to web socket server (useful when you're proxying dev server and client script does not always know where to connect to).
   --client-web-socket-url-hostname <value>  Tells clients connected to devServer to use the provided hostname.
   --client-web-socket-url-pathname <value>  Tells clients connected to devServer to use the provided path to connect.

--- a/bin/cli-flags.js
+++ b/bin/cli-flags.js
@@ -64,14 +64,14 @@ module.exports = {
         multiple: false,
         description:
           'Allows to set custom web socket transport to communicate with dev server.',
-        path: 'client.transport',
+        path: 'client.webSocketTransport',
       },
       {
         type: 'string',
         multiple: false,
         description:
           'Allows to set custom web socket transport to communicate with dev server.',
-        path: 'client.transport',
+        path: 'client.webSocketTransport',
       },
     ],
     description:

--- a/bin/cli-flags.js
+++ b/bin/cli-flags.js
@@ -56,26 +56,26 @@ module.exports = {
     simpleType: 'boolean',
     multiple: false,
   },
-  'client-transport': {
+  'client-web-socket-transport': {
     configs: [
       {
         type: 'enum',
         values: ['sockjs', 'ws'],
         multiple: false,
         description:
-          'Allows to set custom transport to communicate with dev server.',
+          'Allows to set custom web socket transport to communicate with dev server.',
         path: 'client.transport',
       },
       {
         type: 'string',
         multiple: false,
         description:
-          'Allows to set custom transport to communicate with dev server.',
+          'Allows to set custom web socket transport to communicate with dev server.',
         path: 'client.transport',
       },
     ],
     description:
-      'Allows to set custom transport to communicate with dev server.',
+      'Allows to set custom web socket transport to communicate with dev server.',
     simpleType: 'string',
     multiple: false,
   },

--- a/lib/options.json
+++ b/lib/options.json
@@ -104,7 +104,7 @@
           "$ref": "#/definitions/ClientWebSocketTransportString"
         }
       ],
-      "description": "Allows to set custom transport to communicate with dev server."
+      "description": "Allows to set custom web socket transport to communicate with dev server."
     },
     "ClientWebSocketTransportEnum": {
       "enum": ["sockjs", "ws"]

--- a/lib/options.json
+++ b/lib/options.json
@@ -55,8 +55,8 @@
             "progress": {
               "$ref": "#/definitions/ClientProgress"
             },
-            "transport": {
-              "$ref": "#/definitions/ClientTransport"
+            "webSocketTransport": {
+              "$ref": "#/definitions/ClientWebSocketTransport"
             },
             "webSocketURL": {
               "$ref": "#/definitions/ClientWebSocketURL"
@@ -95,21 +95,21 @@
       "description": "Prints compilation progress in percentage in the browser.",
       "type": "boolean"
     },
-    "ClientTransport": {
+    "ClientWebSocketTransport": {
       "anyOf": [
         {
-          "$ref": "#/definitions/ClientTransportEnum"
+          "$ref": "#/definitions/ClientWebSocketTransportEnum"
         },
         {
-          "$ref": "#/definitions/ClientTransportString"
+          "$ref": "#/definitions/ClientWebSocketTransportString"
         }
       ],
       "description": "Allows to set custom transport to communicate with dev server."
     },
-    "ClientTransportEnum": {
+    "ClientWebSocketTransportEnum": {
       "enum": ["sockjs", "ws"]
     },
-    "ClientTransportString": {
+    "ClientWebSocketTransportString": {
       "type": "string",
       "minLength": 1
     },

--- a/lib/utils/DevServerPlugin.js
+++ b/lib/utils/DevServerPlugin.js
@@ -25,8 +25,8 @@ class DevServerPlugin {
     let clientTransport;
 
     if (this.options.client) {
-      if (typeof this.options.client.transport !== 'undefined') {
-        clientTransport = this.options.client.transport;
+      if (typeof this.options.client.webSockettransport !== 'undefined') {
+        clientTransport = this.options.client.webSockettransport;
       } else if (isKnownWebSocketServerImplementation) {
         clientTransport = this.options.webSocketServer.type;
       }
@@ -62,9 +62,9 @@ class DevServerPlugin {
       throw new Error(
         `${
           !isKnownWebSocketServerImplementation
-            ? 'When you use custom web socket implementation you must explicitly specify client.transport. '
+            ? 'When you use custom web socket implementation you must explicitly specify client.webSockettransport. '
             : ''
-        }client.transport must be a string denoting a default implementation (e.g. 'sockjs', 'ws') or a full path to a JS file via require.resolve(...) which exports a class `
+        }client.webSockettransport must be a string denoting a default implementation (e.g. 'sockjs', 'ws') or a full path to a JS file via require.resolve(...) which exports a class `
       );
     }
 

--- a/lib/utils/DevServerPlugin.js
+++ b/lib/utils/DevServerPlugin.js
@@ -25,8 +25,8 @@ class DevServerPlugin {
     let clientTransport;
 
     if (this.options.client) {
-      if (typeof this.options.client.webSockettransport !== 'undefined') {
-        clientTransport = this.options.client.webSockettransport;
+      if (typeof this.options.client.webSocketTransport !== 'undefined') {
+        clientTransport = this.options.client.webSocketTransport;
       } else if (isKnownWebSocketServerImplementation) {
         clientTransport = this.options.webSocketServer.type;
       }
@@ -62,9 +62,9 @@ class DevServerPlugin {
       throw new Error(
         `${
           !isKnownWebSocketServerImplementation
-            ? 'When you use custom web socket implementation you must explicitly specify client.webSockettransport. '
+            ? 'When you use custom web socket implementation you must explicitly specify client.webSocketTransport. '
             : ''
-        }client.webSockettransport must be a string denoting a default implementation (e.g. 'sockjs', 'ws') or a full path to a JS file via require.resolve(...) which exports a class `
+        }client.webSocketTransport must be a string denoting a default implementation (e.g. 'sockjs', 'ws') or a full path to a JS file via require.resolve(...) which exports a class `
       );
     }
 

--- a/test/__snapshots__/validate-options.test.js.snap.webpack4
+++ b/test/__snapshots__/validate-options.test.js.snap.webpack4
@@ -126,7 +126,7 @@ exports[`options validate should throw an error on the "client" option with '{"w
    Details:
     * options.client.webSocketTransport should be one of these:
       \\"sockjs\\" | \\"ws\\" | non-empty string
-      -> Allows to set custom transport to communicate with dev server.
+      -> Allows to set custom web socket transport to communicate with dev server.
       Details:
        * options.client.webSocketTransport should be one of these:
          \\"sockjs\\" | \\"ws\\"

--- a/test/__snapshots__/validate-options.test.js.snap.webpack4
+++ b/test/__snapshots__/validate-options.test.js.snap.webpack4
@@ -76,7 +76,7 @@ exports[`options validate should throw an error on the "client" option with '{"l
 exports[`options validate should throw an error on the "client" option with '{"overlay":""}' value 1`] = `
 "ValidationError: Invalid options object. Dev Server has been initialized using an options object that does not match the API schema.
  - options.client should be one of these:
-   false | object { logging?, overlay?, progress?, transport?, webSocketURL? }
+   false | object { logging?, overlay?, progress?, webSocketTransport?, webSocketURL? }
    -> Allows to specify options for client script in the browser or disable client script. https://webpack.js.org/configuration/dev-server/#devserverclient
    Details:
     * options.client.overlay should be one of these:
@@ -112,25 +112,25 @@ exports[`options validate should throw an error on the "client" option with '{"p
    -> Prints compilation progress in percentage in the browser."
 `;
 
-exports[`options validate should throw an error on the "client" option with '{"transport":true}' value 1`] = `
-"ValidationError: Invalid options object. Dev Server has been initialized using an options object that does not match the API schema.
- - options.client should be one of these:
-   false | object { logging?, overlay?, progress?, transport?, webSocketURL? }
-   -> Allows to specify options for client script in the browser or disable client script. https://webpack.js.org/configuration/dev-server/#devserverclient
-   Details:
-    * options.client.transport should be one of these:
-      \\"sockjs\\" | \\"ws\\" | non-empty string
-      -> Allows to set custom transport to communicate with dev server.
-      Details:
-       * options.client.transport should be one of these:
-         \\"sockjs\\" | \\"ws\\"
-       * options.client.transport should be a non-empty string."
-`;
-
 exports[`options validate should throw an error on the "client" option with '{"unknownOption":true}' value 1`] = `
 "ValidationError: Invalid options object. Dev Server has been initialized using an options object that does not match the API schema.
  - options.client has an unknown property 'unknownOption'. These properties are valid:
-   object { logging?, overlay?, progress?, transport?, webSocketURL? }"
+   object { logging?, overlay?, progress?, webSocketTransport?, webSocketURL? }"
+`;
+
+exports[`options validate should throw an error on the "client" option with '{"webSocketTransport":true}' value 1`] = `
+"ValidationError: Invalid options object. Dev Server has been initialized using an options object that does not match the API schema.
+ - options.client should be one of these:
+   false | object { logging?, overlay?, progress?, webSocketTransport?, webSocketURL? }
+   -> Allows to specify options for client script in the browser or disable client script. https://webpack.js.org/configuration/dev-server/#devserverclient
+   Details:
+    * options.client.webSocketTransport should be one of these:
+      \\"sockjs\\" | \\"ws\\" | non-empty string
+      -> Allows to set custom transport to communicate with dev server.
+      Details:
+       * options.client.webSocketTransport should be one of these:
+         \\"sockjs\\" | \\"ws\\"
+       * options.client.webSocketTransport should be a non-empty string."
 `;
 
 exports[`options validate should throw an error on the "client" option with '{"webSocketURL":{"hostname":""}}' value 1`] = `
@@ -159,7 +159,7 @@ exports[`options validate should throw an error on the "client" option with '{"w
 exports[`options validate should throw an error on the "client" option with '{"webSocketURL":{"port":true}}' value 1`] = `
 "ValidationError: Invalid options object. Dev Server has been initialized using an options object that does not match the API schema.
  - options.client should be one of these:
-   false | object { logging?, overlay?, progress?, transport?, webSocketURL? }
+   false | object { logging?, overlay?, progress?, webSocketTransport?, webSocketURL? }
    -> Allows to specify options for client script in the browser or disable client script. https://webpack.js.org/configuration/dev-server/#devserverclient
    Details:
     * options.client.webSocketURL.port should be one of these:
@@ -173,7 +173,7 @@ exports[`options validate should throw an error on the "client" option with '{"w
 exports[`options validate should throw an error on the "client" option with '{"webSocketURL":{"username":123,"password":976}}' value 1`] = `
 "ValidationError: Invalid options object. Dev Server has been initialized using an options object that does not match the API schema.
  - options.client should be one of these:
-   false | object { logging?, overlay?, progress?, transport?, webSocketURL? }
+   false | object { logging?, overlay?, progress?, webSocketTransport?, webSocketURL? }
    -> Allows to specify options for client script in the browser or disable client script. https://webpack.js.org/configuration/dev-server/#devserverclient
    Details:
     * options.client.webSocketURL.password should be a string.
@@ -185,12 +185,12 @@ exports[`options validate should throw an error on the "client" option with '{"w
 exports[`options validate should throw an error on the "client" option with 'whoops!' value 1`] = `
 "ValidationError: Invalid options object. Dev Server has been initialized using an options object that does not match the API schema.
  - options.client should be one of these:
-   false | object { logging?, overlay?, progress?, transport?, webSocketURL? }
+   false | object { logging?, overlay?, progress?, webSocketTransport?, webSocketURL? }
    -> Allows to specify options for client script in the browser or disable client script. https://webpack.js.org/configuration/dev-server/#devserverclient
    Details:
     * options.client should be false.
     * options.client should be an object:
-      object { logging?, overlay?, progress?, transport?, webSocketURL? }"
+      object { logging?, overlay?, progress?, webSocketTransport?, webSocketURL? }"
 `;
 
 exports[`options validate should throw an error on the "compress" option with '' value 1`] = `

--- a/test/__snapshots__/validate-options.test.js.snap.webpack5
+++ b/test/__snapshots__/validate-options.test.js.snap.webpack5
@@ -126,7 +126,7 @@ exports[`options validate should throw an error on the "client" option with '{"w
    Details:
     * options.client.webSocketTransport should be one of these:
       \\"sockjs\\" | \\"ws\\" | non-empty string
-      -> Allows to set custom transport to communicate with dev server.
+      -> Allows to set custom web socket transport to communicate with dev server.
       Details:
        * options.client.webSocketTransport should be one of these:
          \\"sockjs\\" | \\"ws\\"

--- a/test/__snapshots__/validate-options.test.js.snap.webpack5
+++ b/test/__snapshots__/validate-options.test.js.snap.webpack5
@@ -76,7 +76,7 @@ exports[`options validate should throw an error on the "client" option with '{"l
 exports[`options validate should throw an error on the "client" option with '{"overlay":""}' value 1`] = `
 "ValidationError: Invalid options object. Dev Server has been initialized using an options object that does not match the API schema.
  - options.client should be one of these:
-   false | object { logging?, overlay?, progress?, transport?, webSocketURL? }
+   false | object { logging?, overlay?, progress?, webSocketTransport?, webSocketURL? }
    -> Allows to specify options for client script in the browser or disable client script. https://webpack.js.org/configuration/dev-server/#devserverclient
    Details:
     * options.client.overlay should be one of these:
@@ -112,25 +112,25 @@ exports[`options validate should throw an error on the "client" option with '{"p
    -> Prints compilation progress in percentage in the browser."
 `;
 
-exports[`options validate should throw an error on the "client" option with '{"transport":true}' value 1`] = `
-"ValidationError: Invalid options object. Dev Server has been initialized using an options object that does not match the API schema.
- - options.client should be one of these:
-   false | object { logging?, overlay?, progress?, transport?, webSocketURL? }
-   -> Allows to specify options for client script in the browser or disable client script. https://webpack.js.org/configuration/dev-server/#devserverclient
-   Details:
-    * options.client.transport should be one of these:
-      \\"sockjs\\" | \\"ws\\" | non-empty string
-      -> Allows to set custom transport to communicate with dev server.
-      Details:
-       * options.client.transport should be one of these:
-         \\"sockjs\\" | \\"ws\\"
-       * options.client.transport should be a non-empty string."
-`;
-
 exports[`options validate should throw an error on the "client" option with '{"unknownOption":true}' value 1`] = `
 "ValidationError: Invalid options object. Dev Server has been initialized using an options object that does not match the API schema.
  - options.client has an unknown property 'unknownOption'. These properties are valid:
-   object { logging?, overlay?, progress?, transport?, webSocketURL? }"
+   object { logging?, overlay?, progress?, webSocketTransport?, webSocketURL? }"
+`;
+
+exports[`options validate should throw an error on the "client" option with '{"webSocketTransport":true}' value 1`] = `
+"ValidationError: Invalid options object. Dev Server has been initialized using an options object that does not match the API schema.
+ - options.client should be one of these:
+   false | object { logging?, overlay?, progress?, webSocketTransport?, webSocketURL? }
+   -> Allows to specify options for client script in the browser or disable client script. https://webpack.js.org/configuration/dev-server/#devserverclient
+   Details:
+    * options.client.webSocketTransport should be one of these:
+      \\"sockjs\\" | \\"ws\\" | non-empty string
+      -> Allows to set custom transport to communicate with dev server.
+      Details:
+       * options.client.webSocketTransport should be one of these:
+         \\"sockjs\\" | \\"ws\\"
+       * options.client.webSocketTransport should be a non-empty string."
 `;
 
 exports[`options validate should throw an error on the "client" option with '{"webSocketURL":{"hostname":""}}' value 1`] = `
@@ -159,7 +159,7 @@ exports[`options validate should throw an error on the "client" option with '{"w
 exports[`options validate should throw an error on the "client" option with '{"webSocketURL":{"port":true}}' value 1`] = `
 "ValidationError: Invalid options object. Dev Server has been initialized using an options object that does not match the API schema.
  - options.client should be one of these:
-   false | object { logging?, overlay?, progress?, transport?, webSocketURL? }
+   false | object { logging?, overlay?, progress?, webSocketTransport?, webSocketURL? }
    -> Allows to specify options for client script in the browser or disable client script. https://webpack.js.org/configuration/dev-server/#devserverclient
    Details:
     * options.client.webSocketURL.port should be one of these:
@@ -173,7 +173,7 @@ exports[`options validate should throw an error on the "client" option with '{"w
 exports[`options validate should throw an error on the "client" option with '{"webSocketURL":{"username":123,"password":976}}' value 1`] = `
 "ValidationError: Invalid options object. Dev Server has been initialized using an options object that does not match the API schema.
  - options.client should be one of these:
-   false | object { logging?, overlay?, progress?, transport?, webSocketURL? }
+   false | object { logging?, overlay?, progress?, webSocketTransport?, webSocketURL? }
    -> Allows to specify options for client script in the browser or disable client script. https://webpack.js.org/configuration/dev-server/#devserverclient
    Details:
     * options.client.webSocketURL.password should be a string.
@@ -185,12 +185,12 @@ exports[`options validate should throw an error on the "client" option with '{"w
 exports[`options validate should throw an error on the "client" option with 'whoops!' value 1`] = `
 "ValidationError: Invalid options object. Dev Server has been initialized using an options object that does not match the API schema.
  - options.client should be one of these:
-   false | object { logging?, overlay?, progress?, transport?, webSocketURL? }
+   false | object { logging?, overlay?, progress?, webSocketTransport?, webSocketURL? }
    -> Allows to specify options for client script in the browser or disable client script. https://webpack.js.org/configuration/dev-server/#devserverclient
    Details:
     * options.client should be false.
     * options.client should be an object:
-      object { logging?, overlay?, progress?, transport?, webSocketURL? }"
+      object { logging?, overlay?, progress?, webSocketTransport?, webSocketURL? }"
 `;
 
 exports[`options validate should throw an error on the "compress" option with '' value 1`] = `

--- a/test/cli/__snapshots__/basic.test.js.snap.webpack4
+++ b/test/cli/__snapshots__/basic.test.js.snap.webpack4
@@ -42,6 +42,7 @@ Options:
   --allowed-hosts-reset                     Clear all items provided in 'allowedHosts' configuration. Allows to enumerate the hosts from which access to the dev server are allowed (useful when you are proxying dev server, by default is 'auto'). https://webpack.js.org/configuration/dev-server/#devserverallowedhosts
   --bonjour                                 Allows to broadcasts dev server via ZeroConf networking on start. https://webpack.js.org/configuration/dev-server/#devserverbonjour
   --no-bonjour                              Disallows to broadcasts dev server via ZeroConf networking on start. https://webpack.js.org/configuration/dev-server/#devserverbonjour
+  --client-web-socket-transport <value>     Allows to set custom web socket transport to communicate with dev server.
   --no-client                               Negative 'client' option.
   --client-logging <value>                  Allows to specify options for client script in the browser or disable client script. https://webpack.js.org/configuration/dev-server/#devserverclient
   --client-progress                         Prints compilation progress in percentage in the browser.
@@ -52,7 +53,6 @@ Options:
   --no-client-overlay-errors                Negative 'client-overlay-errors' option.
   --client-overlay-warnings                 Enables a full-screen overlay in the browser when there are compiler warnings.
   --no-client-overlay-warnings              Negative 'client-overlay-warnings' option.
-  --client-web-socket-transport <value>     Allows to set custom web socket transport to communicate with dev server.
   --client-web-socket-url <value>           Allows to specify URL to web socket server (useful when you're proxying dev server and client script does not always know where to connect to).
   --client-web-socket-url-hostname <value>  Tells clients connected to devServer to use the provided hostname.
   --client-web-socket-url-port <value>      Tells clients connected to devServer to use the provided port.

--- a/test/cli/__snapshots__/basic.test.js.snap.webpack4
+++ b/test/cli/__snapshots__/basic.test.js.snap.webpack4
@@ -42,7 +42,6 @@ Options:
   --allowed-hosts-reset                     Clear all items provided in 'allowedHosts' configuration. Allows to enumerate the hosts from which access to the dev server are allowed (useful when you are proxying dev server, by default is 'auto'). https://webpack.js.org/configuration/dev-server/#devserverallowedhosts
   --bonjour                                 Allows to broadcasts dev server via ZeroConf networking on start. https://webpack.js.org/configuration/dev-server/#devserverbonjour
   --no-bonjour                              Disallows to broadcasts dev server via ZeroConf networking on start. https://webpack.js.org/configuration/dev-server/#devserverbonjour
-  --client-transport <value>                Allows to set custom transport to communicate with dev server.
   --no-client                               Negative 'client' option.
   --client-logging <value>                  Allows to specify options for client script in the browser or disable client script. https://webpack.js.org/configuration/dev-server/#devserverclient
   --client-progress                         Prints compilation progress in percentage in the browser.
@@ -53,6 +52,7 @@ Options:
   --no-client-overlay-errors                Negative 'client-overlay-errors' option.
   --client-overlay-warnings                 Enables a full-screen overlay in the browser when there are compiler warnings.
   --no-client-overlay-warnings              Negative 'client-overlay-warnings' option.
+  --client-web-socket-transport <value>     Allows to set custom web socket transport to communicate with dev server.
   --client-web-socket-url <value>           Allows to specify URL to web socket server (useful when you're proxying dev server and client script does not always know where to connect to).
   --client-web-socket-url-hostname <value>  Tells clients connected to devServer to use the provided hostname.
   --client-web-socket-url-port <value>      Tells clients connected to devServer to use the provided port.

--- a/test/cli/__snapshots__/basic.test.js.snap.webpack5
+++ b/test/cli/__snapshots__/basic.test.js.snap.webpack5
@@ -53,7 +53,7 @@ Options:
   --no-client-overlay-warnings              Negative 'client-overlay-warnings' option.
   --client-progress                         Prints compilation progress in percentage in the browser.
   --no-client-progress                      Negative 'client-progress' option.
-  --client-transport <value>                Allows to set custom transport to communicate with dev server.
+  --client-web-socket-transport <value>     Allows to set custom web socket transport to communicate with dev server.
   --client-web-socket-url <value>           Allows to specify URL to web socket server (useful when you're proxying dev server and client script does not always know where to connect to).
   --client-web-socket-url-hostname <value>  Tells clients connected to devServer to use the provided hostname.
   --client-web-socket-url-pathname <value>  Tells clients connected to devServer to use the provided path to connect.

--- a/test/cli/client-option.test.js
+++ b/test/cli/client-option.test.js
@@ -4,22 +4,22 @@ const { testBin } = require('../helpers/test-bin');
 const port = require('../ports-map')['cli-client'];
 
 describe('"client" CLI option', () => {
-  it('should work using "--client-transport sockjs"', async () => {
+  it('should work using "--client-web-socket-transport sockjs"', async () => {
     const { exitCode } = await testBin([
       '--port',
       port,
-      '--client-transport',
+      '--client-web-socket-transport',
       'sockjs',
     ]);
 
     expect(exitCode).toEqual(0);
   });
 
-  it('should work using "--client-transport ws"', async () => {
+  it('should work using "--client-web-socket-transport ws"', async () => {
     const { exitCode } = await testBin([
       '--port',
       port,
-      '--client-transport',
+      '--client-web-socket-transport',
       'ws',
     ]);
 

--- a/test/e2e/__snapshots__/web-socket-server-and-transport.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/web-socket-server-and-transport.test.js.snap.webpack4
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`web socket server and transport should throw an error on wrong path 1`] = `"When you use custom web socket implementation you must explicitly specify client.transport. client.transport must be a string denoting a default implementation (e.g. 'sockjs', 'ws') or a full path to a JS file via require.resolve(...) which exports a class "`;
+exports[`web socket server and transport should throw an error on wrong path 1`] = `"When you use custom web socket implementation you must explicitly specify client.webSocketTransport. client.webSocketTransport must be a string denoting a default implementation (e.g. 'sockjs', 'ws') or a full path to a JS file via require.resolve(...) which exports a class "`;
 
 exports[`web socket server and transport should use "sockjs" transport and "sockjs" web socket server 1`] = `
 Array [

--- a/test/e2e/__snapshots__/web-socket-server-and-transport.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/web-socket-server-and-transport.test.js.snap.webpack5
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`web socket server and transport should throw an error on wrong path 1`] = `"When you use custom web socket implementation you must explicitly specify client.transport. client.transport must be a string denoting a default implementation (e.g. 'sockjs', 'ws') or a full path to a JS file via require.resolve(...) which exports a class "`;
+exports[`web socket server and transport should throw an error on wrong path 1`] = `"When you use custom web socket implementation you must explicitly specify client.webSocketTransport. client.webSocketTransport must be a string denoting a default implementation (e.g. 'sockjs', 'ws') or a full path to a JS file via require.resolve(...) which exports a class "`;
 
 exports[`web socket server and transport should use "sockjs" transport and "sockjs" web socket server 1`] = `
 Array [

--- a/test/e2e/web-socket-server-and-transport.test.js
+++ b/test/e2e/web-socket-server-and-transport.test.js
@@ -259,7 +259,7 @@ describe('web socket server and transport', () => {
     const devServerOptions = {
       port,
       client: {
-        transport: 'ws',
+        webSocketTransport: 'ws',
       },
       webSocketServer: WebsocketServer,
     };
@@ -310,7 +310,7 @@ describe('web socket server and transport', () => {
     const devServerOptions = {
       port,
       client: {
-        transport: 'ws',
+        webSocketTransport: 'ws',
       },
       webSocketServer: {
         type: WebsocketServer,
@@ -363,7 +363,7 @@ describe('web socket server and transport', () => {
     const devServerOptions = {
       port,
       client: {
-        transport: 'ws',
+        webSocketTransport: 'ws',
       },
       webSocketServer: require.resolve('../../lib/servers/WebsocketServer'),
     };
@@ -414,7 +414,7 @@ describe('web socket server and transport', () => {
     const devServerOptions = {
       port,
       client: {
-        transport: 'ws',
+        webSocketTransport: 'ws',
       },
       webSocketServer: {
         type: require.resolve('../../lib/servers/WebsocketServer'),
@@ -497,7 +497,7 @@ describe('web socket server and transport', () => {
     const devServerOptions = {
       port,
       client: {
-        transport: 'sockjs',
+        webSocketTransport: 'sockjs',
       },
     };
     const server = new Server(devServerOptions, compiler);
@@ -547,7 +547,7 @@ describe('web socket server and transport', () => {
     const devServerOptions = {
       port,
       client: {
-        transport: 'ws',
+        webSocketTransport: 'ws',
       },
     };
     const server = new Server(devServerOptions, compiler);
@@ -597,7 +597,7 @@ describe('web socket server and transport', () => {
     const devServerOptions = {
       port,
       client: {
-        transport: 'sockjs',
+        webSocketTransport: 'sockjs',
       },
       webSocketServer: 'sockjs',
     };
@@ -648,7 +648,7 @@ describe('web socket server and transport', () => {
     const devServerOptions = {
       port,
       client: {
-        transport: 'ws',
+        webSocketTransport: 'ws',
       },
       webSocketServer: 'ws',
     };
@@ -699,7 +699,7 @@ describe('web socket server and transport', () => {
     const devServerOptions = {
       port,
       client: {
-        transport: require.resolve(
+        webSocketTransport: require.resolve(
           '../fixtures/custom-client/CustomSockJSClient'
         ),
       },

--- a/test/server/client-option.test.js
+++ b/test/server/client-option.test.js
@@ -17,7 +17,7 @@ describe('client option', () => {
       server = new Server(
         {
           client: {
-            transport: 'sockjs',
+            webSocketTransport: 'sockjs',
           },
           webSocketServer: 'sockjs',
           port,
@@ -68,7 +68,7 @@ describe('client option', () => {
       server = new Server(
         {
           client: {
-            transport: 'sockjs',
+            webSocketTransport: 'sockjs',
           },
           webSocketServer: {
             type: 'sockjs',
@@ -183,12 +183,12 @@ describe('client option', () => {
     });
   });
 
-  describe('transport', () => {
+  describe('webSocketTransport', () => {
     const clientModes = [
       {
         title: 'as a string ("sockjs")',
         client: {
-          transport: 'sockjs',
+          webSocketTransport: 'sockjs',
         },
         webSocketServer: 'sockjs',
         shouldThrow: false,
@@ -196,7 +196,9 @@ describe('client option', () => {
       {
         title: 'as a path ("sockjs")',
         client: {
-          transport: require.resolve('../../client-src/clients/SockJSClient'),
+          webSocketTransport: require.resolve(
+            '../../client-src/clients/SockJSClient'
+          ),
         },
         webSocketServer: 'sockjs',
         shouldThrow: false,
@@ -204,7 +206,7 @@ describe('client option', () => {
       {
         title: 'as a nonexistent path',
         client: {
-          transport: '/bad/path/to/implementation',
+          webSocketTransport: '/bad/path/to/implementation',
         },
         webSocketServer: 'sockjs',
         shouldThrow: true,
@@ -246,7 +248,7 @@ describe('client option', () => {
 
           if (data.shouldThrow) {
             expect(thrownError.message).toMatch(
-              /client\.transport must be a string/
+              /client\.webSocketTransport must be a string/
             );
           }
 

--- a/test/server/utils/DevServerPlugin.test.js
+++ b/test/server/utils/DevServerPlugin.test.js
@@ -18,7 +18,7 @@ describe('DevServerPlugin util', () => {
     const compiler = webpack(webpackOptions);
     const devServerOptions = {
       client: {
-        transport: 'sockjs',
+        webSocketTransport: 'sockjs',
         webSocketURL: {},
       },
       webSocketServer: {
@@ -40,7 +40,7 @@ describe('DevServerPlugin util', () => {
     const compiler = webpack(webpackOptions);
     const devServerOptions = {
       client: {
-        transport: 'sockjs',
+        webSocketTransport: 'sockjs',
         webSocketURL: {},
       },
       webSocketServer: {
@@ -67,7 +67,7 @@ describe('DevServerPlugin util', () => {
     const compiler = webpack(webpackOptions);
     const devServerOptions = {
       client: {
-        transport: 'sockjs',
+        webSocketTransport: 'sockjs',
         webSocketURL: {},
       },
       webSocketServer: {
@@ -94,7 +94,7 @@ describe('DevServerPlugin util', () => {
     const devServerOptions = {
       hot: true,
       client: {
-        transport: 'sockjs',
+        webSocketTransport: 'sockjs',
         webSocketURL: {},
       },
       webSocketServer: {
@@ -122,7 +122,7 @@ describe('DevServerPlugin util', () => {
       const devServerOptions = {
         hot: true,
         client: {
-          transport: 'sockjs',
+          webSocketTransport: 'sockjs',
           webSocketURL: {},
         },
         webSocketServer: {
@@ -155,13 +155,13 @@ describe('DevServerPlugin util', () => {
   );
 
   describe('getWebsocketTransport', () => {
-    it("should work with client.transport: 'sockjs'", () => {
+    it("should work with client.webSocketTransport: 'sockjs'", () => {
       let result;
 
       expect(() => {
         const devServerPlugin = new DevServerPlugin({
           client: {
-            transport: 'sockjs',
+            webSocketTransport: 'sockjs',
           },
           webSocketServer: 'sockjs',
         });
@@ -172,13 +172,13 @@ describe('DevServerPlugin util', () => {
       expect(result).toEqual(sockjsClientPath);
     });
 
-    it('should work with client.transport: SockJSClient full path', () => {
+    it('should work with client.webSocketTransport: SockJSClient full path', () => {
       let result;
 
       expect(() => {
         const devServerPlugin = new DevServerPlugin({
           client: {
-            transport: sockjsClientPath,
+            webSocketTransport: sockjsClientPath,
           },
           webSocketServer: 'sockjs',
         });
@@ -189,44 +189,44 @@ describe('DevServerPlugin util', () => {
       expect(result).toEqual(sockjsClientPath);
     });
 
-    it('should throw with client.transport: bad path', () => {
+    it('should throw with client.webSocketTransport: bad path', () => {
       expect(() => {
         const devServerPlugin = new DevServerPlugin({
           client: {
-            transport: '/bad/path/to/implementation',
+            webSocketTransport: '/bad/path/to/implementation',
           },
           webSocketServer: 'sockjs',
         });
 
         devServerPlugin.getWebsocketTransport();
-      }).toThrow(/client.transport must be a string/);
+      }).toThrow(/client.webSocketTransport must be a string/);
     });
 
-    it('should throw with transportMode.client: bad type', () => {
+    it('should throw with webSocketTransportMode.client: bad type', () => {
       expect(() => {
         const devServerPlugin = new DevServerPlugin({
           client: {
-            transport: 1,
+            webSocketTransport: 1,
           },
           webSocketServer: 'sockjs',
         });
 
         devServerPlugin.getWebsocketTransport();
-      }).toThrow(/client.transport must be a string/);
+      }).toThrow(/client.webSocketTransport must be a string/);
     });
 
-    it('should throw with client.transport: unimplemented client', () => {
+    it('should throw with client.webSocketTransport: unimplemented client', () => {
       expect(() => {
         const devServerPlugin = new DevServerPlugin({
           client: {
-            transport: 'foo',
+            webSocketTransport: 'foo',
           },
           webSocketServer: 'sockjs',
         });
 
         devServerPlugin.getWebsocketTransport();
       }).toThrow(
-        'When you use custom web socket implementation you must explicitly specify client.transport'
+        'When you use custom web socket implementation you must explicitly specify client.webSocketTransport'
       );
     });
   });

--- a/test/server/utils/__snapshots__/normalizeOptions.test.js.snap.webpack4
+++ b/test/server/utils/__snapshots__/normalizeOptions.test.js.snap.webpack4
@@ -35,12 +35,12 @@ Object {
 }
 `;
 
-exports[`normalizeOptions client custom transport path should set correct options 1`] = `
+exports[`normalizeOptions client custom webSocketTransport path should set correct options 1`] = `
 Object {
   "allowedHosts": "auto",
   "client": Object {
     "overlay": true,
-    "transport": "/path/to/custom/client/",
+    "webSocketTransport": "/path/to/custom/client/",
     "webSocketURL": Object {},
   },
   "compress": true,
@@ -221,12 +221,12 @@ Object {
 }
 `;
 
-exports[`normalizeOptions client.transport sockjs string should set correct options 1`] = `
+exports[`normalizeOptions client.webSocketTransport sockjs string should set correct options 1`] = `
 Object {
   "allowedHosts": "auto",
   "client": Object {
     "overlay": true,
-    "transport": "sockjs",
+    "webSocketTransport": "sockjs",
     "webSocketURL": Object {},
   },
   "compress": true,
@@ -257,12 +257,12 @@ Object {
 }
 `;
 
-exports[`normalizeOptions client.transport ws string and webSocketServer object should set correct options 1`] = `
+exports[`normalizeOptions client.webSocketTransport ws string and webSocketServer object should set correct options 1`] = `
 Object {
   "allowedHosts": "auto",
   "client": Object {
     "overlay": true,
-    "transport": "ws",
+    "webSocketTransport": "ws",
     "webSocketURL": Object {},
   },
   "compress": true,
@@ -295,12 +295,12 @@ Object {
 }
 `;
 
-exports[`normalizeOptions client.transport ws string and webSocketServer object with port as string should set correct options 1`] = `
+exports[`normalizeOptions client.webSocketTransport ws string and webSocketServer object with port as string should set correct options 1`] = `
 Object {
   "allowedHosts": "auto",
   "client": Object {
     "overlay": true,
-    "transport": "ws",
+    "webSocketTransport": "ws",
     "webSocketURL": Object {},
   },
   "compress": true,
@@ -333,12 +333,12 @@ Object {
 }
 `;
 
-exports[`normalizeOptions client.transport ws string and webSocketServer ws string should set correct options 1`] = `
+exports[`normalizeOptions client.webSocketTransport ws string and webSocketServer ws string should set correct options 1`] = `
 Object {
   "allowedHosts": "auto",
   "client": Object {
     "overlay": true,
-    "transport": "ws",
+    "webSocketTransport": "ws",
     "webSocketURL": Object {},
   },
   "compress": true,
@@ -369,12 +369,12 @@ Object {
 }
 `;
 
-exports[`normalizeOptions client.transport ws string should set correct options 1`] = `
+exports[`normalizeOptions client.webSocketTransport ws string should set correct options 1`] = `
 Object {
   "allowedHosts": "auto",
   "client": Object {
     "overlay": true,
-    "transport": "ws",
+    "webSocketTransport": "ws",
     "webSocketURL": Object {},
   },
   "compress": true,

--- a/test/server/utils/__snapshots__/normalizeOptions.test.js.snap.webpack5
+++ b/test/server/utils/__snapshots__/normalizeOptions.test.js.snap.webpack5
@@ -35,12 +35,12 @@ Object {
 }
 `;
 
-exports[`normalizeOptions client custom transport path should set correct options 1`] = `
+exports[`normalizeOptions client custom webSocketTransport path should set correct options 1`] = `
 Object {
   "allowedHosts": "auto",
   "client": Object {
     "overlay": true,
-    "transport": "/path/to/custom/client/",
+    "webSocketTransport": "/path/to/custom/client/",
     "webSocketURL": Object {},
   },
   "compress": true,
@@ -221,12 +221,12 @@ Object {
 }
 `;
 
-exports[`normalizeOptions client.transport sockjs string should set correct options 1`] = `
+exports[`normalizeOptions client.webSocketTransport sockjs string should set correct options 1`] = `
 Object {
   "allowedHosts": "auto",
   "client": Object {
     "overlay": true,
-    "transport": "sockjs",
+    "webSocketTransport": "sockjs",
     "webSocketURL": Object {},
   },
   "compress": true,
@@ -257,12 +257,12 @@ Object {
 }
 `;
 
-exports[`normalizeOptions client.transport ws string and webSocketServer object should set correct options 1`] = `
+exports[`normalizeOptions client.webSocketTransport ws string and webSocketServer object should set correct options 1`] = `
 Object {
   "allowedHosts": "auto",
   "client": Object {
     "overlay": true,
-    "transport": "ws",
+    "webSocketTransport": "ws",
     "webSocketURL": Object {},
   },
   "compress": true,
@@ -295,12 +295,12 @@ Object {
 }
 `;
 
-exports[`normalizeOptions client.transport ws string and webSocketServer object with port as string should set correct options 1`] = `
+exports[`normalizeOptions client.webSocketTransport ws string and webSocketServer object with port as string should set correct options 1`] = `
 Object {
   "allowedHosts": "auto",
   "client": Object {
     "overlay": true,
-    "transport": "ws",
+    "webSocketTransport": "ws",
     "webSocketURL": Object {},
   },
   "compress": true,
@@ -333,12 +333,12 @@ Object {
 }
 `;
 
-exports[`normalizeOptions client.transport ws string and webSocketServer ws string should set correct options 1`] = `
+exports[`normalizeOptions client.webSocketTransport ws string and webSocketServer ws string should set correct options 1`] = `
 Object {
   "allowedHosts": "auto",
   "client": Object {
     "overlay": true,
-    "transport": "ws",
+    "webSocketTransport": "ws",
     "webSocketURL": Object {},
   },
   "compress": true,
@@ -369,12 +369,12 @@ Object {
 }
 `;
 
-exports[`normalizeOptions client.transport ws string should set correct options 1`] = `
+exports[`normalizeOptions client.webSocketTransport ws string should set correct options 1`] = `
 Object {
   "allowedHosts": "auto",
   "client": Object {
     "overlay": true,
-    "transport": "ws",
+    "webSocketTransport": "ws",
     "webSocketURL": Object {},
   },
   "compress": true,

--- a/test/server/utils/normalizeOptions.test.js
+++ b/test/server/utils/normalizeOptions.test.js
@@ -21,31 +21,32 @@ describe('normalizeOptions', () => {
       optionsResults: null,
     },
     {
-      title: 'client.transport sockjs string',
+      title: 'client.webSocketTransport sockjs string',
       multiCompiler: false,
       options: {
         client: {
-          transport: 'sockjs',
+          webSocketTransport: 'sockjs',
         },
       },
       optionsResults: null,
     },
     {
-      title: 'client.transport ws string',
+      title: 'client.webSocketTransport ws string',
       multiCompiler: false,
       options: {
         client: {
-          transport: 'ws',
+          webSocketTransport: 'ws',
         },
       },
       optionsResults: null,
     },
     {
-      title: 'client.transport ws string and webSocketServer ws string',
+      title:
+        'client.webSocketTransport ws string and webSocketServer ws string',
       multiCompiler: false,
       options: {
         client: {
-          transport: 'ws',
+          webSocketTransport: 'ws',
         },
         webSocketServer: 'ws',
       },
@@ -68,11 +69,11 @@ describe('normalizeOptions', () => {
       optionsResults: null,
     },
     {
-      title: 'client.transport ws string and webSocketServer object',
+      title: 'client.webSocketTransport ws string and webSocketServer object',
       multiCompiler: false,
       options: {
         client: {
-          transport: 'ws',
+          webSocketTransport: 'ws',
         },
         webSocketServer: {
           type: 'ws',
@@ -87,11 +88,11 @@ describe('normalizeOptions', () => {
     },
     {
       title:
-        'client.transport ws string and webSocketServer object with port as string',
+        'client.webSocketTransport ws string and webSocketServer object with port as string',
       multiCompiler: false,
       options: {
         client: {
-          transport: 'ws',
+          webSocketTransport: 'ws',
         },
         webSocketServer: {
           type: 'ws',
@@ -105,11 +106,11 @@ describe('normalizeOptions', () => {
       optionsResults: null,
     },
     {
-      title: 'client custom transport path',
+      title: 'client custom webSocketTransport path',
       multiCompiler: false,
       options: {
         client: {
-          transport: '/path/to/custom/client/',
+          webSocketTransport: '/path/to/custom/client/',
         },
       },
       optionsResults: null,

--- a/test/server/webSocketServer-option.test.js
+++ b/test/server/webSocketServer-option.test.js
@@ -33,7 +33,7 @@ describe('webSocketServer', () => {
             config,
             {
               port,
-              client: { transport: 'sockjs' },
+              client: { webSocketTransport: 'sockjs' },
               webSocketServer: class MySockJSServer extends BaseServer {
                 constructor(serv) {
                   super(serv);
@@ -143,7 +143,7 @@ describe('webSocketServer', () => {
             config,
             {
               port,
-              client: { transport: 'sockjs' },
+              client: { webSocketTransport: 'sockjs' },
               webSocketServer: class MySockJSServer extends BaseServer {
                 constructor(serv) {
                   super(serv);

--- a/test/validate-options.test.js
+++ b/test/validate-options.test.js
@@ -67,10 +67,10 @@ const tests = {
         },
       },
       {
-        transport: 'sockjs',
+        webSocketTransport: 'sockjs',
       },
       {
-        transport: require.resolve('../client/clients/SockJSClient'),
+        webSocketTransport: require.resolve('../client/clients/SockJSClient'),
       },
       {
         webSocketURL: 'ws://localhost:8080',
@@ -134,7 +134,7 @@ const tests = {
         },
       },
       {
-        transport: true,
+        webSocketTransport: true,
       },
       {
         webSocketURL: { hostname: true, pathname: '', port: 8080 },


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [ ] This is a **bugfix**
- [ ] This is a **feature**
- [X] This is a **code refactor**
- [X] This is a **test update**
- [X] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?
Yes
<!-- Please note that we won't approve your changes if you don't add tests. -->

### Motivation / Use-Case
remove `client.transport` in favor of `client.webSocketTransPort`
<!--
  What existing problem does the pull request solve?

  Please explain the motivation or use-case for making this change.
  If this Pull Request addresses an issue, please link to the issue.
-->

### Breaking Changes
yes, `client.transport` was removed in favor of `client.webSocketTransPort`
<!--
  If this PR introduces a breaking change, please describe the impact and a
  potential migration path for existing applications.
-->

### Additional Info
None