### PR TITLE
fix: get rid of Symbol core-js polyfill

### DIFF
--- a/client-src/modules/logger/index.js
+++ b/client-src/modules/logger/index.js
@@ -1,6 +1,3 @@
 'use strict';
 
-// eslint-disable-next-line import/no-extraneous-dependencies
-require('core-js/stable/symbol');
-
 module.exports = require('webpack/lib/logging/runtime');

--- a/client-src/webpack.config.js
+++ b/client-src/webpack.config.js
@@ -48,6 +48,10 @@ module.exports = [
       ],
     },
     plugins: [
+      new webpack.DefinePlugin({
+        Symbol:
+          '(typeof Symbol !== "undefined" ? Symbol : function (i) { return i; })',
+      }),
       new webpack.NormalModuleReplacementPlugin(
         /^tapable\/lib\/SyncBailHook/,
         path.join(__dirname, 'modules/logger/SyncBailHookFake.js')


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [x] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

Tested manually

### Motivation / Use-Case

Avoid Symbol use when they are not supported

### Breaking Changes

No

### Additional Info

fixed #3502