### PR TITLE
chore: warning when proxy property is undefined

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -832,6 +832,9 @@ class Server {
       if (proxyConfig.target) {
         return createProxyMiddleware(context, proxyConfig);
       }
+      this.logger.warn(
+        `The "target" value specified in the "proxy" property ${context} is not defined and will be skipped.`
+      );
     };
     /**
      * Assume a proxy configuration specified as:


### PR DESCRIPTION
- [ ] This is a **bugfix**
- [x?] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

No

### Motivation / Use-Case

When the `proxy` property target is undefined, the user doesn't know, and it's nice to know its being skipped.

### Breaking Changes
No

### Additional Info

:)
