### PR TITLE
fix: update webpack peer dependency to ^4.37.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "webpack-merge": "^5.8.0"
   },
   "peerDependencies": {
-    "webpack": "^4.0.0 || ^5.0.0"
+    "webpack": "^4.37.0 || ^5.0.0"
   },
   "peerDependenciesMeta": {
     "webpack-cli": {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [ ] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [x] This is a **metadata update**

### For Bugs and Features; did you add new tests?

No, this is a metadata update.

### Motivation / Use-Case

When webpack-dev-server is run on any webpack version < 4.37, this error appears.

    [webpack-cli] TypeError: compiler.getInfrastructureLogger is not a function

This is because `compiler.getInfrastructureLogger` is introduced in webpack v4.37, therefore webpack-dev-server is not compatible with any version of webpack below it.

<!--
  What existing problem does the pull request solve?

  Please explain the motivation or use-case for making this change.
  If this Pull Request addresses an issue, please link to the issue.
-->

### Breaking Changes

None.
<!--
  If this PR introduces a breaking change, please describe the impact and a
  potential migration path for existing applications.
-->

### Additional Info

We hit this error when using `webpack-dev-server@4.0.0-rc.0` with `webpack@4.33.0`.