### PR TITLE
docs: mention webpack-cli in migration docs

### DIFF
--- a/migration-v4.md
+++ b/migration-v4.md
@@ -6,6 +6,7 @@ This document serves as a migration guide for `webpack-dev-server@4.0.0`.
 
 - Minimum supported `Node.js` version is `12.13.0`.
 - Minimum supported `webpack` version is `4.37.0` (**but we so recommend using 5 version**).
+- Minimum compatible `webpack-cli` version is `4.4.0`.
 - The `hotOnly` option was removed, if you need hot only mode, use `{ hot: 'only' }` value.
 
 v3:


### PR DESCRIPTION
- [ ] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [x] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

n/a

### Motivation / Use-Case

Turns out, `webpack-cli@<=4.4.0` crashes on `webpack serve` command when used with `webpack-dev-server@4.0.0`. 
To prevent users from getting stuck or raising unnecessary bug reports, minimum compatible `webpack-cli` shall be mentioned in migration docs.

### Breaking Changes

n/a

### Additional Info

Crash on webpack-cli 4.2.0:

```
/node_modules/webpack-cli/lib/utils/arg-parser.js:59
    options.reduce((parserInstance, option) => {
            ^

TypeError: Cannot read property 'reduce' of undefined
    at argParser (/node_modules/webpack-cli/lib/utils/arg-parser.js:59:13)
    at WebpackCLI.argParser (/node_modules/webpack-cli/lib/webpack-cli.js:63:16)
    at Object.parseArgs [as default] (/node_modules/@webpack-cli/serve/lib/parseArgs.js:26:37)
    at serve (/node_modules/@webpack-cli/serve/lib/index.js:46:63)
    at run (/node_modules/webpack-cli/lib/utils/resolve-command.js:33:12)
    at Command.<anonymous> (/node_modules/webpack-cli/lib/utils/arg-parser.js:34:58)
    at Command.listener [as _actionHandler] (/node_modules/webpack-cli/node_modules/commander/index.js:426:31)
    at Command._parseCommand (/node_modules/webpack-cli/node_modules/commander/index.js:1002:14)
    at Command._dispatchSubcommand (/node_modules/webpack-cli/node_modules/commander/index.js:953:18)
    at Command._parseCommand (/node_modules/webpack-cli/node_modules/commander/index.js:970:12)
```

4.3.0 also produces an error:

```
[webpack-cli] Unable to load '@webpack-cli/serve' command
[webpack-cli] TypeError: devServerFlags is not iterable
    at /node_modules/@webpack-cli/serve/lib/index.js:28:43
    at WebpackCLI.makeCommand (/node_modules/webpack-cli/lib/webpack-cli.js:104:31)
    at ServeCommand.apply (/node_modules/@webpack-cli/serve/lib/index.js:10:19)
    at loadCommandByName (/node_modules/webpack-cli/lib/webpack-cli.js:626:35)
    at Command.<anonymous> (/node_modules/webpack-cli/lib/webpack-cli.js:1091:23)
    at Command.listener [as _actionHandler] (/node_modules/webpack-cli/node_modules/commander/index.js:922:31)
    at Command._parseCommand (/node_modules/webpack-cli/node_modules/commander/index.js:1503:14)
    at Command.parse (/node_modules/webpack-cli/node_modules/commander/index.js:1292:10)
    at Command.parseAsync (/node_modules/webpack-cli/node_modules/commander/index.js:1318:10)
    at WebpackCLI.run (/node_modules/webpack-cli/lib/webpack-cli.js:1123:28)
```
