### PR TITLE
test: use the corresponding port for built-in-routes test

### DIFF
--- a/test/e2e/built-in-routes.test.js
+++ b/test/e2e/built-in-routes.test.js
@@ -5,7 +5,7 @@ const Server = require("../../lib/Server");
 const config = require("../fixtures/client-config/webpack.config");
 const multiConfig = require("../fixtures/multi-public-path-config/webpack.config");
 const runBrowser = require("../helpers/run-browser");
-const port = require("../ports-map")["universal-compiler"];
+const port = require("../ports-map").routes;
 
 describe("Built in routes", () => {
   describe("with simple config", () => {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [ ] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [x] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?
No
<!-- Please note that we won't approve your changes if you don't add tests. -->

### Motivation / Use-Case

use the corresponding port for `built-in-routes.test.js`
<!--
  What existing problem does the pull request solve?

  Please explain the motivation or use-case for making this change.
  If this Pull Request addresses an issue, please link to the issue.
-->

### Breaking Changes
No
<!--
  If this PR introduces a breaking change, please describe the impact and a
  potential migration path for existing applications.
-->

### Additional Info
No