### PR TITLE
docs: mark webpack-cli 4.7.0 as min version for dev server v4

### DIFF
--- a/migration-v4.md
+++ b/migration-v4.md
@@ -12,7 +12,7 @@ This document serves as a migration guide for `webpack-dev-server@4.0.0`.
 
 - Minimum supported `Node.js` version is `12.13.0`.
 - Minimum supported `webpack` version is `4.37.0` (**but we so recommend using 5 version**).
-- Minimum compatible `webpack-cli` version is `4.4.0`.
+- Minimum compatible `webpack-cli` version is `4.7.0`.
 - The `hotOnly` option was removed, if you need hot only mode, use `{ hot: 'only' }` value.
 
 v3:


### PR DESCRIPTION
- [ ] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [x] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?
NA

### Motivation / Use-Case
It seems some problems with webpack-cli v4.6.0 so marking 4.7.0 as minimum supported version https://github.com/webpack/webpack-dev-server/pull/3682#issuecomment-903468936

### Breaking Changes
no

### Additional Info
