### PR TITLE
fix: show warning when `hot` is enabled with the HMR plugin in config

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -1056,16 +1056,20 @@ class Server {
       // TODO remove after drop webpack v4 support
       compiler.options.plugins = compiler.options.plugins || [];
 
-      if (
-        this.options.hot &&
-        !compiler.options.plugins.find(
+      if (this.options.hot) {
+        const HMRPluginExists = compiler.options.plugins.find(
           (p) => p.constructor === webpack.HotModuleReplacementPlugin
-        )
-      ) {
-        // apply the HMR plugin, if it didn't exist before.
-        const plugin = new webpack.HotModuleReplacementPlugin();
+        );
 
-        plugin.apply(compiler);
+        if (HMRPluginExists) {
+          this.logger.warn(
+            `"hot: true" automatically applies HMR plugin, you don't have to add it manually to your webpack configuration.`
+          );
+        } else {
+          // apply the HMR plugin
+          const plugin = new webpack.HotModuleReplacementPlugin();
+          plugin.apply(compiler);
+        }
       }
     });
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [x] This is a **bugfix**
- [ ] This is a **feature**
- [x] This is a **code refactor**
- [x] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?
WIP on tests.
<!-- Please note that we won't approve your changes if you don't add tests. -->

### Motivation / Use-Case

show users a warning when `hot` is enabled with the HMR plugin in the configuration
<!--
  What existing problem does the pull request solve?

  Please explain the motivation or use-case for making this change.
  If this Pull Request addresses an issue, please link to the issue.
-->

### Breaking Changes
None
<!--
  If this PR introduces a breaking change, please describe the impact and a
  potential migration path for existing applications.
-->

### Additional Info
No