### PR TITLE
fix: asset URL in `/webpack-dev-server` route

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -1219,7 +1219,7 @@ class Server {
 
             res.write(
               `<li>
-              <strong><a href="${assetURL}" target="_blank">${assetName}</a></strong>
+              <strong><a href="/${assetURL}" target="_blank">${assetName}</a></strong>
             </li>`
             );
           }

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -1211,7 +1211,7 @@ class Server {
           res.write(`<h2>Compilation: ${name}</h2>`);
           res.write("<ul>");
 
-          const publicPath = item.publicPath === "auto" ? "" : item.publicPath;
+          const publicPath = item.publicPath === "auto" ? "/" : item.publicPath;
 
           for (const asset of item.assets) {
             const assetName = asset.name;
@@ -1219,7 +1219,7 @@ class Server {
 
             res.write(
               `<li>
-              <strong><a href="/${assetURL}" target="_blank">${assetName}</a></strong>
+              <strong><a href="${assetURL}" target="_blank">${assetName}</a></strong>
             </li>`
             );
           }

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -1215,7 +1215,12 @@ class Server {
 
           for (const asset of item.assets) {
             const assetName = asset.name;
-            const assetURL = `${publicPath}${assetName}`;
+
+            let assetURL = `${publicPath}${assetName}`;
+
+            if (!assetURL.startsWith("/")) {
+              assetURL = `/${assetURL}`;
+            }
 
             res.write(
               `<li>

--- a/test/e2e/__snapshots__/built-in-routes.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/built-in-routes.test.js.snap.webpack4
@@ -10,7 +10,7 @@ exports[`Built in routes with multi config should handle GET request to director
             </li></ul></div><div><h2>Compilation: named</h2><ul><li>
               <strong><a href=\\"/bundle2/bar.js\\" target=\\"_blank\\">bar.js</a></strong>
             </li></ul></div><div><h2>Compilation: other</h2><ul><li>
-              <strong><a href=\\"bar.js\\" target=\\"_blank\\">bar.js</a></strong>
+              <strong><a href=\\"/bar.js\\" target=\\"_blank\\">bar.js</a></strong>
             </li></ul></div></body></html>"
 `;
 
@@ -24,9 +24,9 @@ exports[`Built in routes with simple config should handle GET request to directo
 
 exports[`Built in routes with simple config should handle GET request to directory index and list all middleware directories: directory list 1`] = `
 "<!DOCTYPE html><html><head><meta charset=\\"utf-8\\"/></head><body><h1>Assets Report:</h1><div><h2>Compilation: unnamed</h2><ul><li>
-              <strong><a href=\\"main.js\\" target=\\"_blank\\">main.js</a></strong>
+              <strong><a href=\\"/main.js\\" target=\\"_blank\\">main.js</a></strong>
             </li><li>
-              <strong><a href=\\"test.html\\" target=\\"_blank\\">test.html</a></strong>
+              <strong><a href=\\"/test.html\\" target=\\"_blank\\">test.html</a></strong>
             </li></ul></div></body></html>"
 `;
 

--- a/test/e2e/__snapshots__/built-in-routes.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/built-in-routes.test.js.snap.webpack5
@@ -10,7 +10,7 @@ exports[`Built in routes with multi config should handle GET request to director
             </li></ul></div><div><h2>Compilation: named</h2><ul><li>
               <strong><a href=\\"/bundle2/bar.js\\" target=\\"_blank\\">bar.js</a></strong>
             </li></ul></div><div><h2>Compilation: other</h2><ul><li>
-              <strong><a href=\\"bar.js\\" target=\\"_blank\\">bar.js</a></strong>
+              <strong><a href=\\"/bar.js\\" target=\\"_blank\\">bar.js</a></strong>
             </li></ul></div></body></html>"
 `;
 
@@ -24,9 +24,9 @@ exports[`Built in routes with simple config should handle GET request to directo
 
 exports[`Built in routes with simple config should handle GET request to directory index and list all middleware directories: directory list 1`] = `
 "<!DOCTYPE html><html><head><meta charset=\\"utf-8\\"/></head><body><h1>Assets Report:</h1><div><h2>Compilation: unnamed</h2><ul><li>
-              <strong><a href=\\"main.js\\" target=\\"_blank\\">main.js</a></strong>
+              <strong><a href=\\"/main.js\\" target=\\"_blank\\">main.js</a></strong>
             </li><li>
-              <strong><a href=\\"test.html\\" target=\\"_blank\\">test.html</a></strong>
+              <strong><a href=\\"/test.html\\" target=\\"_blank\\">test.html</a></strong>
             </li></ul></div></body></html>"
 `;
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [x] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [x] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

Yes, updated snapshots.
<!-- Please note that we won't approve your changes if you don't add tests. -->

### Motivation / Use-Case

Fix asset URL, `href="index.html"` was redirecting to   `/webpack-dev-server/index.html` instead of `/index.html`.

<!--
  What existing problem does the pull request solve?

  Please explain the motivation or use-case for making this change.
  If this Pull Request addresses an issue, please link to the issue.
-->

### Breaking Changes
None
<!--
  If this PR introduces a breaking change, please describe the impact and a
  potential migration path for existing applications.
-->

### Additional Info
No    