### PR TITLE
test: refactor e2e test to use `response.text()`

### DIFF
--- a/test/e2e/__snapshots__/built-in-routes.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/built-in-routes.test.js.snap.webpack4
@@ -3,7 +3,7 @@
 exports[`Built in routes with multi config should handle GET request to directory index and list all middleware directories: console messages 1`] = `Array []`;
 
 exports[`Built in routes with multi config should handle GET request to directory index and list all middleware directories: directory list 1`] = `
-"<h1>Assets Report:</h1><div><h2>Compilation: unnamed[0]</h2><ul><li>
+"<!DOCTYPE html><html><head><meta charset=\\"utf-8\\"/></head><body><h1>Assets Report:</h1><div><h2>Compilation: unnamed[0]</h2><ul><li>
               <strong><a href=\\"/bundle1/foo.js\\" target=\\"_blank\\">foo.js</a></strong>
             </li><li>
               <strong><a href=\\"/bundle1/path/to/file.html\\" target=\\"_blank\\">path/to/file.html</a></strong>
@@ -11,7 +11,7 @@ exports[`Built in routes with multi config should handle GET request to director
               <strong><a href=\\"/bundle2/bar.js\\" target=\\"_blank\\">bar.js</a></strong>
             </li></ul></div><div><h2>Compilation: other</h2><ul><li>
               <strong><a href=\\"bar.js\\" target=\\"_blank\\">bar.js</a></strong>
-            </li></ul></div>"
+            </li></ul></div></body></html>"
 `;
 
 exports[`Built in routes with multi config should handle GET request to directory index and list all middleware directories: page errors 1`] = `Array []`;
@@ -23,11 +23,11 @@ exports[`Built in routes with multi config should handle GET request to director
 exports[`Built in routes with simple config should handle GET request to directory index and list all middleware directories: console messages 1`] = `Array []`;
 
 exports[`Built in routes with simple config should handle GET request to directory index and list all middleware directories: directory list 1`] = `
-"<h1>Assets Report:</h1><div><h2>Compilation: unnamed</h2><ul><li>
+"<!DOCTYPE html><html><head><meta charset=\\"utf-8\\"/></head><body><h1>Assets Report:</h1><div><h2>Compilation: unnamed</h2><ul><li>
               <strong><a href=\\"main.js\\" target=\\"_blank\\">main.js</a></strong>
             </li><li>
               <strong><a href=\\"test.html\\" target=\\"_blank\\">test.html</a></strong>
-            </li></ul></div>"
+            </li></ul></div></body></html>"
 `;
 
 exports[`Built in routes with simple config should handle GET request to directory index and list all middleware directories: page errors 1`] = `Array []`;

--- a/test/e2e/__snapshots__/built-in-routes.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/built-in-routes.test.js.snap.webpack5
@@ -3,7 +3,7 @@
 exports[`Built in routes with multi config should handle GET request to directory index and list all middleware directories: console messages 1`] = `Array []`;
 
 exports[`Built in routes with multi config should handle GET request to directory index and list all middleware directories: directory list 1`] = `
-"<h1>Assets Report:</h1><div><h2>Compilation: unnamed[0]</h2><ul><li>
+"<!DOCTYPE html><html><head><meta charset=\\"utf-8\\"/></head><body><h1>Assets Report:</h1><div><h2>Compilation: unnamed[0]</h2><ul><li>
               <strong><a href=\\"/bundle1/foo.js\\" target=\\"_blank\\">foo.js</a></strong>
             </li><li>
               <strong><a href=\\"/bundle1/path/to/file.html\\" target=\\"_blank\\">path/to/file.html</a></strong>
@@ -11,7 +11,7 @@ exports[`Built in routes with multi config should handle GET request to director
               <strong><a href=\\"/bundle2/bar.js\\" target=\\"_blank\\">bar.js</a></strong>
             </li></ul></div><div><h2>Compilation: other</h2><ul><li>
               <strong><a href=\\"bar.js\\" target=\\"_blank\\">bar.js</a></strong>
-            </li></ul></div>"
+            </li></ul></div></body></html>"
 `;
 
 exports[`Built in routes with multi config should handle GET request to directory index and list all middleware directories: page errors 1`] = `Array []`;
@@ -23,11 +23,11 @@ exports[`Built in routes with multi config should handle GET request to director
 exports[`Built in routes with simple config should handle GET request to directory index and list all middleware directories: console messages 1`] = `Array []`;
 
 exports[`Built in routes with simple config should handle GET request to directory index and list all middleware directories: directory list 1`] = `
-"<h1>Assets Report:</h1><div><h2>Compilation: unnamed</h2><ul><li>
+"<!DOCTYPE html><html><head><meta charset=\\"utf-8\\"/></head><body><h1>Assets Report:</h1><div><h2>Compilation: unnamed</h2><ul><li>
               <strong><a href=\\"main.js\\" target=\\"_blank\\">main.js</a></strong>
             </li><li>
               <strong><a href=\\"test.html\\" target=\\"_blank\\">test.html</a></strong>
-            </li></ul></div>"
+            </li></ul></div></body></html>"
 `;
 
 exports[`Built in routes with simple config should handle GET request to directory index and list all middleware directories: page errors 1`] = `Array []`;

--- a/test/e2e/built-in-routes.test.js
+++ b/test/e2e/built-in-routes.test.js
@@ -139,19 +139,13 @@ describe("Built in routes", () => {
         }
       );
 
-      const bodyHandle = await page.$("body");
-      const htmlContent = await page.evaluate(
-        (body) => body.innerHTML,
-        bodyHandle
-      );
-
       expect(response.headers()["content-type"]).toMatchSnapshot(
         "response headers content-type"
       );
 
       expect(response.status()).toMatchSnapshot("response status");
 
-      expect(htmlContent).toMatchSnapshot("directory list");
+      expect(await response.text()).toMatchSnapshot("directory list");
 
       expect(consoleMessages.map((message) => message.text())).toMatchSnapshot(
         "console messages"
@@ -181,19 +175,13 @@ describe("Built in routes", () => {
         }
       );
 
-      const bodyHandle = await page.$("body");
-      const htmlContent = await page.evaluate(
-        (body) => body.innerHTML,
-        bodyHandle
-      );
-
       expect(response.headers()["content-type"]).toMatchSnapshot(
         "response headers content-type"
       );
 
       expect(response.status()).toMatchSnapshot("response status");
 
-      expect(htmlContent).toMatchSnapshot("directory list");
+      expect(await response.text()).toMatchSnapshot("directory list");
 
       expect(consoleMessages.map((message) => message.text())).toMatchSnapshot(
         "console messages"
@@ -350,19 +338,13 @@ describe("Built in routes", () => {
         }
       );
 
-      const bodyHandle = await page.$("body");
-      const htmlContent = await page.evaluate(
-        (body) => body.innerHTML,
-        bodyHandle
-      );
-
       expect(response.headers()["content-type"]).toMatchSnapshot(
         "response headers content-type"
       );
 
       expect(response.status()).toMatchSnapshot("response status");
 
-      expect(htmlContent).toMatchSnapshot("directory list");
+      expect(await response.text()).toMatchSnapshot("directory list");
 
       expect(consoleMessages.map((message) => message.text())).toMatchSnapshot(
         "console messages"

--- a/test/e2e/universal-compiler.test.js
+++ b/test/e2e/universal-compiler.test.js
@@ -29,18 +29,14 @@ describe("Universal compiler", () => {
         pageErrors.push(error);
       });
 
-    await page.goto(`http://127.0.0.1:${port}/client.js`, {
+    const response = await page.goto(`http://127.0.0.1:${port}/client.js`, {
       waitUntil: "networkidle0",
     });
 
-    const bodyHandle = await page.$("body");
-    const htmlContent = await page.evaluate(
-      (body) => body.innerHTML,
-      bodyHandle
-    );
+    const responseText = await response.text();
 
-    expect(htmlContent).toContain("Hello from the client");
-    expect(htmlContent).toContain("WebsocketClient");
+    expect(responseText).toContain("Hello from the client");
+    expect(responseText).toContain("WebsocketClient");
 
     expect(consoleMessages.map((message) => message.text())).toMatchSnapshot(
       "console messages"
@@ -76,18 +72,14 @@ describe("Universal compiler", () => {
         pageErrors.push(error);
       });
 
-    await page.goto(`http://127.0.0.1:${port}/server.js`, {
+    const response = await page.goto(`http://127.0.0.1:${port}/server.js`, {
       waitUntil: "networkidle0",
     });
 
-    const bodyHandle = await page.$("body");
-    const htmlContent = await page.evaluate(
-      (body) => body.innerHTML,
-      bodyHandle
-    );
+    const responseText = await response.text();
 
-    expect(htmlContent).toContain("Hello from the server");
-    expect(htmlContent).not.toContain("WebsocketServer");
+    expect(responseText).toContain("Hello from the server");
+    expect(responseText).not.toContain("WebsocketServer");
 
     expect(consoleMessages.map((message) => message.text())).toMatchSnapshot(
       "console messages"


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [ ] This is a **bugfix**
- [ ] This is a **feature**
- [x] This is a **code refactor**
- [x] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?
No
<!-- Please note that we won't approve your changes if you don't add tests. -->

### Motivation / Use-Case

 refactor e2e test to use `response.text()` for consistency with other tests + avoid extra code.
<!--
  What existing problem does the pull request solve?

  Please explain the motivation or use-case for making this change.
  If this Pull Request addresses an issue, please link to the issue.
-->

### Breaking Changes
None
<!--
  If this PR introduces a breaking change, please describe the impact and a
  potential migration path for existing applications.
-->

### Additional Info
No