### PR TITLE
test: refactor to use `response.text()`

### DIFF
--- a/test/e2e/module-federation.test.js
+++ b/test/e2e/module-federation.test.js
@@ -53,15 +53,11 @@ describe("Module federation", () => {
           pageErrors.push(error);
         });
 
-      await page.goto(`http://127.0.0.1:${port}/main.js`, {
+      const response = await page.goto(`http://127.0.0.1:${port}/main.js`, {
         waitUntil: "networkidle0",
       });
 
-      const bodyHandle = await page.$("body");
-      const textContent = await page.evaluate(
-        (body) => body.textContent,
-        bodyHandle
-      );
+      const textContent = await response.text();
 
       expect(textContent).toContain("entry1");
 
@@ -115,15 +111,11 @@ describe("Module federation", () => {
           pageErrors.push(error);
         });
 
-      await page.goto(`http://127.0.0.1:${port}/main.js`, {
+      const response = await page.goto(`http://127.0.0.1:${port}/main.js`, {
         waitUntil: "networkidle0",
       });
 
-      const bodyHandle = await page.$("body");
-      const textContent = await page.evaluate(
-        (body) => body.textContent,
-        bodyHandle
-      );
+      const textContent = await response.text();
 
       expect(textContent).toContain("entry1");
 
@@ -151,15 +143,11 @@ describe("Module federation", () => {
           pageErrors.push(error);
         });
 
-      await page.goto(`http://127.0.0.1:${port}/foo.js`, {
+      const response = await page.goto(`http://127.0.0.1:${port}/foo.js`, {
         waitUntil: "networkidle0",
       });
 
-      const bodyHandle = await page.$("body");
-      const textContent = await page.evaluate(
-        (body) => body.textContent,
-        bodyHandle
-      );
+      const textContent = await response.text();
 
       expect(textContent).not.toContain("entry2");
 
@@ -213,15 +201,11 @@ describe("Module federation", () => {
           pageErrors.push(error);
         });
 
-      await page.goto(`http://127.0.0.1:${port}/main.js`, {
+      const response = await page.goto(`http://127.0.0.1:${port}/main.js`, {
         waitUntil: "networkidle0",
       });
 
-      const bodyHandle = await page.$("body");
-      const textContent = await page.evaluate(
-        (body) => body.textContent,
-        bodyHandle
-      );
+      const textContent = await response.text();
 
       expect(textContent).toContain("entry1");
 
@@ -275,15 +259,14 @@ describe("Module federation", () => {
           pageErrors.push(error);
         });
 
-      await page.goto(`http://127.0.0.1:${port}/remoteEntry.js`, {
-        waitUntil: "networkidle0",
-      });
-
-      const bodyHandle = await page.$("body");
-      const remoteEntryTextContent = await page.evaluate(
-        (body) => body.textContent,
-        bodyHandle
+      const response = await page.goto(
+        `http://127.0.0.1:${port}/remoteEntry.js`,
+        {
+          waitUntil: "networkidle0",
+        }
       );
+
+      const remoteEntryTextContent = await response.text();
 
       expect(remoteEntryTextContent).toMatch(/webpack\/hot\/dev-server\.js/);
 
@@ -303,15 +286,11 @@ describe("Module federation", () => {
           pageErrors.push(error);
         });
 
-      await page.goto(`http://127.0.0.1:${port}/main.js`, {
+      const response = await page.goto(`http://127.0.0.1:${port}/main.js`, {
         waitUntil: "networkidle0",
       });
 
-      const bodyHandle = await page.$("body");
-      const mainEntryTextContent = await page.evaluate(
-        (body) => body.textContent,
-        bodyHandle
-      );
+      const mainEntryTextContent = await response.text();
 
       expect(mainEntryTextContent).toMatch(/webpack\/hot\/dev-server\.js/);
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [ ] This is a **bugfix**
- [ ] This is a **feature**
- [x] This is a **code refactor**
- [x] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?
No
<!-- Please note that we won't approve your changes if you don't add tests. -->

### Motivation / Use-Case

refactor e2e test to use `response.text()` for consistency with other tests + avoid extra code.

Follow up https://github.com/webpack/webpack-dev-server/pull/3761
<!--
  What existing problem does the pull request solve?

  Please explain the motivation or use-case for making this change.
  If this Pull Request addresses an issue, please link to the issue.
-->

### Breaking Changes
None
<!--
  If this PR introduces a breaking change, please describe the impact and a
  potential migration path for existing applications.
-->

### Additional Info
No