### PR TITLE
 fix: replace ansi-html with ansi-html-community

### DIFF
--- a/client-src/default/overlay.js
+++ b/client-src/default/overlay.js
@@ -3,7 +3,7 @@
 // The error overlay is inspired (and mostly copied) from Create React App (https://github.com/facebookincubator/create-react-app)
 // They, in turn, got inspired by webpack-hot-middleware (https://github.com/glenjamin/webpack-hot-middleware).
 
-const ansiHTML = require('ansi-html');
+const ansiHTML = require('ansi-html-community');
 const { AllHtmlEntities } = require('html-entities');
 
 const entities = new AllHtmlEntities();

--- a/package-lock.json
+++ b/package-lock.json
@@ -2148,10 +2148,10 @@
         }
       }
     },
-    "ansi-html": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
-      "integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4="
+    "ansi-html-community": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/ansi-html-community/-/ansi-html-community-0.0.8.tgz",
+      "integrity": "sha512-1APHAyr3+PCamwNw3bXCPp4HFLONZt/yIH0sZp0/469KWNTEy+qN5jQ3GVX6DMZ1UXAi34yVwtTeaG/HpBuuzw=="
     },
     "ansi-regex": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "release": "standard-version"
   },
   "dependencies": {
-    "ansi-html": "0.0.7",
+    "ansi-html-community": "^0.0.8",
     "bonjour": "^3.5.0",
     "chokidar": "^2.1.8",
     "compression": "^1.7.4",


### PR DESCRIPTION
This fixes the ReDoS vulnerability CVE-2021-23424

- [x] This is a **bugfix**
- [ ] This is a **feature**
- [x] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

I only replaced a dependency which has tests on its own.

### Motivation / Use-Case

Fixes #3576
Replaces #3798

### Breaking Changes

None

### Additional Info
