### PR TITLE
fix: close overlay on disconnection

### DIFF
--- a/client-src/index.js
+++ b/client-src/index.js
@@ -161,12 +161,12 @@ const onSocketMessage = {
       log.warn(strippedWarnings[i]);
     }
 
-    const needShowOverlay =
+    const needShowOverlayForWarnings =
       typeof options.overlay === "boolean"
         ? options.overlay
         : options.overlay && options.overlay.warnings;
 
-    if (needShowOverlay) {
+    if (needShowOverlayForWarnings) {
       show(warnings, "warnings");
     }
 
@@ -185,12 +185,12 @@ const onSocketMessage = {
       log.error(strippedErrors[i]);
     }
 
-    const needShowOverlay =
+    const needShowOverlayForErrors =
       typeof options.overlay === "boolean"
         ? options.overlay
         : options.overlay && options.overlay.errors;
 
-    if (needShowOverlay) {
+    if (needShowOverlayForErrors) {
       show(errors, "errors");
     }
   },
@@ -199,6 +199,10 @@ const onSocketMessage = {
   },
   close() {
     log.info("Disconnected!");
+
+    if (options.overlay) {
+      hide();
+    }
 
     sendMessage("Close");
   },

--- a/test/e2e/__snapshots__/overlay.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/overlay.test.js.snap.webpack4
@@ -1,5 +1,33 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`overlay should not show a warning when "client.overlay" is "false": page html 1`] = `
+"<body>
+  <script type=\\"text/javascript\\" charset=\\"utf-8\\" src=\\"/main.js\\"></script>
+</body>
+"
+`;
+
+exports[`overlay should not show a warning when "client.overlay.warnings" is "false": page html 1`] = `
+"<body>
+  <script type=\\"text/javascript\\" charset=\\"utf-8\\" src=\\"/main.js\\"></script>
+</body>
+"
+`;
+
+exports[`overlay should not show an error when "client.overlay" is "false": page html 1`] = `
+"<body>
+  <script type=\\"text/javascript\\" charset=\\"utf-8\\" src=\\"/main.js\\"></script>
+</body>
+"
+`;
+
+exports[`overlay should not show an error when "client.overlay.errors" is "false": page html 1`] = `
+"<body>
+  <script type=\\"text/javascript\\" charset=\\"utf-8\\" src=\\"/main.js\\"></script>
+</body>
+"
+`;
+
 exports[`overlay should not show initially, then show on an error and allow to close: overlay html 1`] = `
 "<body>
   <div
@@ -37,9 +65,9 @@ exports[`overlay should not show initially, then show on an error and allow to c
     <div>
       <span style=\\"color: rgb(227, 96, 73)\\">Error:</span><br /><br />
       <div>
-        ./foo.js 1:1 Module parse failed: Unterminated template (1:1) You may
-        need an appropriate loader to handle this file type, currently no
-        loaders are configured to process this file. See
+        Module parse failed: Unterminated template (1:1) You may need an
+        appropriate loader to handle this file type, currently no loaders are
+        configured to process this file. See
         https://webpack.js.org/concepts#loaders &gt; \`;
       </div>
       <br /><br />
@@ -119,9 +147,9 @@ exports[`overlay should not show initially, then show on an error, then hide on 
     <div>
       <span style=\\"color: rgb(227, 96, 73)\\">Error:</span><br /><br />
       <div>
-        ./foo.js 1:1 Module parse failed: Unterminated template (1:1) You may
-        need an appropriate loader to handle this file type, currently no
-        loaders are configured to process this file. See
+        Module parse failed: Unterminated template (1:1) You may need an
+        appropriate loader to handle this file type, currently no loaders are
+        configured to process this file. See
         https://webpack.js.org/concepts#loaders &gt; \`;
       </div>
       <br /><br />
@@ -201,9 +229,9 @@ exports[`overlay should not show initially, then show on an error, then show oth
     <div>
       <span style=\\"color: rgb(227, 96, 73)\\">Error:</span><br /><br />
       <div>
-        ./foo.js 1:1 Module parse failed: Unterminated template (1:1) You may
-        need an appropriate loader to handle this file type, currently no
-        loaders are configured to process this file. See
+        Module parse failed: Unterminated template (1:1) You may need an
+        appropriate loader to handle this file type, currently no loaders are
+        configured to process this file. See
         https://webpack.js.org/concepts#loaders &gt; \`;
       </div>
       <br /><br />
@@ -250,9 +278,9 @@ exports[`overlay should not show initially, then show on an error, then show oth
     <div>
       <span style=\\"color: rgb(227, 96, 73)\\">Error:</span><br /><br />
       <div>
-        ./foo.js 1:1 Module parse failed: Unterminated template (1:1) You may
-        need an appropriate loader to handle this file type, currently no
-        loaders are configured to process this file. See
+        Module parse failed: Unterminated template (1:1) You may need an
+        appropriate loader to handle this file type, currently no loaders are
+        configured to process this file. See
         https://webpack.js.org/concepts#loaders &gt; \`;a
       </div>
       <br /><br />
@@ -314,35 +342,7 @@ exports[`overlay should not show initially, then show on an error, then show oth
 "
 `;
 
-exports[`overlay should not show on a warning when "client.overlay" is "false": page html 1`] = `
-"<body>
-  <script type=\\"text/javascript\\" charset=\\"utf-8\\" src=\\"/main.js\\"></script>
-</body>
-"
-`;
-
-exports[`overlay should not show on a warning when "client.overlay.warnings" is "false": page html 1`] = `
-"<body>
-  <script type=\\"text/javascript\\" charset=\\"utf-8\\" src=\\"/main.js\\"></script>
-</body>
-"
-`;
-
-exports[`overlay should not show on an error when "client.overlay" is "false": page html 1`] = `
-"<body>
-  <script type=\\"text/javascript\\" charset=\\"utf-8\\" src=\\"/main.js\\"></script>
-</body>
-"
-`;
-
-exports[`overlay should not show on an error when "client.overlay.errors" is "false": page html 1`] = `
-"<body>
-  <script type=\\"text/javascript\\" charset=\\"utf-8\\" src=\\"/main.js\\"></script>
-</body>
-"
-`;
-
-exports[`overlay should show on a warning and error for initial compilation and protects against xss: overlay html 1`] = `
+exports[`overlay should show a warning and error for initial compilation and protects against xss: overlay html 1`] = `
 "<body>
   <div
     id=\\"webpack-dev-server-client-overlay-div\\"
@@ -391,7 +391,7 @@ exports[`overlay should show on a warning and error for initial compilation and 
 "
 `;
 
-exports[`overlay should show on a warning and error for initial compilation and protects against xss: page html 1`] = `
+exports[`overlay should show a warning and error for initial compilation and protects against xss: page html 1`] = `
 "<body>
   <script type=\\"text/javascript\\" charset=\\"utf-8\\" src=\\"/main.js\\"></script>
   <iframe
@@ -410,7 +410,7 @@ exports[`overlay should show on a warning and error for initial compilation and 
 "
 `;
 
-exports[`overlay should show on a warning and error for initial compilation: overlay html 1`] = `
+exports[`overlay should show a warning and error for initial compilation: overlay html 1`] = `
 "<body>
   <div
     id=\\"webpack-dev-server-client-overlay-div\\"
@@ -474,7 +474,7 @@ exports[`overlay should show on a warning and error for initial compilation: ove
 "
 `;
 
-exports[`overlay should show on a warning and error for initial compilation: page html 1`] = `
+exports[`overlay should show a warning and error for initial compilation: page html 1`] = `
 "<body>
   <script type=\\"text/javascript\\" charset=\\"utf-8\\" src=\\"/main.js\\"></script>
   <iframe
@@ -493,7 +493,7 @@ exports[`overlay should show on a warning and error for initial compilation: pag
 "
 `;
 
-exports[`overlay should show on a warning for initial compilation: overlay html 1`] = `
+exports[`overlay should show a warning and hide them after closing connection: overlay html 1`] = `
 "<body>
   <div
     id=\\"webpack-dev-server-client-overlay-div\\"
@@ -537,7 +537,7 @@ exports[`overlay should show on a warning for initial compilation: overlay html 
 "
 `;
 
-exports[`overlay should show on a warning for initial compilation: page html 1`] = `
+exports[`overlay should show a warning and hide them after closing connection: page html 1`] = `
 "<body>
   <script type=\\"text/javascript\\" charset=\\"utf-8\\" src=\\"/main.js\\"></script>
   <iframe
@@ -556,7 +556,14 @@ exports[`overlay should show on a warning for initial compilation: page html 1`]
 "
 `;
 
-exports[`overlay should show on a warning when "client.overlay" is "true": overlay html 1`] = `
+exports[`overlay should show a warning and hide them after closing connection: page html 2`] = `
+"<body>
+  <script type=\\"text/javascript\\" charset=\\"utf-8\\" src=\\"/main.js\\"></script>
+</body>
+"
+`;
+
+exports[`overlay should show a warning for initial compilation: overlay html 1`] = `
 "<body>
   <div
     id=\\"webpack-dev-server-client-overlay-div\\"
@@ -600,7 +607,7 @@ exports[`overlay should show on a warning when "client.overlay" is "true": overl
 "
 `;
 
-exports[`overlay should show on a warning when "client.overlay" is "true": page html 1`] = `
+exports[`overlay should show a warning for initial compilation: page html 1`] = `
 "<body>
   <script type=\\"text/javascript\\" charset=\\"utf-8\\" src=\\"/main.js\\"></script>
   <iframe
@@ -619,7 +626,7 @@ exports[`overlay should show on a warning when "client.overlay" is "true": page 
 "
 `;
 
-exports[`overlay should show on a warning when "client.overlay.errors" is "true": overlay html 1`] = `
+exports[`overlay should show a warning when "client.overlay" is "true": overlay html 1`] = `
 "<body>
   <div
     id=\\"webpack-dev-server-client-overlay-div\\"
@@ -663,7 +670,7 @@ exports[`overlay should show on a warning when "client.overlay.errors" is "true"
 "
 `;
 
-exports[`overlay should show on a warning when "client.overlay.errors" is "true": page html 1`] = `
+exports[`overlay should show a warning when "client.overlay" is "true": page html 1`] = `
 "<body>
   <script type=\\"text/javascript\\" charset=\\"utf-8\\" src=\\"/main.js\\"></script>
   <iframe
@@ -682,7 +689,7 @@ exports[`overlay should show on a warning when "client.overlay.errors" is "true"
 "
 `;
 
-exports[`overlay should show on a warning when "client.overlay.warnings" is "true": overlay html 1`] = `
+exports[`overlay should show a warning when "client.overlay.errors" is "true": overlay html 1`] = `
 "<body>
   <div
     id=\\"webpack-dev-server-client-overlay-div\\"
@@ -726,7 +733,7 @@ exports[`overlay should show on a warning when "client.overlay.warnings" is "tru
 "
 `;
 
-exports[`overlay should show on a warning when "client.overlay.warnings" is "true": page html 1`] = `
+exports[`overlay should show a warning when "client.overlay.errors" is "true": page html 1`] = `
 "<body>
   <script type=\\"text/javascript\\" charset=\\"utf-8\\" src=\\"/main.js\\"></script>
   <iframe
@@ -745,7 +752,70 @@ exports[`overlay should show on a warning when "client.overlay.warnings" is "tru
 "
 `;
 
-exports[`overlay should show on an ansi formatted error for initial compilation: overlay html 1`] = `
+exports[`overlay should show a warning when "client.overlay.warnings" is "true": overlay html 1`] = `
+"<body>
+  <div
+    id=\\"webpack-dev-server-client-overlay-div\\"
+    style=\\"
+      position: fixed;
+      box-sizing: border-box;
+      inset: 0px;
+      width: 100vw;
+      height: 100vh;
+      background-color: rgba(0, 0, 0, 0.85);
+      color: rgb(232, 232, 232);
+      font-family: Menlo, Consolas, monospace;
+      font-size: large;
+      padding: 2rem;
+      line-height: 1.2;
+      white-space: pre-wrap;
+      overflow: auto;
+    \\"
+  >
+    <span>Compiled with problems:</span
+    ><button
+      style=\\"
+        background: transparent;
+        border: none;
+        font-size: 20px;
+        font-weight: bold;
+        color: white;
+        cursor: pointer;
+        float: right;
+      \\"
+    >
+      X</button
+    ><br /><br />
+    <div>
+      <span style=\\"color: rgb(227, 96, 73)\\">Warning:</span><br /><br />
+      <div>Warning from compilation</div>
+      <br /><br />
+    </div>
+  </div>
+</body>
+"
+`;
+
+exports[`overlay should show a warning when "client.overlay.warnings" is "true": page html 1`] = `
+"<body>
+  <script type=\\"text/javascript\\" charset=\\"utf-8\\" src=\\"/main.js\\"></script>
+  <iframe
+    id=\\"webpack-dev-server-client-overlay\\"
+    src=\\"about:blank\\"
+    style=\\"
+      position: fixed;
+      inset: 0px;
+      width: 100vw;
+      height: 100vh;
+      border: none;
+      z-index: 2147483647;
+    \\"
+  ></iframe>
+</body>
+"
+`;
+
+exports[`overlay should show an ansi formatted error for initial compilation: overlay html 1`] = `
 "<body>
   <div
     id=\\"webpack-dev-server-client-overlay-div\\"
@@ -802,7 +872,7 @@ exports[`overlay should show on an ansi formatted error for initial compilation:
 "
 `;
 
-exports[`overlay should show on an ansi formatted error for initial compilation: page html 1`] = `
+exports[`overlay should show an ansi formatted error for initial compilation: page html 1`] = `
 "<body>
   <script type=\\"text/javascript\\" charset=\\"utf-8\\" src=\\"/main.js\\"></script>
   <iframe
@@ -821,7 +891,7 @@ exports[`overlay should show on an ansi formatted error for initial compilation:
 "
 `;
 
-exports[`overlay should show on an error for initial compilation: overlay html 1`] = `
+exports[`overlay should show an error for initial compilation: overlay html 1`] = `
 "<body>
   <div
     id=\\"webpack-dev-server-client-overlay-div\\"
@@ -865,7 +935,7 @@ exports[`overlay should show on an error for initial compilation: overlay html 1
 "
 `;
 
-exports[`overlay should show on an error for initial compilation: page html 1`] = `
+exports[`overlay should show an error for initial compilation: page html 1`] = `
 "<body>
   <script type=\\"text/javascript\\" charset=\\"utf-8\\" src=\\"/main.js\\"></script>
   <iframe
@@ -884,7 +954,7 @@ exports[`overlay should show on an error for initial compilation: page html 1`] 
 "
 `;
 
-exports[`overlay should show on an error when "client.overlay" is "true": overlay html 1`] = `
+exports[`overlay should show an error when "client.overlay" is "true": overlay html 1`] = `
 "<body>
   <div
     id=\\"webpack-dev-server-client-overlay-div\\"
@@ -928,7 +998,7 @@ exports[`overlay should show on an error when "client.overlay" is "true": overla
 "
 `;
 
-exports[`overlay should show on an error when "client.overlay" is "true": page html 1`] = `
+exports[`overlay should show an error when "client.overlay" is "true": page html 1`] = `
 "<body>
   <script type=\\"text/javascript\\" charset=\\"utf-8\\" src=\\"/main.js\\"></script>
   <iframe
@@ -947,7 +1017,7 @@ exports[`overlay should show on an error when "client.overlay" is "true": page h
 "
 `;
 
-exports[`overlay should show on an error when "client.overlay.errors" is "true": overlay html 1`] = `
+exports[`overlay should show an error when "client.overlay.errors" is "true": overlay html 1`] = `
 "<body>
   <div
     id=\\"webpack-dev-server-client-overlay-div\\"
@@ -991,7 +1061,7 @@ exports[`overlay should show on an error when "client.overlay.errors" is "true":
 "
 `;
 
-exports[`overlay should show on an error when "client.overlay.errors" is "true": page html 1`] = `
+exports[`overlay should show an error when "client.overlay.errors" is "true": page html 1`] = `
 "<body>
   <script type=\\"text/javascript\\" charset=\\"utf-8\\" src=\\"/main.js\\"></script>
   <iframe
@@ -1010,7 +1080,7 @@ exports[`overlay should show on an error when "client.overlay.errors" is "true":
 "
 `;
 
-exports[`overlay should show on an error when "client.overlay.warnings" is "true": overlay html 1`] = `
+exports[`overlay should show an error when "client.overlay.warnings" is "true": overlay html 1`] = `
 "<body>
   <div
     id=\\"webpack-dev-server-client-overlay-div\\"
@@ -1054,7 +1124,7 @@ exports[`overlay should show on an error when "client.overlay.warnings" is "true
 "
 `;
 
-exports[`overlay should show on an error when "client.overlay.warnings" is "true": page html 1`] = `
+exports[`overlay should show an error when "client.overlay.warnings" is "true": page html 1`] = `
 "<body>
   <script type=\\"text/javascript\\" charset=\\"utf-8\\" src=\\"/main.js\\"></script>
   <iframe

--- a/test/e2e/__snapshots__/overlay.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/overlay.test.js.snap.webpack4
@@ -65,9 +65,9 @@ exports[`overlay should not show initially, then show on an error and allow to c
     <div>
       <span style=\\"color: rgb(227, 96, 73)\\">Error:</span><br /><br />
       <div>
-        Module parse failed: Unterminated template (1:1) You may need an
-        appropriate loader to handle this file type, currently no loaders are
-        configured to process this file. See
+        ./foo.js 1:1 Module parse failed: Unterminated template (1:1) You may
+        need an appropriate loader to handle this file type, currently no
+        loaders are configured to process this file. See
         https://webpack.js.org/concepts#loaders &gt; \`;
       </div>
       <br /><br />
@@ -147,9 +147,9 @@ exports[`overlay should not show initially, then show on an error, then hide on 
     <div>
       <span style=\\"color: rgb(227, 96, 73)\\">Error:</span><br /><br />
       <div>
-        Module parse failed: Unterminated template (1:1) You may need an
-        appropriate loader to handle this file type, currently no loaders are
-        configured to process this file. See
+        ./foo.js 1:1 Module parse failed: Unterminated template (1:1) You may
+        need an appropriate loader to handle this file type, currently no
+        loaders are configured to process this file. See
         https://webpack.js.org/concepts#loaders &gt; \`;
       </div>
       <br /><br />
@@ -229,9 +229,9 @@ exports[`overlay should not show initially, then show on an error, then show oth
     <div>
       <span style=\\"color: rgb(227, 96, 73)\\">Error:</span><br /><br />
       <div>
-        Module parse failed: Unterminated template (1:1) You may need an
-        appropriate loader to handle this file type, currently no loaders are
-        configured to process this file. See
+        ./foo.js 1:1 Module parse failed: Unterminated template (1:1) You may
+        need an appropriate loader to handle this file type, currently no
+        loaders are configured to process this file. See
         https://webpack.js.org/concepts#loaders &gt; \`;
       </div>
       <br /><br />
@@ -278,9 +278,9 @@ exports[`overlay should not show initially, then show on an error, then show oth
     <div>
       <span style=\\"color: rgb(227, 96, 73)\\">Error:</span><br /><br />
       <div>
-        Module parse failed: Unterminated template (1:1) You may need an
-        appropriate loader to handle this file type, currently no loaders are
-        configured to process this file. See
+        ./foo.js 1:1 Module parse failed: Unterminated template (1:1) You may
+        need an appropriate loader to handle this file type, currently no
+        loaders are configured to process this file. See
         https://webpack.js.org/concepts#loaders &gt; \`;a
       </div>
       <br /><br />

--- a/test/e2e/__snapshots__/overlay.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/overlay.test.js.snap.webpack5
@@ -1,5 +1,33 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`overlay should not show a warning when "client.overlay" is "false": page html 1`] = `
+"<body>
+  <script type=\\"text/javascript\\" charset=\\"utf-8\\" src=\\"/main.js\\"></script>
+</body>
+"
+`;
+
+exports[`overlay should not show a warning when "client.overlay.warnings" is "false": page html 1`] = `
+"<body>
+  <script type=\\"text/javascript\\" charset=\\"utf-8\\" src=\\"/main.js\\"></script>
+</body>
+"
+`;
+
+exports[`overlay should not show an error when "client.overlay" is "false": page html 1`] = `
+"<body>
+  <script type=\\"text/javascript\\" charset=\\"utf-8\\" src=\\"/main.js\\"></script>
+</body>
+"
+`;
+
+exports[`overlay should not show an error when "client.overlay.errors" is "false": page html 1`] = `
+"<body>
+  <script type=\\"text/javascript\\" charset=\\"utf-8\\" src=\\"/main.js\\"></script>
+</body>
+"
+`;
+
 exports[`overlay should not show initially, then show on an error and allow to close: overlay html 1`] = `
 "<body>
   <div
@@ -314,35 +342,7 @@ exports[`overlay should not show initially, then show on an error, then show oth
 "
 `;
 
-exports[`overlay should not show on a warning when "client.overlay" is "false": page html 1`] = `
-"<body>
-  <script type=\\"text/javascript\\" charset=\\"utf-8\\" src=\\"/main.js\\"></script>
-</body>
-"
-`;
-
-exports[`overlay should not show on a warning when "client.overlay.warnings" is "false": page html 1`] = `
-"<body>
-  <script type=\\"text/javascript\\" charset=\\"utf-8\\" src=\\"/main.js\\"></script>
-</body>
-"
-`;
-
-exports[`overlay should not show on an error when "client.overlay" is "false": page html 1`] = `
-"<body>
-  <script type=\\"text/javascript\\" charset=\\"utf-8\\" src=\\"/main.js\\"></script>
-</body>
-"
-`;
-
-exports[`overlay should not show on an error when "client.overlay.errors" is "false": page html 1`] = `
-"<body>
-  <script type=\\"text/javascript\\" charset=\\"utf-8\\" src=\\"/main.js\\"></script>
-</body>
-"
-`;
-
-exports[`overlay should show on a warning and error for initial compilation and protects against xss: overlay html 1`] = `
+exports[`overlay should show a warning and error for initial compilation and protects against xss: overlay html 1`] = `
 "<body>
   <div
     id=\\"webpack-dev-server-client-overlay-div\\"
@@ -391,7 +391,7 @@ exports[`overlay should show on a warning and error for initial compilation and 
 "
 `;
 
-exports[`overlay should show on a warning and error for initial compilation and protects against xss: page html 1`] = `
+exports[`overlay should show a warning and error for initial compilation and protects against xss: page html 1`] = `
 "<body>
   <script type=\\"text/javascript\\" charset=\\"utf-8\\" src=\\"/main.js\\"></script>
   <iframe
@@ -410,7 +410,7 @@ exports[`overlay should show on a warning and error for initial compilation and 
 "
 `;
 
-exports[`overlay should show on a warning and error for initial compilation: overlay html 1`] = `
+exports[`overlay should show a warning and error for initial compilation: overlay html 1`] = `
 "<body>
   <div
     id=\\"webpack-dev-server-client-overlay-div\\"
@@ -474,7 +474,7 @@ exports[`overlay should show on a warning and error for initial compilation: ove
 "
 `;
 
-exports[`overlay should show on a warning and error for initial compilation: page html 1`] = `
+exports[`overlay should show a warning and error for initial compilation: page html 1`] = `
 "<body>
   <script type=\\"text/javascript\\" charset=\\"utf-8\\" src=\\"/main.js\\"></script>
   <iframe
@@ -493,7 +493,7 @@ exports[`overlay should show on a warning and error for initial compilation: pag
 "
 `;
 
-exports[`overlay should show on a warning for initial compilation: overlay html 1`] = `
+exports[`overlay should show a warning and hide them after closing connection: overlay html 1`] = `
 "<body>
   <div
     id=\\"webpack-dev-server-client-overlay-div\\"
@@ -537,7 +537,7 @@ exports[`overlay should show on a warning for initial compilation: overlay html 
 "
 `;
 
-exports[`overlay should show on a warning for initial compilation: page html 1`] = `
+exports[`overlay should show a warning and hide them after closing connection: page html 1`] = `
 "<body>
   <script type=\\"text/javascript\\" charset=\\"utf-8\\" src=\\"/main.js\\"></script>
   <iframe
@@ -556,7 +556,14 @@ exports[`overlay should show on a warning for initial compilation: page html 1`]
 "
 `;
 
-exports[`overlay should show on a warning when "client.overlay" is "true": overlay html 1`] = `
+exports[`overlay should show a warning and hide them after closing connection: page html 2`] = `
+"<body>
+  <script type=\\"text/javascript\\" charset=\\"utf-8\\" src=\\"/main.js\\"></script>
+</body>
+"
+`;
+
+exports[`overlay should show a warning for initial compilation: overlay html 1`] = `
 "<body>
   <div
     id=\\"webpack-dev-server-client-overlay-div\\"
@@ -600,7 +607,7 @@ exports[`overlay should show on a warning when "client.overlay" is "true": overl
 "
 `;
 
-exports[`overlay should show on a warning when "client.overlay" is "true": page html 1`] = `
+exports[`overlay should show a warning for initial compilation: page html 1`] = `
 "<body>
   <script type=\\"text/javascript\\" charset=\\"utf-8\\" src=\\"/main.js\\"></script>
   <iframe
@@ -619,7 +626,7 @@ exports[`overlay should show on a warning when "client.overlay" is "true": page 
 "
 `;
 
-exports[`overlay should show on a warning when "client.overlay.errors" is "true": overlay html 1`] = `
+exports[`overlay should show a warning when "client.overlay" is "true": overlay html 1`] = `
 "<body>
   <div
     id=\\"webpack-dev-server-client-overlay-div\\"
@@ -663,7 +670,7 @@ exports[`overlay should show on a warning when "client.overlay.errors" is "true"
 "
 `;
 
-exports[`overlay should show on a warning when "client.overlay.errors" is "true": page html 1`] = `
+exports[`overlay should show a warning when "client.overlay" is "true": page html 1`] = `
 "<body>
   <script type=\\"text/javascript\\" charset=\\"utf-8\\" src=\\"/main.js\\"></script>
   <iframe
@@ -682,7 +689,7 @@ exports[`overlay should show on a warning when "client.overlay.errors" is "true"
 "
 `;
 
-exports[`overlay should show on a warning when "client.overlay.warnings" is "true": overlay html 1`] = `
+exports[`overlay should show a warning when "client.overlay.errors" is "true": overlay html 1`] = `
 "<body>
   <div
     id=\\"webpack-dev-server-client-overlay-div\\"
@@ -726,7 +733,7 @@ exports[`overlay should show on a warning when "client.overlay.warnings" is "tru
 "
 `;
 
-exports[`overlay should show on a warning when "client.overlay.warnings" is "true": page html 1`] = `
+exports[`overlay should show a warning when "client.overlay.errors" is "true": page html 1`] = `
 "<body>
   <script type=\\"text/javascript\\" charset=\\"utf-8\\" src=\\"/main.js\\"></script>
   <iframe
@@ -745,7 +752,70 @@ exports[`overlay should show on a warning when "client.overlay.warnings" is "tru
 "
 `;
 
-exports[`overlay should show on an ansi formatted error for initial compilation: overlay html 1`] = `
+exports[`overlay should show a warning when "client.overlay.warnings" is "true": overlay html 1`] = `
+"<body>
+  <div
+    id=\\"webpack-dev-server-client-overlay-div\\"
+    style=\\"
+      position: fixed;
+      box-sizing: border-box;
+      inset: 0px;
+      width: 100vw;
+      height: 100vh;
+      background-color: rgba(0, 0, 0, 0.85);
+      color: rgb(232, 232, 232);
+      font-family: Menlo, Consolas, monospace;
+      font-size: large;
+      padding: 2rem;
+      line-height: 1.2;
+      white-space: pre-wrap;
+      overflow: auto;
+    \\"
+  >
+    <span>Compiled with problems:</span
+    ><button
+      style=\\"
+        background: transparent;
+        border: none;
+        font-size: 20px;
+        font-weight: bold;
+        color: white;
+        cursor: pointer;
+        float: right;
+      \\"
+    >
+      X</button
+    ><br /><br />
+    <div>
+      <span style=\\"color: rgb(227, 96, 73)\\">Warning:</span><br /><br />
+      <div>Warning from compilation</div>
+      <br /><br />
+    </div>
+  </div>
+</body>
+"
+`;
+
+exports[`overlay should show a warning when "client.overlay.warnings" is "true": page html 1`] = `
+"<body>
+  <script type=\\"text/javascript\\" charset=\\"utf-8\\" src=\\"/main.js\\"></script>
+  <iframe
+    id=\\"webpack-dev-server-client-overlay\\"
+    src=\\"about:blank\\"
+    style=\\"
+      position: fixed;
+      inset: 0px;
+      width: 100vw;
+      height: 100vh;
+      border: none;
+      z-index: 2147483647;
+    \\"
+  ></iframe>
+</body>
+"
+`;
+
+exports[`overlay should show an ansi formatted error for initial compilation: overlay html 1`] = `
 "<body>
   <div
     id=\\"webpack-dev-server-client-overlay-div\\"
@@ -802,7 +872,7 @@ exports[`overlay should show on an ansi formatted error for initial compilation:
 "
 `;
 
-exports[`overlay should show on an ansi formatted error for initial compilation: page html 1`] = `
+exports[`overlay should show an ansi formatted error for initial compilation: page html 1`] = `
 "<body>
   <script type=\\"text/javascript\\" charset=\\"utf-8\\" src=\\"/main.js\\"></script>
   <iframe
@@ -821,7 +891,7 @@ exports[`overlay should show on an ansi formatted error for initial compilation:
 "
 `;
 
-exports[`overlay should show on an error for initial compilation: overlay html 1`] = `
+exports[`overlay should show an error for initial compilation: overlay html 1`] = `
 "<body>
   <div
     id=\\"webpack-dev-server-client-overlay-div\\"
@@ -865,7 +935,7 @@ exports[`overlay should show on an error for initial compilation: overlay html 1
 "
 `;
 
-exports[`overlay should show on an error for initial compilation: page html 1`] = `
+exports[`overlay should show an error for initial compilation: page html 1`] = `
 "<body>
   <script type=\\"text/javascript\\" charset=\\"utf-8\\" src=\\"/main.js\\"></script>
   <iframe
@@ -884,7 +954,7 @@ exports[`overlay should show on an error for initial compilation: page html 1`] 
 "
 `;
 
-exports[`overlay should show on an error when "client.overlay" is "true": overlay html 1`] = `
+exports[`overlay should show an error when "client.overlay" is "true": overlay html 1`] = `
 "<body>
   <div
     id=\\"webpack-dev-server-client-overlay-div\\"
@@ -928,7 +998,7 @@ exports[`overlay should show on an error when "client.overlay" is "true": overla
 "
 `;
 
-exports[`overlay should show on an error when "client.overlay" is "true": page html 1`] = `
+exports[`overlay should show an error when "client.overlay" is "true": page html 1`] = `
 "<body>
   <script type=\\"text/javascript\\" charset=\\"utf-8\\" src=\\"/main.js\\"></script>
   <iframe
@@ -947,7 +1017,7 @@ exports[`overlay should show on an error when "client.overlay" is "true": page h
 "
 `;
 
-exports[`overlay should show on an error when "client.overlay.errors" is "true": overlay html 1`] = `
+exports[`overlay should show an error when "client.overlay.errors" is "true": overlay html 1`] = `
 "<body>
   <div
     id=\\"webpack-dev-server-client-overlay-div\\"
@@ -991,7 +1061,7 @@ exports[`overlay should show on an error when "client.overlay.errors" is "true":
 "
 `;
 
-exports[`overlay should show on an error when "client.overlay.errors" is "true": page html 1`] = `
+exports[`overlay should show an error when "client.overlay.errors" is "true": page html 1`] = `
 "<body>
   <script type=\\"text/javascript\\" charset=\\"utf-8\\" src=\\"/main.js\\"></script>
   <iframe
@@ -1010,7 +1080,7 @@ exports[`overlay should show on an error when "client.overlay.errors" is "true":
 "
 `;
 
-exports[`overlay should show on an error when "client.overlay.warnings" is "true": overlay html 1`] = `
+exports[`overlay should show an error when "client.overlay.warnings" is "true": overlay html 1`] = `
 "<body>
   <div
     id=\\"webpack-dev-server-client-overlay-div\\"
@@ -1054,7 +1124,7 @@ exports[`overlay should show on an error when "client.overlay.warnings" is "true
 "
 `;
 
-exports[`overlay should show on an error when "client.overlay.warnings" is "true": page html 1`] = `
+exports[`overlay should show an error when "client.overlay.warnings" is "true": page html 1`] = `
 "<body>
   <script type=\\"text/javascript\\" charset=\\"utf-8\\" src=\\"/main.js\\"></script>
   <iframe


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [x] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [x] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

Yes

### Motivation / Use-Case

close overlay when connection is disconnected 

### Breaking Changes

No

### Additional Info

Also it fixed duplicate errors/warnings after stop and run again server
