### PR TITLE
fix: don't reserve unused port too early

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -2071,6 +2071,7 @@ class Server {
 
   async start() {
     await this.normalizeOptions();
+    await this.initialize();
 
     if (this.options.ipc) {
       await new Promise((resolve, reject) => {
@@ -2102,8 +2103,6 @@ class Server {
       this.options.host = await Server.getHostname(this.options.host);
       this.options.port = await Server.getFreePort(this.options.port);
     }
-
-    await this.initialize();
 
     const listenOptions = this.options.ipc
       ? { path: this.options.ipc }


### PR DESCRIPTION

<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [x] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**


### For Bugs and Features; did you add new tests?
### Motivation / Use-Case
At the moment, when starting 2 processes at the same time and using `port: 0` or `port auto` in the majority of cases one of the servers will fail because both server will end up being assigned the same port.

The reason for this is that a number of precious milliseconds elapse between the `getFreePort` and `listen` call. The main reason for this is the `initialize` method.

```
../Users/cli-reproductions/node_modules/webpack-dev-server/lib/Server.js:1544
      throw error;
Error: listen EADDRINUSE: address already in use 127.0.0.1:8080
    at Server.setupListenHandle [as _listen2] (net.js:1320:16)
    at listenInCluster (net.js:1368:12)
    at GetAddrInfoReqWrap.doListen [as callback] (net.js:1505:7)
    at GetAddrInfoReqWrap.onlookup [as oncomplete] (dns.js:71:8) {
  code: 'EADDRINUSE',
  errno: -48,
  syscall: 'listen',
  address: '127.0.0.1',
  port: 8080
}
```



<!-- Please note that we won't approve your changes if you don't add tests. -->



<!--
  What existing problem does the pull request solve?

  Please explain the motivation or use-case for making this change.
  If this Pull Request addresses an issue, please link to the issue.
-->

