### PR TITLE
perf: remove assets from stats

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -36,13 +36,14 @@ class Server {
     this.webSocketProxies = [];
     this.sockets = [];
     this.compiler = compiler;
+    this.currentHash = null;
   }
 
   static get DEFAULT_STATS() {
     return {
       all: false,
       hash: true,
-      assets: true,
+      assets: false,
       warnings: true,
       errors: true,
       errorDetails: false,
@@ -2006,13 +2007,13 @@ class Server {
 
   // Send stats to a socket or multiple sockets
   sendStats(clients, stats, force) {
+    this.currentHash = this.currentHash ?? stats.hash;
     const shouldEmit =
       !force &&
       stats &&
       (!stats.errors || stats.errors.length === 0) &&
       (!stats.warnings || stats.warnings.length === 0) &&
-      stats.assets &&
-      stats.assets.every((asset) => !asset.emitted);
+      this.currentHash === stats.hash;
 
     if (shouldEmit) {
       this.sendMessage(clients, "still-ok");
@@ -2020,6 +2021,7 @@ class Server {
       return;
     }
 
+    this.currentHash = stats.hash;
     this.sendMessage(clients, "hash", stats.hash);
 
     if (stats.errors.length > 0 || stats.warnings.length > 0) {


### PR DESCRIPTION
- [ x ] This is a **bugfix**

### For Bugs and Features; did you add new tests?

no, I am willing to, but am unsure exactly where this functionality is currently being tests

### Motivation / Use-Case

stats.toJson call is more expensive with `assets` enabled, but it is not needed. Instead, we still keep track of hash so as to keep to only refresh the page when there is a real change (saving file with no changes will not refresh the page)

Before
![image](https://user-images.githubusercontent.com/16494982/135504356-b94b7c44-8382-4513-a1ff-699d45005d5b.png)

After
![image](https://user-images.githubusercontent.com/16494982/135504466-755d496a-0378-438c-92cd-1cfdbee3080b.png)


### Breaking Changes

none

### Additional Info
