### PR TITLE
fix: fix live reload for child compiler scenario

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -1184,7 +1184,7 @@ class Server {
       result.hash = `${result.hash || ""}|${statsJson.hash}`;
       result.errors = [...(result.errors || []), ...statsJson.errors];
       result.warnings = [...(result.warnings || []), ...statsJson.warnings];
-      statsJson.children.forEach((child) => {
+      (statsJson.children || []).forEach((child) => {
         reduceFn(child, result);
       });
       return result;

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -42,6 +42,7 @@ class Server {
   static get DEFAULT_STATS() {
     return {
       all: false,
+      children: true,
       hash: true,
       warnings: true,
       errors: true,
@@ -1179,7 +1180,17 @@ class Server {
       stats.warningsFilter = compilerOptions.stats.warningsFilter;
     }
 
-    return statsObj.toJson(stats);
+    const reduceFn = (statsJson, result = {}) => {
+      result.hash = `${result.hash || ""}|${statsJson.hash}`;
+      result.errors = [...(result.errors || []), ...statsJson.errors];
+      result.warnings = [...(result.warnings || []), ...statsJson.warnings];
+      statsJson.children.forEach((child) => {
+        reduceFn(child, result);
+      });
+      return result;
+    };
+
+    return reduceFn(statsObj.toJson(stats));
   }
 
   setupHooks() {

--- a/test/e2e/__snapshots__/hot-and-live-reload.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/hot-and-live-reload.test.js.snap.webpack5
@@ -45,6 +45,11 @@ Array [
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] Live Reloading enabled.",
+  "[webpack-dev-server] App updated. Recompiling...",
+  "[webpack-dev-server] App updated. Reloading...",
+  "[HMR] Waiting for update signal from WDS...",
+  "[webpack-dev-server] Hot Module Replacement enabled.",
+  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -300,6 +305,9 @@ Array [
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
   "[webpack-dev-server] Live Reloading enabled.",
+  "[webpack-dev-server] App updated. Recompiling...",
+  "[webpack-dev-server] App updated. Reloading...",
+  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -311,6 +319,9 @@ Array [
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
   "[webpack-dev-server] Live Reloading enabled.",
+  "[webpack-dev-server] App updated. Recompiling...",
+  "[webpack-dev-server] App updated. Reloading...",
+  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -318,6 +329,9 @@ exports[`hot and live reload should work and refresh content using live reload w
 
 exports[`hot and live reload should work and refresh content using live reload when live reload enabled and hot disabled (ws): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Live Reloading enabled.",
+  "[webpack-dev-server] App updated. Recompiling...",
+  "[webpack-dev-server] App updated. Reloading...",
   "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
@@ -347,6 +361,10 @@ exports[`hot and live reload should work with manual client setup (default): pag
 
 exports[`hot and live reload should work with manual client setup and allow to disable hot module replacement (default): console messages 1`] = `
 Array [
+  "[HMR] Waiting for update signal from WDS...",
+  "[webpack-dev-server] Live Reloading enabled.",
+  "[webpack-dev-server] App updated. Recompiling...",
+  "[webpack-dev-server] App updated. Reloading...",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
@@ -385,6 +403,9 @@ exports[`hot and live reload should work with manual client setup and allow to e
 
 exports[`hot and live reload should work with manual client setup and allow to enable live reload (default): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Live Reloading enabled.",
+  "[webpack-dev-server] App updated. Recompiling...",
+  "[webpack-dev-server] App updated. Reloading...",
   "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",

--- a/test/e2e/hot-and-live-reload.test.js
+++ b/test/e2e/hot-and-live-reload.test.js
@@ -15,6 +15,8 @@ const reloadConfig = require("../fixtures/reload-config/webpack.config");
 const runBrowser = require("../helpers/run-browser");
 const port = require("../ports-map")["hot-and-live-reload"];
 
+const isWebpack5 = webpack.version.startsWith("5");
+
 const cssFilePath = path.resolve(
   __dirname,
   "../fixtures/reload-config/main.css"
@@ -570,9 +572,10 @@ describe("hot and live reload", () => {
         expect(backgroundColorAfter).toEqual("rgb(255, 0, 0)");
       }
 
-      fs.writeFileSync(jsFilePath, "console.log('hello from child.js');");
-
-      await waitFunc();
+      if (isWebpack5) {
+        fs.writeFileSync(jsFilePath, "console.log('hello from child.js');");
+        await waitFunc();
+      }
 
       expect(consoleMessages).toMatchSnapshot("console messages");
       expect(pageErrors).toMatchSnapshot("page errors");

--- a/test/fixtures/reload-config/webpack.config.js
+++ b/test/fixtures/reload-config/webpack.config.js
@@ -2,7 +2,43 @@
 
 const webpack = require("webpack");
 
+const { EntryOptionPlugin, Compilation } = webpack;
+const { getNormalizedWebpackOptions } = webpack.config;
+
 const isWebpack5 = webpack.version.startsWith("5");
+
+class TestChildCompilerPlugin {
+  constructor(options) {
+    this.options = getNormalizedWebpackOptions(options);
+  }
+
+  apply(compiler) {
+    compiler.hooks.thisCompilation.tap(
+      "TestApplyEntryOptionPlugin",
+      (compilation) => {
+        compilation.hooks.processAssets.tapAsync(
+          {
+            name: "TestChildCompilerPlugin",
+            stage: Compilation.PROCESS_ASSETS_STAGE_SUMMARIZE,
+          },
+          (assets, callback) => {
+            const child = compilation.createChildCompiler(
+              "TestChildCompilerPlugin"
+            );
+            EntryOptionPlugin.applyEntryOption(
+              child,
+              compilation.compiler.context,
+              this.options.entry
+            );
+            child.runAsChild(() => {
+              callback();
+            });
+          }
+        );
+      }
+    );
+  }
+}
 
 module.exports = {
   mode: "development",
@@ -30,4 +66,12 @@ module.exports = {
     : {
         level: "info",
       },
+
+  plugins: [
+    new TestChildCompilerPlugin({
+      entry: {
+        child: "./child",
+      },
+    }),
+  ],
 };

--- a/test/fixtures/reload-config/webpack.config.js
+++ b/test/fixtures/reload-config/webpack.config.js
@@ -3,40 +3,35 @@
 const webpack = require("webpack");
 
 const { EntryOptionPlugin, Compilation } = webpack;
-const { getNormalizedWebpackOptions } = webpack.config;
 
 const isWebpack5 = webpack.version.startsWith("5");
 
 class TestChildCompilerPlugin {
   constructor(options) {
-    this.options = getNormalizedWebpackOptions(options);
+    this.name = "TestChildCompilerPlugin";
+    this.options = webpack.config.getNormalizedWebpackOptions(options);
   }
 
   apply(compiler) {
-    compiler.hooks.thisCompilation.tap(
-      "TestApplyEntryOptionPlugin",
-      (compilation) => {
-        compilation.hooks.processAssets.tapAsync(
-          {
-            name: "TestChildCompilerPlugin",
-            stage: Compilation.PROCESS_ASSETS_STAGE_SUMMARIZE,
-          },
-          (assets, callback) => {
-            const child = compilation.createChildCompiler(
-              "TestChildCompilerPlugin"
-            );
-            EntryOptionPlugin.applyEntryOption(
-              child,
-              compilation.compiler.context,
-              this.options.entry
-            );
-            child.runAsChild(() => {
-              callback();
-            });
-          }
-        );
-      }
-    );
+    compiler.hooks.thisCompilation.tap(this.name, (compilation) => {
+      compilation.hooks.processAssets.tapAsync(
+        {
+          name: this.name,
+          stage: Compilation.PROCESS_ASSETS_STAGE_SUMMARIZE,
+        },
+        (assets, callback) => {
+          const child = compilation.createChildCompiler(this.name);
+          EntryOptionPlugin.applyEntryOption(
+            child,
+            compilation.compiler.context,
+            this.options.entry
+          );
+          child.runAsChild(() => {
+            callback();
+          });
+        }
+      );
+    });
   }
 }
 
@@ -67,11 +62,13 @@ module.exports = {
         level: "info",
       },
 
-  plugins: [
-    new TestChildCompilerPlugin({
-      entry: {
-        child: "./child",
-      },
-    }),
-  ],
+  plugins: isWebpack5
+    ? [
+        new TestChildCompilerPlugin({
+          entry: {
+            child: "./child",
+          },
+        }),
+      ]
+    : [],
 };


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

fix #3971

- [X] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

Currently, webpack-dev-server only cares `stats.hash` but this hash does not count child compilation when you run the childCompiler after parent's `seal` stage.

<!-- Please note that we won't approve your changes if you don't add tests. -->

### Motivation / Use-Case

<!--
  What existing problem does the pull request solve?

  Please explain the motivation or use-case for making this change.
  If this Pull Request addresses an issue, please link to the issue.
-->

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  potential migration path for existing applications.
-->

### Additional Info
