### PR TITLE
fix: invalid host message is missing on clientwith https (#3997)

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -1633,7 +1633,9 @@ class Server {
       ) {
         this.sendMessage([client], "error", "Invalid Host/Origin header");
 
-        client.terminate();
+        // With https enabled, the sendMessage above is encrypted asynchronously so not yet sent
+        // Terminate would prevent it sending, so use close to allow it to be sent
+        client.close();
 
         return;
       }

--- a/test/e2e/__snapshots__/allowed-hosts.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/allowed-hosts.test.js.snap.webpack4
@@ -278,6 +278,30 @@ Array [
 
 exports[`allowed hosts should disconnect web socket client using custom hostname from web socket server with the "auto" value based on the "host" header ("ws"): page errors 1`] = `Array []`;
 
+exports[`allowed hosts should disconnect web socket client using custom hostname from web socket server with the "auto" value based on the "host" header when "https" is enabled ("sockjs"): console messages 1`] = `
+Array [
+  "[HMR] Waiting for update signal from WDS...",
+  "Hey.",
+  "[webpack-dev-server] Invalid Host/Origin header",
+  "[webpack-dev-server] Disconnected!",
+  "[webpack-dev-server] Trying to reconnect...",
+]
+`;
+
+exports[`allowed hosts should disconnect web socket client using custom hostname from web socket server with the "auto" value based on the "host" header when "https" is enabled ("sockjs"): page errors 1`] = `Array []`;
+
+exports[`allowed hosts should disconnect web socket client using custom hostname from web socket server with the "auto" value based on the "host" header when "https" is enabled ("ws"): console messages 1`] = `
+Array [
+  "[HMR] Waiting for update signal from WDS...",
+  "Hey.",
+  "[webpack-dev-server] Invalid Host/Origin header",
+  "[webpack-dev-server] Disconnected!",
+  "[webpack-dev-server] Trying to reconnect...",
+]
+`;
+
+exports[`allowed hosts should disconnect web socket client using custom hostname from web socket server with the "auto" value based on the "host" header when "https" is enabled ("ws"): page errors 1`] = `Array []`;
+
 exports[`allowed hosts should disconnect web socket client using custom hostname from web socket server with the "auto" value based on the "origin" header ("sockjs"): console messages 1`] = `
 Array [
   "[HMR] Waiting for update signal from WDS...",

--- a/test/e2e/__snapshots__/allowed-hosts.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/allowed-hosts.test.js.snap.webpack5
@@ -278,6 +278,30 @@ Array [
 
 exports[`allowed hosts should disconnect web socket client using custom hostname from web socket server with the "auto" value based on the "host" header ("ws"): page errors 1`] = `Array []`;
 
+exports[`allowed hosts should disconnect web socket client using custom hostname from web socket server with the "auto" value based on the "host" header when "https" is enabled ("sockjs"): console messages 1`] = `
+Array [
+  "[HMR] Waiting for update signal from WDS...",
+  "Hey.",
+  "[webpack-dev-server] Invalid Host/Origin header",
+  "[webpack-dev-server] Disconnected!",
+  "[webpack-dev-server] Trying to reconnect...",
+]
+`;
+
+exports[`allowed hosts should disconnect web socket client using custom hostname from web socket server with the "auto" value based on the "host" header when "https" is enabled ("sockjs"): page errors 1`] = `Array []`;
+
+exports[`allowed hosts should disconnect web socket client using custom hostname from web socket server with the "auto" value based on the "host" header when "https" is enabled ("ws"): console messages 1`] = `
+Array [
+  "[HMR] Waiting for update signal from WDS...",
+  "Hey.",
+  "[webpack-dev-server] Invalid Host/Origin header",
+  "[webpack-dev-server] Disconnected!",
+  "[webpack-dev-server] Trying to reconnect...",
+]
+`;
+
+exports[`allowed hosts should disconnect web socket client using custom hostname from web socket server with the "auto" value based on the "host" header when "https" is enabled ("ws"): page errors 1`] = `Array []`;
+
 exports[`allowed hosts should disconnect web socket client using custom hostname from web socket server with the "auto" value based on the "origin" header ("sockjs"): console messages 1`] = `
 Array [
   "[HMR] Waiting for update signal from WDS...",

--- a/test/e2e/allowed-hosts.test.js
+++ b/test/e2e/allowed-hosts.test.js
@@ -88,6 +88,85 @@ describe("allowed hosts", () => {
       await server.stop();
     });
 
+    it(`should disconnect web socket client using custom hostname from web socket server with the "auto" value based on the "host" header when "https" is enabled ("${webSocketServer}")`, async () => {
+      const devServerHost = "127.0.0.1";
+      const devServerPort = port1;
+      const proxyHost = devServerHost;
+      const proxyPort = port2;
+
+      const compiler = webpack(config);
+      const devServerOptions = {
+        client: {
+          webSocketURL: {
+            port: port2,
+            protocol: "ws",
+          },
+        },
+        webSocketServer,
+        port: devServerPort,
+        host: devServerHost,
+        allowedHosts: "auto",
+        https: true,
+      };
+      const server = new Server(devServerOptions, compiler);
+
+      await server.start();
+
+      function startProxy(callback) {
+        const app = express();
+
+        app.use(
+          "/",
+          createProxyMiddleware({
+            // Emulation
+            onProxyReqWs: (proxyReq) => {
+              proxyReq.setHeader("host", "my-test-host");
+            },
+            target: `https://${devServerHost}:${devServerPort}`,
+            secure: false,
+            ws: true,
+            changeOrigin: true,
+            logLevel: "warn",
+          })
+        );
+
+        return app.listen(proxyPort, proxyHost, callback);
+      }
+
+      const proxy = await new Promise((resolve) => {
+        const proxyCreated = startProxy(() => {
+          resolve(proxyCreated);
+        });
+      });
+
+      const { page, browser } = await runBrowser();
+
+      const pageErrors = [];
+      const consoleMessages = [];
+
+      page
+        .on("console", (message) => {
+          consoleMessages.push(message);
+        })
+        .on("pageerror", (error) => {
+          pageErrors.push(error);
+        });
+
+      await page.goto(`http://${proxyHost}:${proxyPort}/main`, {
+        waitUntil: "networkidle0",
+      });
+
+      expect(consoleMessages.map((message) => message.text())).toMatchSnapshot(
+        "console messages"
+      );
+      expect(pageErrors).toMatchSnapshot("page errors");
+
+      proxy.close();
+
+      await browser.close();
+      await server.stop();
+    });
+
     it(`should disconnect web socket client using custom hostname from web socket server with the "auto" value based on the "origin" header ("${webSocketServer}")`, async () => {
       const devServerHost = "127.0.0.1";
       const devServerPort = port1;


### PR DESCRIPTION
- [x] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [x] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

Added a new test that successfully fails with `client.terminate`

### Motivation / Use-Case

See #3997. When host/origin headers do not match, `client.terminate` was being called. However, when HTTPS is enabled, this message is encrypted asynchronously by NodeJS before it gets written to the socket. Therefore, when `client.terminate` destroys the underlying socket the previous `sendMessage` had not yet been written to the socket.

Only applies when HTTPS is enabled.

Using `client.close` ensures that the socket is closed after all data is sent.

### Breaking Changes

None

### Additional Info

Granted, with a bad client, this could leak forever as there is no timeout. However, I do not see timeouts elsewhere so they could be added as part of adding them elsewhere. It's also a development tool that is unlikely to be very long lived, and will be extremely easy to restart upon any issue (always attended), so it's likely timeouts would unnecessarily overcomplicate the implementation with little benefit.

I also fixed loads of warnings I was getting running tests about EventEmitter leaks due to the signal listener that is registered when creating an instance. I can remove this code from this commit if it's a problem - it seemed very minor and fine to add as part of same commit - and either omit it entirely or raise separately for you.

Fixes #3997 