### PR TITLE
fix: show deprecation warning for both `https` and `http2`

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -674,14 +674,21 @@ class Server {
     const isHTTPs = Boolean(options.https);
     const isSPDY = Boolean(options.http2);
 
-    if (isHTTPs || isSPDY) {
+    if (isHTTPs) {
       // TODO: remove in the next major release
       util.deprecate(
         () => {},
-        `'${
-          isHTTPs ? "https" : "http2"
-        }' option is deprecated. Please use the 'server' option.`,
-        `DEP_WEBPACK_DEV_SERVER_${isHTTPs ? "HTTPS" : "HTTP2"}`
+        "'https' option is deprecated. Please use the 'server' option.",
+        "DEP_WEBPACK_DEV_SERVER_HTTPS"
+      )();
+    }
+
+    if (isSPDY) {
+      // TODO: remove in the next major release
+      util.deprecate(
+        () => {},
+        "'http2' option is deprecated. Please use the 'server' option.",
+        "DEP_WEBPACK_DEV_SERVER_HTTP2"
       )();
     }
 

--- a/test/e2e/http2.test.js
+++ b/test/e2e/http2.test.js
@@ -21,9 +21,12 @@ describe("http2 option", () => {
     let page;
     let browser;
     let HTTPVersion;
+    let utilSpy;
 
     beforeEach(async () => {
       compiler = webpack(config);
+
+      utilSpy = jest.spyOn(util, "deprecate");
 
       server = new Server(
         {
@@ -49,6 +52,7 @@ describe("http2 option", () => {
     });
 
     afterEach(async () => {
+      utilSpy.mockRestore();
       await browser.close();
       await server.stop();
     });
@@ -81,6 +85,15 @@ describe("http2 option", () => {
       });
 
       expect(HTTPVersion).toEqual("h2");
+
+      // should show deprecated warning for both `https` and `http2`
+      expect(utilSpy.mock.calls[0][1]).toBe(
+        "'https' option is deprecated. Please use the 'server' option."
+      );
+
+      expect(utilSpy.mock.calls[1][1]).toBe(
+        "'http2' option is deprecated. Please use the 'server' option."
+      );
 
       http2Req.end();
     });
@@ -118,6 +131,7 @@ describe("http2 option", () => {
     });
 
     afterEach(async () => {
+      utilSpy.mockRestore();
       await browser.close();
       await server.stop();
     });


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [x] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

Yes
<!-- Please note that we won't approve your changes if you don't add tests. -->

### Motivation / Use-Case

show deprecation warning for both `https` and `http2` when used together.

<!--
  What existing problem does the pull request solve?

  Please explain the motivation or use-case for making this change.
  If this Pull Request addresses an issue, please link to the issue.
-->

### Breaking Changes
None
<!--
  If this PR introduces a breaking change, please describe the impact and a
  potential migration path for existing applications.
-->

### Additional Info
No