### PR TITLE
fix: mark `--open-app` deprecated in favor of `--open-app-name`

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Options:
   --no-open                                 Does not open the default browser.
   --open-target <value...>                  Opens specified page in browser.
   --open-app-name <value...>                Open specified browser.
-  --open-app <value...>                     Open specified browser. Deprecated: please use open.app.name/--open-app-name.
+  --open-app <value...>                     Open specified browser. Deprecated: please use '--open-app-name'.
   --open-reset                              Clear all items provided in 'open' configuration. Allows to configure dev server to open the browser(s) and page(s) after server had been started (set it to true to open your default browser).
   --open-target-reset                       Clear all items provided in 'open.target' configuration. Opens specified page in browser.
   --open-app-name-reset                     Clear all items provided in 'open.app.name' configuration. Open specified browser.

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Options:
   --no-open                                 Does not open the default browser.
   --open-target <value...>                  Opens specified page in browser.
   --open-app-name <value...>                Open specified browser.
-  --open-app <value...>                     Open specified browser.
+  --open-app <value...>                     Open specified browser. Deprecated: please use open.app.name/--open-app-name.
   --open-reset                              Clear all items provided in 'open' configuration. Allows to configure dev server to open the browser(s) and page(s) after server had been started (set it to true to open your default browser).
   --open-target-reset                       Clear all items provided in 'open.target' configuration. Opens specified page in browser.
   --open-app-name-reset                     Clear all items provided in 'open.app.name' configuration. Open specified browser.

--- a/bin/cli-flags.js
+++ b/bin/cli-flags.js
@@ -806,11 +806,13 @@ module.exports = {
       {
         type: "string",
         multiple: true,
-        description: "Open specified browser.",
+        description:
+          "Open specified browser. Deprecated: please use open.app.name/--open-app-name.",
         path: "open[].app",
       },
     ],
-    description: "Open specified browser.",
+    description:
+      "Open specified browser. Deprecated: please use open.app.name/--open-app-name.",
     simpleType: "string",
     multiple: true,
   },

--- a/bin/cli-flags.js
+++ b/bin/cli-flags.js
@@ -807,12 +807,12 @@ module.exports = {
         type: "string",
         multiple: true,
         description:
-          "Open specified browser. Deprecated: please use open.app.name/--open-app-name.",
+          "Open specified browser. Deprecated: please use '--open-app-name'.",
         path: "open[].app",
       },
     ],
     description:
-      "Open specified browser. Deprecated: please use open.app.name/--open-app-name.",
+      "Open specified browser. Deprecated: please use '--open-app-name'.",
     simpleType: "string",
     multiple: true,
   },

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -910,6 +910,7 @@ class Server {
 
     // https://github.com/webpack/webpack-dev-server/issues/1990
     const defaultOpenOptions = { wait: false };
+    // TODO: remove --open-app in favor of --open-app-name
     const getOpenItemsFromObject = ({ target, ...rest }) => {
       const normalizedOptions = { ...defaultOpenOptions, ...rest };
 

--- a/lib/options.json
+++ b/lib/options.json
@@ -581,7 +581,7 @@
             {
               "type": "string",
               "minLength": 1,
-              "description": "Open specified browser. Deprecated: please use open.app.name/--open-app-name."
+              "description": "Open specified browser. Deprecated: please use '--open-app-name'."
             }
           ],
           "description": "Open specified browser."

--- a/lib/options.json
+++ b/lib/options.json
@@ -580,7 +580,8 @@
             },
             {
               "type": "string",
-              "minLength": 1
+              "minLength": 1,
+              "description": "Open specified browser. Deprecated: please use open.app.name/--open-app-name."
             }
           ],
           "description": "Open specified browser."

--- a/test/__snapshots__/validate-options.test.js.snap.webpack4
+++ b/test/__snapshots__/validate-options.test.js.snap.webpack4
@@ -521,7 +521,7 @@ exports[`options validate should throw an error on the "open" option with '{"app
        * options.open.app should be an object:
          object { name?, arguments? }
        * options.open.app should be a non-empty string.
-         -> Open specified browser. Deprecated: please use open.app.name/--open-app-name."
+         -> Open specified browser. Deprecated: please use '--open-app-name'."
 `;
 
 exports[`options validate should throw an error on the "open" option with '{"foo":"bar"}' value 1`] = `

--- a/test/__snapshots__/validate-options.test.js.snap.webpack4
+++ b/test/__snapshots__/validate-options.test.js.snap.webpack4
@@ -520,7 +520,8 @@ exports[`options validate should throw an error on the "open" option with '{"app
       Details:
        * options.open.app should be an object:
          object { name?, arguments? }
-       * options.open.app should be a non-empty string."
+       * options.open.app should be a non-empty string.
+         -> Open specified browser. Deprecated: please use open.app.name/--open-app-name."
 `;
 
 exports[`options validate should throw an error on the "open" option with '{"foo":"bar"}' value 1`] = `

--- a/test/__snapshots__/validate-options.test.js.snap.webpack5
+++ b/test/__snapshots__/validate-options.test.js.snap.webpack5
@@ -521,7 +521,7 @@ exports[`options validate should throw an error on the "open" option with '{"app
        * options.open.app should be an object:
          object { name?, arguments? }
        * options.open.app should be a non-empty string.
-         -> Open specified browser. Deprecated: please use open.app.name/--open-app-name."
+         -> Open specified browser. Deprecated: please use '--open-app-name'."
 `;
 
 exports[`options validate should throw an error on the "open" option with '{"foo":"bar"}' value 1`] = `

--- a/test/__snapshots__/validate-options.test.js.snap.webpack5
+++ b/test/__snapshots__/validate-options.test.js.snap.webpack5
@@ -520,7 +520,8 @@ exports[`options validate should throw an error on the "open" option with '{"app
       Details:
        * options.open.app should be an object:
          object { name?, arguments? }
-       * options.open.app should be a non-empty string."
+       * options.open.app should be a non-empty string.
+         -> Open specified browser. Deprecated: please use open.app.name/--open-app-name."
 `;
 
 exports[`options validate should throw an error on the "open" option with '{"foo":"bar"}' value 1`] = `

--- a/test/cli/__snapshots__/basic.test.js.snap.webpack4
+++ b/test/cli/__snapshots__/basic.test.js.snap.webpack4
@@ -116,7 +116,7 @@ Options:
   --no-open                                 Does not open the default browser.
   --open-target <value...>                  Opens specified page in browser.
   --open-app-name <value...>                Open specified browser.
-  --open-app <value...>                     Open specified browser.
+  --open-app <value...>                     Open specified browser. Deprecated: please use open.app.name/--open-app-name.
   --open-reset                              Clear all items provided in 'open' configuration. Allows to configure dev server to open the browser(s) and page(s) after server had been started (set it to true to open your default browser).
   --open-target-reset                       Clear all items provided in 'open.target' configuration. Opens specified page in browser.
   --open-app-name-reset                     Clear all items provided in 'open.app.name' configuration. Open specified browser.

--- a/test/cli/__snapshots__/basic.test.js.snap.webpack4
+++ b/test/cli/__snapshots__/basic.test.js.snap.webpack4
@@ -116,7 +116,7 @@ Options:
   --no-open                                 Does not open the default browser.
   --open-target <value...>                  Opens specified page in browser.
   --open-app-name <value...>                Open specified browser.
-  --open-app <value...>                     Open specified browser. Deprecated: please use open.app.name/--open-app-name.
+  --open-app <value...>                     Open specified browser. Deprecated: please use '--open-app-name'.
   --open-reset                              Clear all items provided in 'open' configuration. Allows to configure dev server to open the browser(s) and page(s) after server had been started (set it to true to open your default browser).
   --open-target-reset                       Clear all items provided in 'open.target' configuration. Opens specified page in browser.
   --open-app-name-reset                     Clear all items provided in 'open.app.name' configuration. Open specified browser.

--- a/test/cli/__snapshots__/basic.test.js.snap.webpack5
+++ b/test/cli/__snapshots__/basic.test.js.snap.webpack5
@@ -114,7 +114,7 @@ Options:
   --no-open                                 Negative 'open' option.
   --open-target <value...>                  Opens specified page in browser.
   --open-app-name <value...>                Open specified browser.
-  --open-app <value...>                     Open specified browser. Deprecated: please use open.app.name/--open-app-name.
+  --open-app <value...>                     Open specified browser. Deprecated: please use '--open-app-name'.
   --open-reset                              Clear all items provided in 'open' configuration. Allows to configure dev server to open the browser(s) and page(s) after server had been started (set it to true to open your default browser).
   --open-target-reset                       Clear all items provided in 'open.target' configuration. Opens specified page in browser.
   --open-app-name-reset                     Clear all items provided in 'open.app.name' configuration. Open specified browser.

--- a/test/cli/__snapshots__/basic.test.js.snap.webpack5
+++ b/test/cli/__snapshots__/basic.test.js.snap.webpack5
@@ -114,7 +114,7 @@ Options:
   --no-open                                 Negative 'open' option.
   --open-target <value...>                  Opens specified page in browser.
   --open-app-name <value...>                Open specified browser.
-  --open-app <value...>                     Open specified browser.
+  --open-app <value...>                     Open specified browser. Deprecated: please use open.app.name/--open-app-name.
   --open-reset                              Clear all items provided in 'open' configuration. Allows to configure dev server to open the browser(s) and page(s) after server had been started (set it to true to open your default browser).
   --open-target-reset                       Clear all items provided in 'open.target' configuration. Opens specified page in browser.
   --open-app-name-reset                     Clear all items provided in 'open.app.name' configuration. Open specified browser.


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [x] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [x] This is a **test update**
- [x] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

<!-- Please note that we won't approve your changes if you don't add tests. -->

### Motivation / Use-Case

 mark `--open-app` deprecated in favor of `--open-app-name` because they are duplicate flags.
 Also, add TODO to remove `--open-app`.
<!--
  What existing problem does the pull request solve?

  Please explain the motivation or use-case for making this change.
  If this Pull Request addresses an issue, please link to the issue.
-->

### Breaking Changes
No
<!--
  If this PR introduces a breaking change, please describe the impact and a
  potential migration path for existing applications.
-->

### Additional Info
No