### PR TITLE
fix: allow to pass options for custom server

### DIFF
--- a/lib/options.json
+++ b/lib/options.json
@@ -667,7 +667,14 @@
       "type": "object",
       "properties": {
         "type": {
-          "$ref": "#/definitions/ServerType"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ServerType"
+            },
+            {
+              "$ref": "#/definitions/ServerString"
+            }
+          ]
         },
         "options": {
           "$ref": "#/definitions/ServerOptions"

--- a/test/e2e/__snapshots__/server.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/server.test.js.snap.webpack4
@@ -511,6 +511,23 @@ exports[`server option as object cacert, pfx, key and cert are buffer should han
 "
 `;
 
+exports[`server option as object custom server with options should handle GET request to index route (/): console messages 1`] = `Array []`;
+
+exports[`server option as object custom server with options should handle GET request to index route (/): http options 1`] = `
+Object {
+  "maxHeaderSize": 16384,
+}
+`;
+
+exports[`server option as object custom server with options should handle GET request to index route (/): page errors 1`] = `Array []`;
+
+exports[`server option as object custom server with options should handle GET request to index route (/): response status 1`] = `200`;
+
+exports[`server option as object custom server with options should handle GET request to index route (/): response text 1`] = `
+"Heyo.
+"
+`;
+
 exports[`server option as object options should be prioritized over http2 options should handle GET request to index route (/): console messages 1`] = `Array []`;
 
 exports[`server option as object options should be prioritized over http2 options should handle GET request to index route (/): https options 1`] = `

--- a/test/e2e/__snapshots__/server.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/server.test.js.snap.webpack5
@@ -511,6 +511,23 @@ exports[`server option as object cacert, pfx, key and cert are buffer should han
 "
 `;
 
+exports[`server option as object custom server with options should handle GET request to index route (/): console messages 1`] = `Array []`;
+
+exports[`server option as object custom server with options should handle GET request to index route (/): http options 1`] = `
+Object {
+  "maxHeaderSize": 16384,
+}
+`;
+
+exports[`server option as object custom server with options should handle GET request to index route (/): page errors 1`] = `Array []`;
+
+exports[`server option as object custom server with options should handle GET request to index route (/): response status 1`] = `200`;
+
+exports[`server option as object custom server with options should handle GET request to index route (/): response text 1`] = `
+"Heyo.
+"
+`;
+
 exports[`server option as object options should be prioritized over http2 options should handle GET request to index route (/): console messages 1`] = `Array []`;
 
 exports[`server option as object options should be prioritized over http2 options should handle GET request to index route (/): https options 1`] = `

--- a/test/validate-options.test.js
+++ b/test/validate-options.test.js
@@ -393,6 +393,7 @@ const tests = {
       "http",
       "https",
       "spdy",
+      "custom-server.js",
       {
         type: "http",
       },
@@ -401,6 +402,9 @@ const tests = {
       },
       {
         type: "spdy",
+      },
+      {
+        type: "custom-server.js",
       },
       {
         type: "https",


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [x] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [x] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?
Yes
<!-- Please note that we won't approve your changes if you don't add tests. -->

### Motivation / Use-Case

We already allow `server: "own-server-package"`, so update schema to allow` server: { type: "own-server-package" }`
<!--
  What existing problem does the pull request solve?

  Please explain the motivation or use-case for making this change.
  If this Pull Request addresses an issue, please link to the issue.
-->

### Breaking Changes
None
<!--
  If this PR introduces a breaking change, please describe the impact and a
  potential migration path for existing applications.
-->

### Additional Info
No