### PR TITLE
Bump selfserve version to 1.10.13 to fix transitive CVE with node-forge 0.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "p-retry": "^4.5.0",
     "portfinder": "^1.0.28",
     "schema-utils": "^4.0.0",
-    "selfsigned": "^1.10.11",
+    "selfsigned": "^1.10.13",
     "serve-index": "^1.9.1",
     "sockjs": "^0.3.21",
     "spdy": "^4.0.2",


### PR DESCRIPTION
- [x] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

No, relying on existing tests.

### Motivation / Use-Case

Motivation is to remove a CVE in node-forge 0.10.0.

See: https://github.com/jfromaniello/selfsigned/pull/49

### Breaking Changes

Shouldn't have any.

### Additional Info
