### PR TITLE
feat: allow to configure more `client` options via resource URL

### DIFF
--- a/client-src/index.js
+++ b/client-src/index.js
@@ -46,22 +46,22 @@ const options = {
 };
 const parsedResourceQuery = parseURL(__resourceQuery);
 
+const enabledFeatures = [];
+
 if (parsedResourceQuery.hot === "true") {
   options.hot = true;
 
-  log.info("Hot Module Replacement enabled.");
+  enabledFeatures.push("HMR");
 }
 
 if (parsedResourceQuery["live-reload"] === "true") {
   options.liveReload = true;
-
-  log.info("Live Reloading enabled.");
+  enabledFeatures.push("live reloading");
 }
 
 if (parsedResourceQuery.progress === "true") {
   options.liveReload = true;
-
-  log.info("Progress reporting enabled.");
+  enabledFeatures.push("progress");
 }
 
 if (parsedResourceQuery.overlay) {
@@ -79,17 +79,7 @@ if (parsedResourceQuery.overlay) {
       ...options.overlay,
     };
   }
-
-  if (
-    options.overlay === true ||
-    (options.overlay.errors && options.overlay.warnings)
-  ) {
-    log.info("Overlay is enabled for both errors and warnings.");
-  } else if (options.overlay.errors) {
-    log.info("Overlay is enabled for errors only.");
-  } else if (options.overlay.warnings) {
-    log.info("Overlay is enabled for warnings only.");
-  }
+  enabledFeatures.push("overlay");
 }
 
 if (parsedResourceQuery.logging) {
@@ -98,6 +88,10 @@ if (parsedResourceQuery.logging) {
 
 if (typeof parsedResourceQuery.reconnect !== "undefined") {
   options.reconnect = Number(parsedResourceQuery.reconnect);
+}
+
+if (enabledFeatures.length > 0) {
+  log.info(`server started with ${enabledFeatures.join(', ')} enabled.`)
 }
 
 /**

--- a/client-src/index.js
+++ b/client-src/index.js
@@ -58,6 +58,40 @@ if (parsedResourceQuery["live-reload"] === "true") {
   log.info("Live Reloading enabled.");
 }
 
+if (parsedResourceQuery.progress === "true") {
+  options.liveReload = true;
+
+  log.info("Progress reporting enabled.");
+}
+
+if (parsedResourceQuery.overlay) {
+  try {
+    options.overlay = JSON.parse(parsedResourceQuery.overlay);
+  } catch (e) {
+    log.error("Error parsing overlay options from resource query:", e);
+  }
+
+  // Fill in default "true" params for partially-specified objects.
+  if (typeof options.overlay === "object") {
+    options.overlay = {
+      errors: true,
+      warnings: true,
+      ...options.overlay,
+    };
+  }
+
+  if (
+    options.overlay === true ||
+    (options.overlay.errors && options.overlay.warnings)
+  ) {
+    log.info("Overlay is enabled for both errors and warnings.");
+  } else if (options.overlay.errors) {
+    log.info("Overlay is enabled for errors only.");
+  } else if (options.overlay.warnings) {
+    log.info("Overlay is enabled for warnings only.");
+  }
+}
+
 if (parsedResourceQuery.logging) {
   options.logging = parsedResourceQuery.logging;
 }

--- a/client-src/index.js
+++ b/client-src/index.js
@@ -5,7 +5,7 @@ import stripAnsi from "./utils/stripAnsi.js";
 import parseURL from "./utils/parseURL.js";
 import socket from "./socket.js";
 import { formatProblem, show, hide } from "./overlay.js";
-import { log, setLogLevel } from "./utils/log.js";
+import { log, logEnabledFeatures, setLogLevel } from "./utils/log.js";
 import sendMessage from "./utils/sendMessage.js";
 import reloadApp from "./utils/reloadApp.js";
 import createSocketURL from "./utils/createSocketURL.js";
@@ -46,22 +46,26 @@ const options = {
 };
 const parsedResourceQuery = parseURL(__resourceQuery);
 
-const enabledFeatures = [];
+const enabledFeatures = {
+  "Hot Module Replacement": false,
+  "Live Reloading": false,
+  Progress: false,
+  Overlay: false,
+};
 
 if (parsedResourceQuery.hot === "true") {
   options.hot = true;
-
-  enabledFeatures.push("Hot Module Replacement");
+  enabledFeatures["Hot Module Replacement"] = true;
 }
 
 if (parsedResourceQuery["live-reload"] === "true") {
   options.liveReload = true;
-  enabledFeatures.push("Live Reloading");
+  enabledFeatures["Live Reloading"] = true;
 }
 
 if (parsedResourceQuery.progress === "true") {
   options.progress = true;
-  enabledFeatures.push("Progress");
+  enabledFeatures.Progress = true;
 }
 
 if (parsedResourceQuery.overlay) {
@@ -79,7 +83,7 @@ if (parsedResourceQuery.overlay) {
       ...options.overlay,
     };
   }
-  enabledFeatures.push("Overlay");
+  enabledFeatures.Overlay = true;
 }
 
 if (parsedResourceQuery.logging) {
@@ -90,9 +94,7 @@ if (typeof parsedResourceQuery.reconnect !== "undefined") {
   options.reconnect = Number(parsedResourceQuery.reconnect);
 }
 
-if (enabledFeatures.length > 0) {
-  log.info(`server started with ${enabledFeatures.join(", ")} enabled.`);
-}
+logEnabledFeatures(enabledFeatures);
 
 /**
  * @param {string} level

--- a/client-src/index.js
+++ b/client-src/index.js
@@ -51,17 +51,17 @@ const enabledFeatures = [];
 if (parsedResourceQuery.hot === "true") {
   options.hot = true;
 
-  enabledFeatures.push("HMR");
+  enabledFeatures.push("Hot Module Replacement");
 }
 
 if (parsedResourceQuery["live-reload"] === "true") {
   options.liveReload = true;
-  enabledFeatures.push("live reloading");
+  enabledFeatures.push("Live Reloading");
 }
 
 if (parsedResourceQuery.progress === "true") {
-  options.liveReload = true;
-  enabledFeatures.push("progress");
+  options.progress = true;
+  enabledFeatures.push("Progress");
 }
 
 if (parsedResourceQuery.overlay) {
@@ -79,7 +79,7 @@ if (parsedResourceQuery.overlay) {
       ...options.overlay,
     };
   }
-  enabledFeatures.push("overlay");
+  enabledFeatures.push("Overlay");
 }
 
 if (parsedResourceQuery.logging) {
@@ -91,7 +91,7 @@ if (typeof parsedResourceQuery.reconnect !== "undefined") {
 }
 
 if (enabledFeatures.length > 0) {
-  log.info(`server started with ${enabledFeatures.join(', ')} enabled.`)
+  log.info(`server started with ${enabledFeatures.join(", ")} enabled.`);
 }
 
 /**
@@ -120,8 +120,6 @@ const onSocketMessage = {
     }
 
     options.hot = true;
-
-    log.info("Hot Module Replacement enabled.");
   },
   liveReload() {
     if (parsedResourceQuery["live-reload"] === "false") {
@@ -129,8 +127,6 @@ const onSocketMessage = {
     }
 
     options.liveReload = true;
-
-    log.info("Live Reloading enabled.");
   },
   invalid() {
     log.info("App updated. Recompiling...");

--- a/client-src/utils/log.js
+++ b/client-src/utils/log.js
@@ -18,4 +18,22 @@ setLogLevel(defaultLevel);
 
 const log = logger.getLogger(name);
 
-export { log, setLogLevel };
+const logEnabledFeatures = (features) => {
+  const enabledFeatures = Object.entries(features);
+  if (!features || enabledFeatures.length === 0) {
+    return;
+  }
+
+  let logString = "Server started:";
+
+  // Server started: Hot Module Replacement enabled, Live Reloading enabled, Overlay disabled.
+  for (const [key, value] of Object.entries(features)) {
+    logString += ` ${key} ${value ? "enabled" : "disabled"},`;
+  }
+  // replace last comma with a period
+  logString = logString.slice(0, -1).concat(".");
+
+  log.info(logString);
+};
+
+export { log, logEnabledFeatures, setLogLevel };

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -619,6 +619,14 @@ class Server {
           );
         }
 
+        if (typeof this.options.hot !== "undefined") {
+          searchParams.set("hot", String(this.options.hot));
+        }
+
+        if (typeof this.options.liveReload !== "undefined") {
+          searchParams.set("live-reload", String(this.options.liveReload));
+        }
+
         webSocketURLStr = searchParams.toString();
       }
 

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -597,6 +597,19 @@ class Server {
           searchParams.set("logging", client.logging);
         }
 
+        if (typeof client.progress !== "undefined") {
+          searchParams.set("progress", String(client.progress));
+        }
+
+        if (typeof client.overlay !== "undefined") {
+          searchParams.set(
+            "overlay",
+            typeof client.overlay === "boolean"
+              ? String(client.overlay)
+              : JSON.stringify(client.overlay)
+          );
+        }
+
         if (typeof client.reconnect !== "undefined") {
           searchParams.set(
             "reconnect",

--- a/test/client/__snapshots__/index.test.js.snap.webpack4
+++ b/test/client/__snapshots__/index.test.js.snap.webpack4
@@ -14,10 +14,6 @@ exports[`index should run onSocketMessage.close 2`] = `"Close"`;
 
 exports[`index should run onSocketMessage.error 1`] = `"error!!"`;
 
-exports[`index should run onSocketMessage.hot 1`] = `"Hot Module Replacement enabled."`;
-
-exports[`index should run onSocketMessage.liveReload 1`] = `"Live Reloading enabled."`;
-
 exports[`index should run onSocketMessage.ok 1`] = `"Ok"`;
 
 exports[`index should run onSocketMessage.ok 2`] = `

--- a/test/client/__snapshots__/index.test.js.snap.webpack5
+++ b/test/client/__snapshots__/index.test.js.snap.webpack5
@@ -14,10 +14,6 @@ exports[`index should run onSocketMessage.close 2`] = `"Close"`;
 
 exports[`index should run onSocketMessage.error 1`] = `"error!!"`;
 
-exports[`index should run onSocketMessage.hot 1`] = `"Hot Module Replacement enabled."`;
-
-exports[`index should run onSocketMessage.liveReload 1`] = `"Live Reloading enabled."`;
-
 exports[`index should run onSocketMessage.ok 1`] = `"Ok"`;
 
 exports[`index should run onSocketMessage.ok 2`] = `

--- a/test/client/index.test.js
+++ b/test/client/index.test.js
@@ -83,18 +83,6 @@ describe("index", () => {
     expect(socket.mock.calls[0]).toMatchSnapshot();
   });
 
-  test("should run onSocketMessage.hot", () => {
-    onSocketMessage.hot();
-
-    expect(log.log.info.mock.calls[0][0]).toMatchSnapshot();
-  });
-
-  test("should run onSocketMessage.liveReload", () => {
-    onSocketMessage.liveReload();
-
-    expect(log.log.info.mock.calls[0][0]).toMatchSnapshot();
-  });
-
   test("should run onSocketMessage['still-ok']", () => {
     onSocketMessage["still-ok"]();
 
@@ -279,7 +267,7 @@ describe("index", () => {
     onSocketMessage.hot();
     onSocketMessage.close();
 
-    expect(log.log.info.mock.calls[1][0]).toMatchSnapshot();
+    expect(log.log.info.mock.calls[0][0]).toMatchSnapshot();
     expect(sendMessage.mock.calls[0][0]).toMatchSnapshot();
   });
 
@@ -288,7 +276,7 @@ describe("index", () => {
     onSocketMessage.liveReload();
     onSocketMessage.close();
 
-    expect(log.log.info.mock.calls[1][0]).toMatchSnapshot();
+    expect(log.log.info.mock.calls[0][0]).toMatchSnapshot();
     expect(sendMessage.mock.calls[0][0]).toMatchSnapshot();
   });
 

--- a/test/client/index.test.js
+++ b/test/client/index.test.js
@@ -25,6 +25,7 @@ describe("index", () => {
         warn: jest.fn(),
         error: jest.fn(),
       },
+      logEnabledFeatures: jest.fn(),
       setLogLevel: jest.fn(),
     });
 

--- a/test/client/index.test.js
+++ b/test/client/index.test.js
@@ -207,6 +207,60 @@ describe("index", () => {
     expect(overlay.show).toBeCalled();
   });
 
+  test("should parse overlay options from resource query", () => {
+    jest.isolateModules(() => {
+      // Pass JSON config with warnings disabled
+      global.__resourceQuery = `?overlay=${encodeURIComponent(
+        `{"warnings": false}`
+      )}`;
+      overlay.show.mockReset();
+      socket.mockReset();
+      jest.unmock("../../client-src/utils/parseURL.js");
+      require("../../client-src");
+      onSocketMessage = socket.mock.calls[0][1];
+
+      onSocketMessage.warnings(["warn1"]);
+      expect(overlay.show).not.toBeCalled();
+
+      onSocketMessage.errors(["error1"]);
+      expect(overlay.show).toBeCalledTimes(1);
+    });
+
+    jest.isolateModules(() => {
+      // Pass JSON config with errors disabled
+      global.__resourceQuery = `?overlay=${encodeURIComponent(
+        `{"errors": false}`
+      )}`;
+      overlay.show.mockReset();
+      socket.mockReset();
+      jest.unmock("../../client-src/utils/parseURL.js");
+      require("../../client-src");
+      onSocketMessage = socket.mock.calls[0][1];
+
+      onSocketMessage.errors(["error1"]);
+      expect(overlay.show).not.toBeCalled();
+
+      onSocketMessage.warnings(["warn1"]);
+      expect(overlay.show).toBeCalledTimes(1);
+    });
+
+    jest.isolateModules(() => {
+      // Use simple boolean
+      global.__resourceQuery = "?overlay=true";
+      jest.unmock("../../client-src/utils/parseURL.js");
+      socket.mockReset();
+      overlay.show.mockReset();
+      require("../../client-src");
+      onSocketMessage = socket.mock.calls[0][1];
+
+      onSocketMessage.warnings(["warn2"]);
+      expect(overlay.show).toBeCalledTimes(1);
+
+      onSocketMessage.errors(["error2"]);
+      expect(overlay.show).toBeCalledTimes(2);
+    });
+  });
+
   test("should run onSocketMessage.error", () => {
     onSocketMessage.error("error!!");
 

--- a/test/e2e/__snapshots__/allowed-hosts.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/allowed-hosts.test.js.snap.webpack4
@@ -38,11 +38,9 @@ exports[`allowed hosts check host headers should always allow value of the \`hos
 
 exports[`allowed hosts should connect web socket client using "[::1] host to web socket server with the "auto" value ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -50,11 +48,9 @@ exports[`allowed hosts should connect web socket client using "[::1] host to web
 
 exports[`allowed hosts should connect web socket client using "[::1] host to web socket server with the "auto" value ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -62,11 +58,9 @@ exports[`allowed hosts should connect web socket client using "[::1] host to web
 
 exports[`allowed hosts should connect web socket client using "127.0.0.1" host to web socket server with the "auto" value ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -74,11 +68,9 @@ exports[`allowed hosts should connect web socket client using "127.0.0.1" host t
 
 exports[`allowed hosts should connect web socket client using "127.0.0.1" host to web socket server with the "auto" value ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -86,11 +78,9 @@ exports[`allowed hosts should connect web socket client using "127.0.0.1" host t
 
 exports[`allowed hosts should connect web socket client using "chrome-extension:" protocol to web socket server with the "auto" value ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -98,11 +88,9 @@ exports[`allowed hosts should connect web socket client using "chrome-extension:
 
 exports[`allowed hosts should connect web socket client using "chrome-extension:" protocol to web socket server with the "auto" value ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -110,11 +98,9 @@ exports[`allowed hosts should connect web socket client using "chrome-extension:
 
 exports[`allowed hosts should connect web socket client using "file:" protocol to web socket server with the "auto" value ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -122,11 +108,9 @@ exports[`allowed hosts should connect web socket client using "file:" protocol t
 
 exports[`allowed hosts should connect web socket client using "file:" protocol to web socket server with the "auto" value ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -134,11 +118,9 @@ exports[`allowed hosts should connect web socket client using "file:" protocol t
 
 exports[`allowed hosts should connect web socket client using custom hostname to web socket server with the "all" value ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -146,11 +128,9 @@ exports[`allowed hosts should connect web socket client using custom hostname to
 
 exports[`allowed hosts should connect web socket client using custom hostname to web socket server with the "all" value ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -158,11 +138,9 @@ exports[`allowed hosts should connect web socket client using custom hostname to
 
 exports[`allowed hosts should connect web socket client using custom hostname to web socket server with the "all" value in array ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -170,11 +148,9 @@ exports[`allowed hosts should connect web socket client using custom hostname to
 
 exports[`allowed hosts should connect web socket client using custom hostname to web socket server with the "all" value in array ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -182,11 +158,9 @@ exports[`allowed hosts should connect web socket client using custom hostname to
 
 exports[`allowed hosts should connect web socket client using custom hostname to web socket server with the custom hostname value ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -194,11 +168,9 @@ exports[`allowed hosts should connect web socket client using custom hostname to
 
 exports[`allowed hosts should connect web socket client using custom hostname to web socket server with the custom hostname value ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -206,11 +178,9 @@ exports[`allowed hosts should connect web socket client using custom hostname to
 
 exports[`allowed hosts should connect web socket client using custom hostname to web socket server with the custom hostname value starting with dot ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -218,11 +188,9 @@ exports[`allowed hosts should connect web socket client using custom hostname to
 
 exports[`allowed hosts should connect web socket client using custom hostname to web socket server with the custom hostname value starting with dot ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -230,11 +198,9 @@ exports[`allowed hosts should connect web socket client using custom hostname to
 
 exports[`allowed hosts should connect web socket client using custom hostname to web socket server with the multiple custom hostname values ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -242,11 +208,9 @@ exports[`allowed hosts should connect web socket client using custom hostname to
 
 exports[`allowed hosts should connect web socket client using custom hostname to web socket server with the multiple custom hostname values ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -254,11 +218,9 @@ exports[`allowed hosts should connect web socket client using custom hostname to
 
 exports[`allowed hosts should connect web socket client using custom sub hostname to web socket server with the custom hostname value ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -266,11 +228,9 @@ exports[`allowed hosts should connect web socket client using custom sub hostnam
 
 exports[`allowed hosts should connect web socket client using custom sub hostname to web socket server with the custom hostname value ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -278,11 +238,9 @@ exports[`allowed hosts should connect web socket client using custom sub hostnam
 
 exports[`allowed hosts should connect web socket client using localhost to web socket server with the "auto" value ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -290,11 +248,9 @@ exports[`allowed hosts should connect web socket client using localhost to web s
 
 exports[`allowed hosts should connect web socket client using localhost to web socket server with the "auto" value ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -314,7 +270,7 @@ exports[`allowed hosts should disconnect web client using localhost to web socke
 
 exports[`allowed hosts should disconnect web socket client using custom hostname from web socket server with the "auto" value based on the "host" header ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Invalid Host/Origin header",
@@ -327,7 +283,7 @@ exports[`allowed hosts should disconnect web socket client using custom hostname
 
 exports[`allowed hosts should disconnect web socket client using custom hostname from web socket server with the "auto" value based on the "host" header ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Invalid Host/Origin header",
@@ -340,7 +296,7 @@ exports[`allowed hosts should disconnect web socket client using custom hostname
 
 exports[`allowed hosts should disconnect web socket client using custom hostname from web socket server with the "auto" value based on the "host" header when "server: 'https'" is enabled ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Invalid Host/Origin header",
@@ -353,7 +309,7 @@ exports[`allowed hosts should disconnect web socket client using custom hostname
 
 exports[`allowed hosts should disconnect web socket client using custom hostname from web socket server with the "auto" value based on the "host" header when "server: 'https'" is enabled ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Invalid Host/Origin header",
@@ -366,7 +322,7 @@ exports[`allowed hosts should disconnect web socket client using custom hostname
 
 exports[`allowed hosts should disconnect web socket client using custom hostname from web socket server with the "auto" value based on the "origin" header ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Invalid Host/Origin header",
@@ -379,7 +335,7 @@ exports[`allowed hosts should disconnect web socket client using custom hostname
 
 exports[`allowed hosts should disconnect web socket client using custom hostname from web socket server with the "auto" value based on the "origin" header ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Invalid Host/Origin header",

--- a/test/e2e/__snapshots__/allowed-hosts.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/allowed-hosts.test.js.snap.webpack4
@@ -38,6 +38,7 @@ exports[`allowed hosts check host headers should always allow value of the \`hos
 
 exports[`allowed hosts should connect web socket client using "[::1] host to web socket server with the "auto" value ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -49,6 +50,7 @@ exports[`allowed hosts should connect web socket client using "[::1] host to web
 
 exports[`allowed hosts should connect web socket client using "[::1] host to web socket server with the "auto" value ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -60,6 +62,7 @@ exports[`allowed hosts should connect web socket client using "[::1] host to web
 
 exports[`allowed hosts should connect web socket client using "127.0.0.1" host to web socket server with the "auto" value ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -71,6 +74,7 @@ exports[`allowed hosts should connect web socket client using "127.0.0.1" host t
 
 exports[`allowed hosts should connect web socket client using "127.0.0.1" host to web socket server with the "auto" value ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -82,6 +86,7 @@ exports[`allowed hosts should connect web socket client using "127.0.0.1" host t
 
 exports[`allowed hosts should connect web socket client using "chrome-extension:" protocol to web socket server with the "auto" value ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -93,6 +98,7 @@ exports[`allowed hosts should connect web socket client using "chrome-extension:
 
 exports[`allowed hosts should connect web socket client using "chrome-extension:" protocol to web socket server with the "auto" value ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -104,6 +110,7 @@ exports[`allowed hosts should connect web socket client using "chrome-extension:
 
 exports[`allowed hosts should connect web socket client using "file:" protocol to web socket server with the "auto" value ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -115,6 +122,7 @@ exports[`allowed hosts should connect web socket client using "file:" protocol t
 
 exports[`allowed hosts should connect web socket client using "file:" protocol to web socket server with the "auto" value ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -126,6 +134,7 @@ exports[`allowed hosts should connect web socket client using "file:" protocol t
 
 exports[`allowed hosts should connect web socket client using custom hostname to web socket server with the "all" value ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -137,6 +146,7 @@ exports[`allowed hosts should connect web socket client using custom hostname to
 
 exports[`allowed hosts should connect web socket client using custom hostname to web socket server with the "all" value ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -148,6 +158,7 @@ exports[`allowed hosts should connect web socket client using custom hostname to
 
 exports[`allowed hosts should connect web socket client using custom hostname to web socket server with the "all" value in array ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -159,6 +170,7 @@ exports[`allowed hosts should connect web socket client using custom hostname to
 
 exports[`allowed hosts should connect web socket client using custom hostname to web socket server with the "all" value in array ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -170,6 +182,7 @@ exports[`allowed hosts should connect web socket client using custom hostname to
 
 exports[`allowed hosts should connect web socket client using custom hostname to web socket server with the custom hostname value ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -181,6 +194,7 @@ exports[`allowed hosts should connect web socket client using custom hostname to
 
 exports[`allowed hosts should connect web socket client using custom hostname to web socket server with the custom hostname value ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -192,6 +206,7 @@ exports[`allowed hosts should connect web socket client using custom hostname to
 
 exports[`allowed hosts should connect web socket client using custom hostname to web socket server with the custom hostname value starting with dot ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -203,6 +218,7 @@ exports[`allowed hosts should connect web socket client using custom hostname to
 
 exports[`allowed hosts should connect web socket client using custom hostname to web socket server with the custom hostname value starting with dot ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -214,6 +230,7 @@ exports[`allowed hosts should connect web socket client using custom hostname to
 
 exports[`allowed hosts should connect web socket client using custom hostname to web socket server with the multiple custom hostname values ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -225,6 +242,7 @@ exports[`allowed hosts should connect web socket client using custom hostname to
 
 exports[`allowed hosts should connect web socket client using custom hostname to web socket server with the multiple custom hostname values ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -236,6 +254,7 @@ exports[`allowed hosts should connect web socket client using custom hostname to
 
 exports[`allowed hosts should connect web socket client using custom sub hostname to web socket server with the custom hostname value ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -247,6 +266,7 @@ exports[`allowed hosts should connect web socket client using custom sub hostnam
 
 exports[`allowed hosts should connect web socket client using custom sub hostname to web socket server with the custom hostname value ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -258,6 +278,7 @@ exports[`allowed hosts should connect web socket client using custom sub hostnam
 
 exports[`allowed hosts should connect web socket client using localhost to web socket server with the "auto" value ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -269,6 +290,7 @@ exports[`allowed hosts should connect web socket client using localhost to web s
 
 exports[`allowed hosts should connect web socket client using localhost to web socket server with the "auto" value ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -292,6 +314,7 @@ exports[`allowed hosts should disconnect web client using localhost to web socke
 
 exports[`allowed hosts should disconnect web socket client using custom hostname from web socket server with the "auto" value based on the "host" header ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Invalid Host/Origin header",
@@ -304,6 +327,7 @@ exports[`allowed hosts should disconnect web socket client using custom hostname
 
 exports[`allowed hosts should disconnect web socket client using custom hostname from web socket server with the "auto" value based on the "host" header ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Invalid Host/Origin header",
@@ -316,6 +340,7 @@ exports[`allowed hosts should disconnect web socket client using custom hostname
 
 exports[`allowed hosts should disconnect web socket client using custom hostname from web socket server with the "auto" value based on the "host" header when "server: 'https'" is enabled ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Invalid Host/Origin header",
@@ -328,6 +353,7 @@ exports[`allowed hosts should disconnect web socket client using custom hostname
 
 exports[`allowed hosts should disconnect web socket client using custom hostname from web socket server with the "auto" value based on the "host" header when "server: 'https'" is enabled ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Invalid Host/Origin header",
@@ -340,6 +366,7 @@ exports[`allowed hosts should disconnect web socket client using custom hostname
 
 exports[`allowed hosts should disconnect web socket client using custom hostname from web socket server with the "auto" value based on the "origin" header ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Invalid Host/Origin header",
@@ -352,6 +379,7 @@ exports[`allowed hosts should disconnect web socket client using custom hostname
 
 exports[`allowed hosts should disconnect web socket client using custom hostname from web socket server with the "auto" value based on the "origin" header ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Invalid Host/Origin header",

--- a/test/e2e/__snapshots__/allowed-hosts.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/allowed-hosts.test.js.snap.webpack4
@@ -38,7 +38,7 @@ exports[`allowed hosts check host headers should always allow value of the \`hos
 
 exports[`allowed hosts should connect web socket client using "[::1] host to web socket server with the "auto" value ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -48,7 +48,7 @@ exports[`allowed hosts should connect web socket client using "[::1] host to web
 
 exports[`allowed hosts should connect web socket client using "[::1] host to web socket server with the "auto" value ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -58,7 +58,7 @@ exports[`allowed hosts should connect web socket client using "[::1] host to web
 
 exports[`allowed hosts should connect web socket client using "127.0.0.1" host to web socket server with the "auto" value ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -68,7 +68,7 @@ exports[`allowed hosts should connect web socket client using "127.0.0.1" host t
 
 exports[`allowed hosts should connect web socket client using "127.0.0.1" host to web socket server with the "auto" value ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -78,7 +78,7 @@ exports[`allowed hosts should connect web socket client using "127.0.0.1" host t
 
 exports[`allowed hosts should connect web socket client using "chrome-extension:" protocol to web socket server with the "auto" value ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -88,7 +88,7 @@ exports[`allowed hosts should connect web socket client using "chrome-extension:
 
 exports[`allowed hosts should connect web socket client using "chrome-extension:" protocol to web socket server with the "auto" value ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -98,7 +98,7 @@ exports[`allowed hosts should connect web socket client using "chrome-extension:
 
 exports[`allowed hosts should connect web socket client using "file:" protocol to web socket server with the "auto" value ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -108,7 +108,7 @@ exports[`allowed hosts should connect web socket client using "file:" protocol t
 
 exports[`allowed hosts should connect web socket client using "file:" protocol to web socket server with the "auto" value ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -118,7 +118,7 @@ exports[`allowed hosts should connect web socket client using "file:" protocol t
 
 exports[`allowed hosts should connect web socket client using custom hostname to web socket server with the "all" value ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -128,7 +128,7 @@ exports[`allowed hosts should connect web socket client using custom hostname to
 
 exports[`allowed hosts should connect web socket client using custom hostname to web socket server with the "all" value ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -138,7 +138,7 @@ exports[`allowed hosts should connect web socket client using custom hostname to
 
 exports[`allowed hosts should connect web socket client using custom hostname to web socket server with the "all" value in array ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -148,7 +148,7 @@ exports[`allowed hosts should connect web socket client using custom hostname to
 
 exports[`allowed hosts should connect web socket client using custom hostname to web socket server with the "all" value in array ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -158,7 +158,7 @@ exports[`allowed hosts should connect web socket client using custom hostname to
 
 exports[`allowed hosts should connect web socket client using custom hostname to web socket server with the custom hostname value ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -168,7 +168,7 @@ exports[`allowed hosts should connect web socket client using custom hostname to
 
 exports[`allowed hosts should connect web socket client using custom hostname to web socket server with the custom hostname value ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -178,7 +178,7 @@ exports[`allowed hosts should connect web socket client using custom hostname to
 
 exports[`allowed hosts should connect web socket client using custom hostname to web socket server with the custom hostname value starting with dot ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -188,7 +188,7 @@ exports[`allowed hosts should connect web socket client using custom hostname to
 
 exports[`allowed hosts should connect web socket client using custom hostname to web socket server with the custom hostname value starting with dot ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -198,7 +198,7 @@ exports[`allowed hosts should connect web socket client using custom hostname to
 
 exports[`allowed hosts should connect web socket client using custom hostname to web socket server with the multiple custom hostname values ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -208,7 +208,7 @@ exports[`allowed hosts should connect web socket client using custom hostname to
 
 exports[`allowed hosts should connect web socket client using custom hostname to web socket server with the multiple custom hostname values ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -218,7 +218,7 @@ exports[`allowed hosts should connect web socket client using custom hostname to
 
 exports[`allowed hosts should connect web socket client using custom sub hostname to web socket server with the custom hostname value ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -228,7 +228,7 @@ exports[`allowed hosts should connect web socket client using custom sub hostnam
 
 exports[`allowed hosts should connect web socket client using custom sub hostname to web socket server with the custom hostname value ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -238,7 +238,7 @@ exports[`allowed hosts should connect web socket client using custom sub hostnam
 
 exports[`allowed hosts should connect web socket client using localhost to web socket server with the "auto" value ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -248,7 +248,7 @@ exports[`allowed hosts should connect web socket client using localhost to web s
 
 exports[`allowed hosts should connect web socket client using localhost to web socket server with the "auto" value ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -270,7 +270,7 @@ exports[`allowed hosts should disconnect web client using localhost to web socke
 
 exports[`allowed hosts should disconnect web socket client using custom hostname from web socket server with the "auto" value based on the "host" header ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Invalid Host/Origin header",
@@ -283,7 +283,7 @@ exports[`allowed hosts should disconnect web socket client using custom hostname
 
 exports[`allowed hosts should disconnect web socket client using custom hostname from web socket server with the "auto" value based on the "host" header ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Invalid Host/Origin header",
@@ -296,7 +296,7 @@ exports[`allowed hosts should disconnect web socket client using custom hostname
 
 exports[`allowed hosts should disconnect web socket client using custom hostname from web socket server with the "auto" value based on the "host" header when "server: 'https'" is enabled ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Invalid Host/Origin header",
@@ -309,7 +309,7 @@ exports[`allowed hosts should disconnect web socket client using custom hostname
 
 exports[`allowed hosts should disconnect web socket client using custom hostname from web socket server with the "auto" value based on the "host" header when "server: 'https'" is enabled ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Invalid Host/Origin header",
@@ -322,7 +322,7 @@ exports[`allowed hosts should disconnect web socket client using custom hostname
 
 exports[`allowed hosts should disconnect web socket client using custom hostname from web socket server with the "auto" value based on the "origin" header ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Invalid Host/Origin header",
@@ -335,7 +335,7 @@ exports[`allowed hosts should disconnect web socket client using custom hostname
 
 exports[`allowed hosts should disconnect web socket client using custom hostname from web socket server with the "auto" value based on the "origin" header ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Invalid Host/Origin header",

--- a/test/e2e/__snapshots__/allowed-hosts.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/allowed-hosts.test.js.snap.webpack5
@@ -38,11 +38,9 @@ exports[`allowed hosts check host headers should always allow value of the \`hos
 
 exports[`allowed hosts should connect web socket client using "[::1] host to web socket server with the "auto" value ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -50,11 +48,9 @@ exports[`allowed hosts should connect web socket client using "[::1] host to web
 
 exports[`allowed hosts should connect web socket client using "[::1] host to web socket server with the "auto" value ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -62,11 +58,9 @@ exports[`allowed hosts should connect web socket client using "[::1] host to web
 
 exports[`allowed hosts should connect web socket client using "127.0.0.1" host to web socket server with the "auto" value ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -74,11 +68,9 @@ exports[`allowed hosts should connect web socket client using "127.0.0.1" host t
 
 exports[`allowed hosts should connect web socket client using "127.0.0.1" host to web socket server with the "auto" value ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -86,11 +78,9 @@ exports[`allowed hosts should connect web socket client using "127.0.0.1" host t
 
 exports[`allowed hosts should connect web socket client using "chrome-extension:" protocol to web socket server with the "auto" value ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -98,11 +88,9 @@ exports[`allowed hosts should connect web socket client using "chrome-extension:
 
 exports[`allowed hosts should connect web socket client using "chrome-extension:" protocol to web socket server with the "auto" value ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -110,11 +98,9 @@ exports[`allowed hosts should connect web socket client using "chrome-extension:
 
 exports[`allowed hosts should connect web socket client using "file:" protocol to web socket server with the "auto" value ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -122,11 +108,9 @@ exports[`allowed hosts should connect web socket client using "file:" protocol t
 
 exports[`allowed hosts should connect web socket client using "file:" protocol to web socket server with the "auto" value ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -134,11 +118,9 @@ exports[`allowed hosts should connect web socket client using "file:" protocol t
 
 exports[`allowed hosts should connect web socket client using custom hostname to web socket server with the "all" value ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -146,11 +128,9 @@ exports[`allowed hosts should connect web socket client using custom hostname to
 
 exports[`allowed hosts should connect web socket client using custom hostname to web socket server with the "all" value ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -158,11 +138,9 @@ exports[`allowed hosts should connect web socket client using custom hostname to
 
 exports[`allowed hosts should connect web socket client using custom hostname to web socket server with the "all" value in array ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -170,11 +148,9 @@ exports[`allowed hosts should connect web socket client using custom hostname to
 
 exports[`allowed hosts should connect web socket client using custom hostname to web socket server with the "all" value in array ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -182,11 +158,9 @@ exports[`allowed hosts should connect web socket client using custom hostname to
 
 exports[`allowed hosts should connect web socket client using custom hostname to web socket server with the custom hostname value ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -194,11 +168,9 @@ exports[`allowed hosts should connect web socket client using custom hostname to
 
 exports[`allowed hosts should connect web socket client using custom hostname to web socket server with the custom hostname value ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -206,11 +178,9 @@ exports[`allowed hosts should connect web socket client using custom hostname to
 
 exports[`allowed hosts should connect web socket client using custom hostname to web socket server with the custom hostname value starting with dot ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -218,11 +188,9 @@ exports[`allowed hosts should connect web socket client using custom hostname to
 
 exports[`allowed hosts should connect web socket client using custom hostname to web socket server with the custom hostname value starting with dot ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -230,11 +198,9 @@ exports[`allowed hosts should connect web socket client using custom hostname to
 
 exports[`allowed hosts should connect web socket client using custom hostname to web socket server with the multiple custom hostname values ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -242,11 +208,9 @@ exports[`allowed hosts should connect web socket client using custom hostname to
 
 exports[`allowed hosts should connect web socket client using custom hostname to web socket server with the multiple custom hostname values ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -254,11 +218,9 @@ exports[`allowed hosts should connect web socket client using custom hostname to
 
 exports[`allowed hosts should connect web socket client using custom sub hostname to web socket server with the custom hostname value ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -266,11 +228,9 @@ exports[`allowed hosts should connect web socket client using custom sub hostnam
 
 exports[`allowed hosts should connect web socket client using custom sub hostname to web socket server with the custom hostname value ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -278,11 +238,9 @@ exports[`allowed hosts should connect web socket client using custom sub hostnam
 
 exports[`allowed hosts should connect web socket client using localhost to web socket server with the "auto" value ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -290,11 +248,9 @@ exports[`allowed hosts should connect web socket client using localhost to web s
 
 exports[`allowed hosts should connect web socket client using localhost to web socket server with the "auto" value ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -314,7 +270,7 @@ exports[`allowed hosts should disconnect web client using localhost to web socke
 
 exports[`allowed hosts should disconnect web socket client using custom hostname from web socket server with the "auto" value based on the "host" header ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Invalid Host/Origin header",
@@ -327,7 +283,7 @@ exports[`allowed hosts should disconnect web socket client using custom hostname
 
 exports[`allowed hosts should disconnect web socket client using custom hostname from web socket server with the "auto" value based on the "host" header ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Invalid Host/Origin header",
@@ -340,7 +296,7 @@ exports[`allowed hosts should disconnect web socket client using custom hostname
 
 exports[`allowed hosts should disconnect web socket client using custom hostname from web socket server with the "auto" value based on the "host" header when "server: 'https'" is enabled ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Invalid Host/Origin header",
@@ -353,7 +309,7 @@ exports[`allowed hosts should disconnect web socket client using custom hostname
 
 exports[`allowed hosts should disconnect web socket client using custom hostname from web socket server with the "auto" value based on the "host" header when "server: 'https'" is enabled ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Invalid Host/Origin header",
@@ -366,7 +322,7 @@ exports[`allowed hosts should disconnect web socket client using custom hostname
 
 exports[`allowed hosts should disconnect web socket client using custom hostname from web socket server with the "auto" value based on the "origin" header ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Invalid Host/Origin header",
@@ -379,7 +335,7 @@ exports[`allowed hosts should disconnect web socket client using custom hostname
 
 exports[`allowed hosts should disconnect web socket client using custom hostname from web socket server with the "auto" value based on the "origin" header ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Invalid Host/Origin header",

--- a/test/e2e/__snapshots__/allowed-hosts.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/allowed-hosts.test.js.snap.webpack5
@@ -38,6 +38,7 @@ exports[`allowed hosts check host headers should always allow value of the \`hos
 
 exports[`allowed hosts should connect web socket client using "[::1] host to web socket server with the "auto" value ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -49,6 +50,7 @@ exports[`allowed hosts should connect web socket client using "[::1] host to web
 
 exports[`allowed hosts should connect web socket client using "[::1] host to web socket server with the "auto" value ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -60,6 +62,7 @@ exports[`allowed hosts should connect web socket client using "[::1] host to web
 
 exports[`allowed hosts should connect web socket client using "127.0.0.1" host to web socket server with the "auto" value ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -71,6 +74,7 @@ exports[`allowed hosts should connect web socket client using "127.0.0.1" host t
 
 exports[`allowed hosts should connect web socket client using "127.0.0.1" host to web socket server with the "auto" value ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -82,6 +86,7 @@ exports[`allowed hosts should connect web socket client using "127.0.0.1" host t
 
 exports[`allowed hosts should connect web socket client using "chrome-extension:" protocol to web socket server with the "auto" value ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -93,6 +98,7 @@ exports[`allowed hosts should connect web socket client using "chrome-extension:
 
 exports[`allowed hosts should connect web socket client using "chrome-extension:" protocol to web socket server with the "auto" value ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -104,6 +110,7 @@ exports[`allowed hosts should connect web socket client using "chrome-extension:
 
 exports[`allowed hosts should connect web socket client using "file:" protocol to web socket server with the "auto" value ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -115,6 +122,7 @@ exports[`allowed hosts should connect web socket client using "file:" protocol t
 
 exports[`allowed hosts should connect web socket client using "file:" protocol to web socket server with the "auto" value ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -126,6 +134,7 @@ exports[`allowed hosts should connect web socket client using "file:" protocol t
 
 exports[`allowed hosts should connect web socket client using custom hostname to web socket server with the "all" value ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -137,6 +146,7 @@ exports[`allowed hosts should connect web socket client using custom hostname to
 
 exports[`allowed hosts should connect web socket client using custom hostname to web socket server with the "all" value ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -148,6 +158,7 @@ exports[`allowed hosts should connect web socket client using custom hostname to
 
 exports[`allowed hosts should connect web socket client using custom hostname to web socket server with the "all" value in array ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -159,6 +170,7 @@ exports[`allowed hosts should connect web socket client using custom hostname to
 
 exports[`allowed hosts should connect web socket client using custom hostname to web socket server with the "all" value in array ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -170,6 +182,7 @@ exports[`allowed hosts should connect web socket client using custom hostname to
 
 exports[`allowed hosts should connect web socket client using custom hostname to web socket server with the custom hostname value ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -181,6 +194,7 @@ exports[`allowed hosts should connect web socket client using custom hostname to
 
 exports[`allowed hosts should connect web socket client using custom hostname to web socket server with the custom hostname value ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -192,6 +206,7 @@ exports[`allowed hosts should connect web socket client using custom hostname to
 
 exports[`allowed hosts should connect web socket client using custom hostname to web socket server with the custom hostname value starting with dot ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -203,6 +218,7 @@ exports[`allowed hosts should connect web socket client using custom hostname to
 
 exports[`allowed hosts should connect web socket client using custom hostname to web socket server with the custom hostname value starting with dot ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -214,6 +230,7 @@ exports[`allowed hosts should connect web socket client using custom hostname to
 
 exports[`allowed hosts should connect web socket client using custom hostname to web socket server with the multiple custom hostname values ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -225,6 +242,7 @@ exports[`allowed hosts should connect web socket client using custom hostname to
 
 exports[`allowed hosts should connect web socket client using custom hostname to web socket server with the multiple custom hostname values ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -236,6 +254,7 @@ exports[`allowed hosts should connect web socket client using custom hostname to
 
 exports[`allowed hosts should connect web socket client using custom sub hostname to web socket server with the custom hostname value ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -247,6 +266,7 @@ exports[`allowed hosts should connect web socket client using custom sub hostnam
 
 exports[`allowed hosts should connect web socket client using custom sub hostname to web socket server with the custom hostname value ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -258,6 +278,7 @@ exports[`allowed hosts should connect web socket client using custom sub hostnam
 
 exports[`allowed hosts should connect web socket client using localhost to web socket server with the "auto" value ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -269,6 +290,7 @@ exports[`allowed hosts should connect web socket client using localhost to web s
 
 exports[`allowed hosts should connect web socket client using localhost to web socket server with the "auto" value ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -292,6 +314,7 @@ exports[`allowed hosts should disconnect web client using localhost to web socke
 
 exports[`allowed hosts should disconnect web socket client using custom hostname from web socket server with the "auto" value based on the "host" header ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Invalid Host/Origin header",
@@ -304,6 +327,7 @@ exports[`allowed hosts should disconnect web socket client using custom hostname
 
 exports[`allowed hosts should disconnect web socket client using custom hostname from web socket server with the "auto" value based on the "host" header ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Invalid Host/Origin header",
@@ -316,6 +340,7 @@ exports[`allowed hosts should disconnect web socket client using custom hostname
 
 exports[`allowed hosts should disconnect web socket client using custom hostname from web socket server with the "auto" value based on the "host" header when "server: 'https'" is enabled ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Invalid Host/Origin header",
@@ -328,6 +353,7 @@ exports[`allowed hosts should disconnect web socket client using custom hostname
 
 exports[`allowed hosts should disconnect web socket client using custom hostname from web socket server with the "auto" value based on the "host" header when "server: 'https'" is enabled ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Invalid Host/Origin header",
@@ -340,6 +366,7 @@ exports[`allowed hosts should disconnect web socket client using custom hostname
 
 exports[`allowed hosts should disconnect web socket client using custom hostname from web socket server with the "auto" value based on the "origin" header ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Invalid Host/Origin header",
@@ -352,6 +379,7 @@ exports[`allowed hosts should disconnect web socket client using custom hostname
 
 exports[`allowed hosts should disconnect web socket client using custom hostname from web socket server with the "auto" value based on the "origin" header ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Invalid Host/Origin header",

--- a/test/e2e/__snapshots__/allowed-hosts.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/allowed-hosts.test.js.snap.webpack5
@@ -38,7 +38,7 @@ exports[`allowed hosts check host headers should always allow value of the \`hos
 
 exports[`allowed hosts should connect web socket client using "[::1] host to web socket server with the "auto" value ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -48,7 +48,7 @@ exports[`allowed hosts should connect web socket client using "[::1] host to web
 
 exports[`allowed hosts should connect web socket client using "[::1] host to web socket server with the "auto" value ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -58,7 +58,7 @@ exports[`allowed hosts should connect web socket client using "[::1] host to web
 
 exports[`allowed hosts should connect web socket client using "127.0.0.1" host to web socket server with the "auto" value ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -68,7 +68,7 @@ exports[`allowed hosts should connect web socket client using "127.0.0.1" host t
 
 exports[`allowed hosts should connect web socket client using "127.0.0.1" host to web socket server with the "auto" value ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -78,7 +78,7 @@ exports[`allowed hosts should connect web socket client using "127.0.0.1" host t
 
 exports[`allowed hosts should connect web socket client using "chrome-extension:" protocol to web socket server with the "auto" value ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -88,7 +88,7 @@ exports[`allowed hosts should connect web socket client using "chrome-extension:
 
 exports[`allowed hosts should connect web socket client using "chrome-extension:" protocol to web socket server with the "auto" value ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -98,7 +98,7 @@ exports[`allowed hosts should connect web socket client using "chrome-extension:
 
 exports[`allowed hosts should connect web socket client using "file:" protocol to web socket server with the "auto" value ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -108,7 +108,7 @@ exports[`allowed hosts should connect web socket client using "file:" protocol t
 
 exports[`allowed hosts should connect web socket client using "file:" protocol to web socket server with the "auto" value ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -118,7 +118,7 @@ exports[`allowed hosts should connect web socket client using "file:" protocol t
 
 exports[`allowed hosts should connect web socket client using custom hostname to web socket server with the "all" value ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -128,7 +128,7 @@ exports[`allowed hosts should connect web socket client using custom hostname to
 
 exports[`allowed hosts should connect web socket client using custom hostname to web socket server with the "all" value ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -138,7 +138,7 @@ exports[`allowed hosts should connect web socket client using custom hostname to
 
 exports[`allowed hosts should connect web socket client using custom hostname to web socket server with the "all" value in array ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -148,7 +148,7 @@ exports[`allowed hosts should connect web socket client using custom hostname to
 
 exports[`allowed hosts should connect web socket client using custom hostname to web socket server with the "all" value in array ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -158,7 +158,7 @@ exports[`allowed hosts should connect web socket client using custom hostname to
 
 exports[`allowed hosts should connect web socket client using custom hostname to web socket server with the custom hostname value ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -168,7 +168,7 @@ exports[`allowed hosts should connect web socket client using custom hostname to
 
 exports[`allowed hosts should connect web socket client using custom hostname to web socket server with the custom hostname value ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -178,7 +178,7 @@ exports[`allowed hosts should connect web socket client using custom hostname to
 
 exports[`allowed hosts should connect web socket client using custom hostname to web socket server with the custom hostname value starting with dot ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -188,7 +188,7 @@ exports[`allowed hosts should connect web socket client using custom hostname to
 
 exports[`allowed hosts should connect web socket client using custom hostname to web socket server with the custom hostname value starting with dot ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -198,7 +198,7 @@ exports[`allowed hosts should connect web socket client using custom hostname to
 
 exports[`allowed hosts should connect web socket client using custom hostname to web socket server with the multiple custom hostname values ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -208,7 +208,7 @@ exports[`allowed hosts should connect web socket client using custom hostname to
 
 exports[`allowed hosts should connect web socket client using custom hostname to web socket server with the multiple custom hostname values ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -218,7 +218,7 @@ exports[`allowed hosts should connect web socket client using custom hostname to
 
 exports[`allowed hosts should connect web socket client using custom sub hostname to web socket server with the custom hostname value ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -228,7 +228,7 @@ exports[`allowed hosts should connect web socket client using custom sub hostnam
 
 exports[`allowed hosts should connect web socket client using custom sub hostname to web socket server with the custom hostname value ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -238,7 +238,7 @@ exports[`allowed hosts should connect web socket client using custom sub hostnam
 
 exports[`allowed hosts should connect web socket client using localhost to web socket server with the "auto" value ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -248,7 +248,7 @@ exports[`allowed hosts should connect web socket client using localhost to web s
 
 exports[`allowed hosts should connect web socket client using localhost to web socket server with the "auto" value ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -270,7 +270,7 @@ exports[`allowed hosts should disconnect web client using localhost to web socke
 
 exports[`allowed hosts should disconnect web socket client using custom hostname from web socket server with the "auto" value based on the "host" header ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Invalid Host/Origin header",
@@ -283,7 +283,7 @@ exports[`allowed hosts should disconnect web socket client using custom hostname
 
 exports[`allowed hosts should disconnect web socket client using custom hostname from web socket server with the "auto" value based on the "host" header ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Invalid Host/Origin header",
@@ -296,7 +296,7 @@ exports[`allowed hosts should disconnect web socket client using custom hostname
 
 exports[`allowed hosts should disconnect web socket client using custom hostname from web socket server with the "auto" value based on the "host" header when "server: 'https'" is enabled ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Invalid Host/Origin header",
@@ -309,7 +309,7 @@ exports[`allowed hosts should disconnect web socket client using custom hostname
 
 exports[`allowed hosts should disconnect web socket client using custom hostname from web socket server with the "auto" value based on the "host" header when "server: 'https'" is enabled ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Invalid Host/Origin header",
@@ -322,7 +322,7 @@ exports[`allowed hosts should disconnect web socket client using custom hostname
 
 exports[`allowed hosts should disconnect web socket client using custom hostname from web socket server with the "auto" value based on the "origin" header ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Invalid Host/Origin header",
@@ -335,7 +335,7 @@ exports[`allowed hosts should disconnect web socket client using custom hostname
 
 exports[`allowed hosts should disconnect web socket client using custom hostname from web socket server with the "auto" value based on the "origin" header ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Invalid Host/Origin header",

--- a/test/e2e/__snapshots__/api.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/api.test.js.snap.webpack4
@@ -2,6 +2,7 @@
 
 exports[`API Invalidate callback should use the default \`noop\` callback when invalidate is called without any callback: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -15,6 +16,7 @@ exports[`API Invalidate callback should use the default \`noop\` callback when i
 
 exports[`API Invalidate callback should use the provided \`callback\` function: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -28,6 +30,7 @@ exports[`API Invalidate callback should use the provided \`callback\` function: 
 
 exports[`API Server.checkHostHeader should allow URLs with scheme for checking origin when the "option.client.webSocketURL" is object: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "WebSocket connection to 'ws://test.host:8158/ws' failed: Error in connection establishment: net::ERR_NAME_NOT_RESOLVED",
@@ -45,6 +48,7 @@ exports[`API Server.checkHostHeader should allow URLs with scheme for checking o
 
 exports[`API Server.getFreePort should retry finding the port for up to defaultPortRetry times (number): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -58,6 +62,7 @@ exports[`API Server.getFreePort should retry finding the port for up to defaultP
 
 exports[`API Server.getFreePort should retry finding the port for up to defaultPortRetry times (string): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -71,6 +76,7 @@ exports[`API Server.getFreePort should retry finding the port for up to defaultP
 
 exports[`API Server.getFreePort should retry finding the port when serial ports are busy: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -84,6 +90,7 @@ exports[`API Server.getFreePort should retry finding the port when serial ports 
 
 exports[`API Server.getFreePort should return the port when the port is \`null\`: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -97,6 +104,7 @@ exports[`API Server.getFreePort should return the port when the port is \`null\`
 
 exports[`API Server.getFreePort should return the port when the port is undefined: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -112,6 +120,7 @@ exports[`API Server.getFreePort should throw the error when the port isn't found
 
 exports[`API WEBPACK_SERVE environment variable should be present: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -125,6 +134,7 @@ exports[`API WEBPACK_SERVE environment variable should be present: response stat
 
 exports[`API deprecated API should log warning when the "port" and "host" options from options different from arguments ('listen' method): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -138,6 +148,7 @@ exports[`API deprecated API should work with deprecated API ('listen' and 'close
 
 exports[`API deprecated API should work with deprecated API ('listen' and 'close' methods): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -151,6 +162,7 @@ exports[`API deprecated API should work with deprecated API ('listen' and 'close
 
 exports[`API deprecated API should work with deprecated API (only compiler in constructor): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -164,6 +176,7 @@ exports[`API deprecated API should work with deprecated API (only compiler in co
 
 exports[`API deprecated API should work with deprecated API (the order of the arguments in the constructor): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -177,6 +190,7 @@ exports[`API deprecated API should work with deprecated API (the order of the ar
 
 exports[`API latest async API should work and allow to rerun dev server multiple times: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -186,6 +200,7 @@ Array [
 
 exports[`API latest async API should work and allow to rerun dev server multiple times: console messages 2`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -199,6 +214,7 @@ exports[`API latest async API should work and allow to rerun dev server multiple
 
 exports[`API latest async API should work when using configured manually: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] Hot Module Replacement enabled.",
   "Hey.",
@@ -210,6 +226,7 @@ exports[`API latest async API should work when using configured manually: page e
 
 exports[`API latest async API should work with async API: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -221,6 +238,7 @@ exports[`API latest async API should work with async API: page errors 1`] = `Arr
 
 exports[`API latest async API should work with callback API: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",

--- a/test/e2e/__snapshots__/api.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/api.test.js.snap.webpack4
@@ -214,7 +214,6 @@ exports[`API latest async API should work and allow to rerun dev server multiple
 
 exports[`API latest async API should work when using configured manually: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] Hot Module Replacement enabled.",
   "Hey.",

--- a/test/e2e/__snapshots__/api.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/api.test.js.snap.webpack4
@@ -2,7 +2,7 @@
 
 exports[`API Invalidate callback should use the default \`noop\` callback when invalidate is called without any callback: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -14,7 +14,7 @@ exports[`API Invalidate callback should use the default \`noop\` callback when i
 
 exports[`API Invalidate callback should use the provided \`callback\` function: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -26,7 +26,7 @@ exports[`API Invalidate callback should use the provided \`callback\` function: 
 
 exports[`API Server.checkHostHeader should allow URLs with scheme for checking origin when the "option.client.webSocketURL" is object: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "WebSocket connection to 'ws://test.host:8158/ws' failed: Error in connection establishment: net::ERR_NAME_NOT_RESOLVED",
@@ -44,7 +44,7 @@ exports[`API Server.checkHostHeader should allow URLs with scheme for checking o
 
 exports[`API Server.getFreePort should retry finding the port for up to defaultPortRetry times (number): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -56,7 +56,7 @@ exports[`API Server.getFreePort should retry finding the port for up to defaultP
 
 exports[`API Server.getFreePort should retry finding the port for up to defaultPortRetry times (string): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -68,7 +68,7 @@ exports[`API Server.getFreePort should retry finding the port for up to defaultP
 
 exports[`API Server.getFreePort should retry finding the port when serial ports are busy: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -80,7 +80,7 @@ exports[`API Server.getFreePort should retry finding the port when serial ports 
 
 exports[`API Server.getFreePort should return the port when the port is \`null\`: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -92,7 +92,7 @@ exports[`API Server.getFreePort should return the port when the port is \`null\`
 
 exports[`API Server.getFreePort should return the port when the port is undefined: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -106,7 +106,7 @@ exports[`API Server.getFreePort should throw the error when the port isn't found
 
 exports[`API WEBPACK_SERVE environment variable should be present: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -118,7 +118,7 @@ exports[`API WEBPACK_SERVE environment variable should be present: response stat
 
 exports[`API deprecated API should log warning when the "port" and "host" options from options different from arguments ('listen' method): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -130,7 +130,7 @@ exports[`API deprecated API should work with deprecated API ('listen' and 'close
 
 exports[`API deprecated API should work with deprecated API ('listen' and 'close' methods): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -142,7 +142,7 @@ exports[`API deprecated API should work with deprecated API ('listen' and 'close
 
 exports[`API deprecated API should work with deprecated API (only compiler in constructor): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -154,7 +154,7 @@ exports[`API deprecated API should work with deprecated API (only compiler in co
 
 exports[`API deprecated API should work with deprecated API (the order of the arguments in the constructor): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -166,7 +166,7 @@ exports[`API deprecated API should work with deprecated API (the order of the ar
 
 exports[`API latest async API should work and allow to rerun dev server multiple times: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -174,7 +174,7 @@ Array [
 
 exports[`API latest async API should work and allow to rerun dev server multiple times: console messages 2`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -187,7 +187,7 @@ exports[`API latest async API should work and allow to rerun dev server multiple
 exports[`API latest async API should work when using configured manually: console messages 1`] = `
 Array [
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] server started with Hot Module Replacement enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading disabled, Progress disabled, Overlay disabled.",
   "Hey.",
 ]
 `;
@@ -196,7 +196,7 @@ exports[`API latest async API should work when using configured manually: page e
 
 exports[`API latest async API should work with async API: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -206,7 +206,7 @@ exports[`API latest async API should work with async API: page errors 1`] = `Arr
 
 exports[`API latest async API should work with callback API: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]

--- a/test/e2e/__snapshots__/api.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/api.test.js.snap.webpack4
@@ -2,11 +2,9 @@
 
 exports[`API Invalidate callback should use the default \`noop\` callback when invalidate is called without any callback: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -16,11 +14,9 @@ exports[`API Invalidate callback should use the default \`noop\` callback when i
 
 exports[`API Invalidate callback should use the provided \`callback\` function: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -30,7 +26,7 @@ exports[`API Invalidate callback should use the provided \`callback\` function: 
 
 exports[`API Server.checkHostHeader should allow URLs with scheme for checking origin when the "option.client.webSocketURL" is object: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "WebSocket connection to 'ws://test.host:8158/ws' failed: Error in connection establishment: net::ERR_NAME_NOT_RESOLVED",
@@ -48,11 +44,9 @@ exports[`API Server.checkHostHeader should allow URLs with scheme for checking o
 
 exports[`API Server.getFreePort should retry finding the port for up to defaultPortRetry times (number): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -62,11 +56,9 @@ exports[`API Server.getFreePort should retry finding the port for up to defaultP
 
 exports[`API Server.getFreePort should retry finding the port for up to defaultPortRetry times (string): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -76,11 +68,9 @@ exports[`API Server.getFreePort should retry finding the port for up to defaultP
 
 exports[`API Server.getFreePort should retry finding the port when serial ports are busy: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -90,11 +80,9 @@ exports[`API Server.getFreePort should retry finding the port when serial ports 
 
 exports[`API Server.getFreePort should return the port when the port is \`null\`: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -104,11 +92,9 @@ exports[`API Server.getFreePort should return the port when the port is \`null\`
 
 exports[`API Server.getFreePort should return the port when the port is undefined: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -120,11 +106,9 @@ exports[`API Server.getFreePort should throw the error when the port isn't found
 
 exports[`API WEBPACK_SERVE environment variable should be present: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -134,11 +118,9 @@ exports[`API WEBPACK_SERVE environment variable should be present: response stat
 
 exports[`API deprecated API should log warning when the "port" and "host" options from options different from arguments ('listen' method): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -148,11 +130,9 @@ exports[`API deprecated API should work with deprecated API ('listen' and 'close
 
 exports[`API deprecated API should work with deprecated API ('listen' and 'close' methods): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -162,11 +142,9 @@ exports[`API deprecated API should work with deprecated API ('listen' and 'close
 
 exports[`API deprecated API should work with deprecated API (only compiler in constructor): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -176,11 +154,9 @@ exports[`API deprecated API should work with deprecated API (only compiler in co
 
 exports[`API deprecated API should work with deprecated API (the order of the arguments in the constructor): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -190,21 +166,17 @@ exports[`API deprecated API should work with deprecated API (the order of the ar
 
 exports[`API latest async API should work and allow to rerun dev server multiple times: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`API latest async API should work and allow to rerun dev server multiple times: console messages 2`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -215,9 +187,8 @@ exports[`API latest async API should work and allow to rerun dev server multiple
 exports[`API latest async API should work when using configured manually: console messages 1`] = `
 Array [
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
+  "[webpack-dev-server] server started with Hot Module Replacement enabled.",
   "Hey.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -225,11 +196,9 @@ exports[`API latest async API should work when using configured manually: page e
 
 exports[`API latest async API should work with async API: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -237,11 +206,9 @@ exports[`API latest async API should work with async API: page errors 1`] = `Arr
 
 exports[`API latest async API should work with callback API: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 

--- a/test/e2e/__snapshots__/api.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/api.test.js.snap.webpack5
@@ -2,6 +2,7 @@
 
 exports[`API Invalidate callback should use the default \`noop\` callback when invalidate is called without any callback: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -15,6 +16,7 @@ exports[`API Invalidate callback should use the default \`noop\` callback when i
 
 exports[`API Invalidate callback should use the provided \`callback\` function: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -28,6 +30,7 @@ exports[`API Invalidate callback should use the provided \`callback\` function: 
 
 exports[`API Server.checkHostHeader should allow URLs with scheme for checking origin when the "option.client.webSocketURL" is object: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "WebSocket connection to 'ws://test.host:8158/ws' failed: Error in connection establishment: net::ERR_NAME_NOT_RESOLVED",
@@ -45,6 +48,7 @@ exports[`API Server.checkHostHeader should allow URLs with scheme for checking o
 
 exports[`API Server.getFreePort should retry finding the port for up to defaultPortRetry times (number): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -58,6 +62,7 @@ exports[`API Server.getFreePort should retry finding the port for up to defaultP
 
 exports[`API Server.getFreePort should retry finding the port for up to defaultPortRetry times (string): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -71,6 +76,7 @@ exports[`API Server.getFreePort should retry finding the port for up to defaultP
 
 exports[`API Server.getFreePort should retry finding the port when serial ports are busy: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -84,6 +90,7 @@ exports[`API Server.getFreePort should retry finding the port when serial ports 
 
 exports[`API Server.getFreePort should return the port when the port is \`null\`: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -97,6 +104,7 @@ exports[`API Server.getFreePort should return the port when the port is \`null\`
 
 exports[`API Server.getFreePort should return the port when the port is undefined: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -112,6 +120,7 @@ exports[`API Server.getFreePort should throw the error when the port isn't found
 
 exports[`API WEBPACK_SERVE environment variable should be present: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -125,6 +134,7 @@ exports[`API WEBPACK_SERVE environment variable should be present: response stat
 
 exports[`API deprecated API should log warning when the "port" and "host" options from options different from arguments ('listen' method): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -138,6 +148,7 @@ exports[`API deprecated API should work with deprecated API ('listen' and 'close
 
 exports[`API deprecated API should work with deprecated API ('listen' and 'close' methods): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -151,6 +162,7 @@ exports[`API deprecated API should work with deprecated API ('listen' and 'close
 
 exports[`API deprecated API should work with deprecated API (only compiler in constructor): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -164,6 +176,7 @@ exports[`API deprecated API should work with deprecated API (only compiler in co
 
 exports[`API deprecated API should work with deprecated API (the order of the arguments in the constructor): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -177,6 +190,7 @@ exports[`API deprecated API should work with deprecated API (the order of the ar
 
 exports[`API latest async API should work and allow to rerun dev server multiple times: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -186,6 +200,7 @@ Array [
 
 exports[`API latest async API should work and allow to rerun dev server multiple times: console messages 2`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -199,6 +214,7 @@ exports[`API latest async API should work and allow to rerun dev server multiple
 
 exports[`API latest async API should work when using configured manually: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] Hot Module Replacement enabled.",
   "Hey.",
@@ -210,6 +226,7 @@ exports[`API latest async API should work when using configured manually: page e
 
 exports[`API latest async API should work with async API: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -221,6 +238,7 @@ exports[`API latest async API should work with async API: page errors 1`] = `Arr
 
 exports[`API latest async API should work with callback API: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",

--- a/test/e2e/__snapshots__/api.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/api.test.js.snap.webpack5
@@ -214,7 +214,6 @@ exports[`API latest async API should work and allow to rerun dev server multiple
 
 exports[`API latest async API should work when using configured manually: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] Hot Module Replacement enabled.",
   "Hey.",

--- a/test/e2e/__snapshots__/api.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/api.test.js.snap.webpack5
@@ -2,7 +2,7 @@
 
 exports[`API Invalidate callback should use the default \`noop\` callback when invalidate is called without any callback: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -14,7 +14,7 @@ exports[`API Invalidate callback should use the default \`noop\` callback when i
 
 exports[`API Invalidate callback should use the provided \`callback\` function: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -26,7 +26,7 @@ exports[`API Invalidate callback should use the provided \`callback\` function: 
 
 exports[`API Server.checkHostHeader should allow URLs with scheme for checking origin when the "option.client.webSocketURL" is object: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "WebSocket connection to 'ws://test.host:8158/ws' failed: Error in connection establishment: net::ERR_NAME_NOT_RESOLVED",
@@ -44,7 +44,7 @@ exports[`API Server.checkHostHeader should allow URLs with scheme for checking o
 
 exports[`API Server.getFreePort should retry finding the port for up to defaultPortRetry times (number): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -56,7 +56,7 @@ exports[`API Server.getFreePort should retry finding the port for up to defaultP
 
 exports[`API Server.getFreePort should retry finding the port for up to defaultPortRetry times (string): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -68,7 +68,7 @@ exports[`API Server.getFreePort should retry finding the port for up to defaultP
 
 exports[`API Server.getFreePort should retry finding the port when serial ports are busy: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -80,7 +80,7 @@ exports[`API Server.getFreePort should retry finding the port when serial ports 
 
 exports[`API Server.getFreePort should return the port when the port is \`null\`: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -92,7 +92,7 @@ exports[`API Server.getFreePort should return the port when the port is \`null\`
 
 exports[`API Server.getFreePort should return the port when the port is undefined: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -106,7 +106,7 @@ exports[`API Server.getFreePort should throw the error when the port isn't found
 
 exports[`API WEBPACK_SERVE environment variable should be present: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -118,7 +118,7 @@ exports[`API WEBPACK_SERVE environment variable should be present: response stat
 
 exports[`API deprecated API should log warning when the "port" and "host" options from options different from arguments ('listen' method): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -130,7 +130,7 @@ exports[`API deprecated API should work with deprecated API ('listen' and 'close
 
 exports[`API deprecated API should work with deprecated API ('listen' and 'close' methods): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -142,7 +142,7 @@ exports[`API deprecated API should work with deprecated API ('listen' and 'close
 
 exports[`API deprecated API should work with deprecated API (only compiler in constructor): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -154,7 +154,7 @@ exports[`API deprecated API should work with deprecated API (only compiler in co
 
 exports[`API deprecated API should work with deprecated API (the order of the arguments in the constructor): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -166,7 +166,7 @@ exports[`API deprecated API should work with deprecated API (the order of the ar
 
 exports[`API latest async API should work and allow to rerun dev server multiple times: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -174,7 +174,7 @@ Array [
 
 exports[`API latest async API should work and allow to rerun dev server multiple times: console messages 2`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -187,7 +187,7 @@ exports[`API latest async API should work and allow to rerun dev server multiple
 exports[`API latest async API should work when using configured manually: console messages 1`] = `
 Array [
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] server started with Hot Module Replacement enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading disabled, Progress disabled, Overlay disabled.",
   "Hey.",
 ]
 `;
@@ -196,7 +196,7 @@ exports[`API latest async API should work when using configured manually: page e
 
 exports[`API latest async API should work with async API: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -206,7 +206,7 @@ exports[`API latest async API should work with async API: page errors 1`] = `Arr
 
 exports[`API latest async API should work with callback API: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]

--- a/test/e2e/__snapshots__/api.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/api.test.js.snap.webpack5
@@ -2,11 +2,9 @@
 
 exports[`API Invalidate callback should use the default \`noop\` callback when invalidate is called without any callback: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -16,11 +14,9 @@ exports[`API Invalidate callback should use the default \`noop\` callback when i
 
 exports[`API Invalidate callback should use the provided \`callback\` function: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -30,7 +26,7 @@ exports[`API Invalidate callback should use the provided \`callback\` function: 
 
 exports[`API Server.checkHostHeader should allow URLs with scheme for checking origin when the "option.client.webSocketURL" is object: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "WebSocket connection to 'ws://test.host:8158/ws' failed: Error in connection establishment: net::ERR_NAME_NOT_RESOLVED",
@@ -48,11 +44,9 @@ exports[`API Server.checkHostHeader should allow URLs with scheme for checking o
 
 exports[`API Server.getFreePort should retry finding the port for up to defaultPortRetry times (number): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -62,11 +56,9 @@ exports[`API Server.getFreePort should retry finding the port for up to defaultP
 
 exports[`API Server.getFreePort should retry finding the port for up to defaultPortRetry times (string): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -76,11 +68,9 @@ exports[`API Server.getFreePort should retry finding the port for up to defaultP
 
 exports[`API Server.getFreePort should retry finding the port when serial ports are busy: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -90,11 +80,9 @@ exports[`API Server.getFreePort should retry finding the port when serial ports 
 
 exports[`API Server.getFreePort should return the port when the port is \`null\`: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -104,11 +92,9 @@ exports[`API Server.getFreePort should return the port when the port is \`null\`
 
 exports[`API Server.getFreePort should return the port when the port is undefined: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -120,11 +106,9 @@ exports[`API Server.getFreePort should throw the error when the port isn't found
 
 exports[`API WEBPACK_SERVE environment variable should be present: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -134,11 +118,9 @@ exports[`API WEBPACK_SERVE environment variable should be present: response stat
 
 exports[`API deprecated API should log warning when the "port" and "host" options from options different from arguments ('listen' method): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -148,11 +130,9 @@ exports[`API deprecated API should work with deprecated API ('listen' and 'close
 
 exports[`API deprecated API should work with deprecated API ('listen' and 'close' methods): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -162,11 +142,9 @@ exports[`API deprecated API should work with deprecated API ('listen' and 'close
 
 exports[`API deprecated API should work with deprecated API (only compiler in constructor): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -176,11 +154,9 @@ exports[`API deprecated API should work with deprecated API (only compiler in co
 
 exports[`API deprecated API should work with deprecated API (the order of the arguments in the constructor): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -190,21 +166,17 @@ exports[`API deprecated API should work with deprecated API (the order of the ar
 
 exports[`API latest async API should work and allow to rerun dev server multiple times: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`API latest async API should work and allow to rerun dev server multiple times: console messages 2`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -215,9 +187,8 @@ exports[`API latest async API should work and allow to rerun dev server multiple
 exports[`API latest async API should work when using configured manually: console messages 1`] = `
 Array [
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
+  "[webpack-dev-server] server started with Hot Module Replacement enabled.",
   "Hey.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -225,11 +196,9 @@ exports[`API latest async API should work when using configured manually: page e
 
 exports[`API latest async API should work with async API: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -237,11 +206,9 @@ exports[`API latest async API should work with async API: page errors 1`] = `Arr
 
 exports[`API latest async API should work with callback API: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 

--- a/test/e2e/__snapshots__/bonjour.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/bonjour.test.js.snap.webpack4
@@ -2,11 +2,9 @@
 
 exports[`bonjour option as object should apply bonjour options: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -16,11 +14,9 @@ exports[`bonjour option as object should apply bonjour options: response status 
 
 exports[`bonjour option as true should call bonjour with correct params: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -30,11 +26,9 @@ exports[`bonjour option as true should call bonjour with correct params: respons
 
 exports[`bonjour option bonjour object and 'https' should apply bonjour options: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -44,11 +38,9 @@ exports[`bonjour option bonjour object and 'https' should apply bonjour options:
 
 exports[`bonjour option bonjour object and 'server' option should apply bonjour options: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -58,11 +50,9 @@ exports[`bonjour option bonjour object and 'server' option should apply bonjour 
 
 exports[`bonjour option with 'https' option should call bonjour with 'https' type: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -72,11 +62,9 @@ exports[`bonjour option with 'https' option should call bonjour with 'https' typ
 
 exports[`bonjour option with 'server' option should call bonjour with 'https' type: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 

--- a/test/e2e/__snapshots__/bonjour.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/bonjour.test.js.snap.webpack4
@@ -2,7 +2,7 @@
 
 exports[`bonjour option as object should apply bonjour options: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -14,7 +14,7 @@ exports[`bonjour option as object should apply bonjour options: response status 
 
 exports[`bonjour option as true should call bonjour with correct params: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -26,7 +26,7 @@ exports[`bonjour option as true should call bonjour with correct params: respons
 
 exports[`bonjour option bonjour object and 'https' should apply bonjour options: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -38,7 +38,7 @@ exports[`bonjour option bonjour object and 'https' should apply bonjour options:
 
 exports[`bonjour option bonjour object and 'server' option should apply bonjour options: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -50,7 +50,7 @@ exports[`bonjour option bonjour object and 'server' option should apply bonjour 
 
 exports[`bonjour option with 'https' option should call bonjour with 'https' type: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -62,7 +62,7 @@ exports[`bonjour option with 'https' option should call bonjour with 'https' typ
 
 exports[`bonjour option with 'server' option should call bonjour with 'https' type: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]

--- a/test/e2e/__snapshots__/bonjour.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/bonjour.test.js.snap.webpack4
@@ -2,6 +2,7 @@
 
 exports[`bonjour option as object should apply bonjour options: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -15,6 +16,7 @@ exports[`bonjour option as object should apply bonjour options: response status 
 
 exports[`bonjour option as true should call bonjour with correct params: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -28,6 +30,7 @@ exports[`bonjour option as true should call bonjour with correct params: respons
 
 exports[`bonjour option bonjour object and 'https' should apply bonjour options: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -41,6 +44,7 @@ exports[`bonjour option bonjour object and 'https' should apply bonjour options:
 
 exports[`bonjour option bonjour object and 'server' option should apply bonjour options: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -54,6 +58,7 @@ exports[`bonjour option bonjour object and 'server' option should apply bonjour 
 
 exports[`bonjour option with 'https' option should call bonjour with 'https' type: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -67,6 +72,7 @@ exports[`bonjour option with 'https' option should call bonjour with 'https' typ
 
 exports[`bonjour option with 'server' option should call bonjour with 'https' type: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",

--- a/test/e2e/__snapshots__/bonjour.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/bonjour.test.js.snap.webpack5
@@ -2,11 +2,9 @@
 
 exports[`bonjour option as object should apply bonjour options: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -16,11 +14,9 @@ exports[`bonjour option as object should apply bonjour options: response status 
 
 exports[`bonjour option as true should call bonjour with correct params: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -30,11 +26,9 @@ exports[`bonjour option as true should call bonjour with correct params: respons
 
 exports[`bonjour option bonjour object and 'https' should apply bonjour options: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -44,11 +38,9 @@ exports[`bonjour option bonjour object and 'https' should apply bonjour options:
 
 exports[`bonjour option bonjour object and 'server' option should apply bonjour options: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -58,11 +50,9 @@ exports[`bonjour option bonjour object and 'server' option should apply bonjour 
 
 exports[`bonjour option with 'https' option should call bonjour with 'https' type: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -72,11 +62,9 @@ exports[`bonjour option with 'https' option should call bonjour with 'https' typ
 
 exports[`bonjour option with 'server' option should call bonjour with 'https' type: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 

--- a/test/e2e/__snapshots__/bonjour.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/bonjour.test.js.snap.webpack5
@@ -2,7 +2,7 @@
 
 exports[`bonjour option as object should apply bonjour options: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -14,7 +14,7 @@ exports[`bonjour option as object should apply bonjour options: response status 
 
 exports[`bonjour option as true should call bonjour with correct params: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -26,7 +26,7 @@ exports[`bonjour option as true should call bonjour with correct params: respons
 
 exports[`bonjour option bonjour object and 'https' should apply bonjour options: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -38,7 +38,7 @@ exports[`bonjour option bonjour object and 'https' should apply bonjour options:
 
 exports[`bonjour option bonjour object and 'server' option should apply bonjour options: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -50,7 +50,7 @@ exports[`bonjour option bonjour object and 'server' option should apply bonjour 
 
 exports[`bonjour option with 'https' option should call bonjour with 'https' type: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -62,7 +62,7 @@ exports[`bonjour option with 'https' option should call bonjour with 'https' typ
 
 exports[`bonjour option with 'server' option should call bonjour with 'https' type: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]

--- a/test/e2e/__snapshots__/bonjour.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/bonjour.test.js.snap.webpack5
@@ -2,6 +2,7 @@
 
 exports[`bonjour option as object should apply bonjour options: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -15,6 +16,7 @@ exports[`bonjour option as object should apply bonjour options: response status 
 
 exports[`bonjour option as true should call bonjour with correct params: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -28,6 +30,7 @@ exports[`bonjour option as true should call bonjour with correct params: respons
 
 exports[`bonjour option bonjour object and 'https' should apply bonjour options: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -41,6 +44,7 @@ exports[`bonjour option bonjour object and 'https' should apply bonjour options:
 
 exports[`bonjour option bonjour object and 'server' option should apply bonjour options: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -54,6 +58,7 @@ exports[`bonjour option bonjour object and 'server' option should apply bonjour 
 
 exports[`bonjour option with 'https' option should call bonjour with 'https' type: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -67,6 +72,7 @@ exports[`bonjour option with 'https' option should call bonjour with 'https' typ
 
 exports[`bonjour option with 'server' option should call bonjour with 'https' type: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",

--- a/test/e2e/__snapshots__/built-in-routes.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/built-in-routes.test.js.snap.webpack4
@@ -52,11 +52,9 @@ exports[`Built in routes with simple config should handle GET request to magic a
 
 exports[`Built in routes with simple config should handle GET request to magic async html: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 

--- a/test/e2e/__snapshots__/built-in-routes.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/built-in-routes.test.js.snap.webpack4
@@ -52,7 +52,7 @@ exports[`Built in routes with simple config should handle GET request to magic a
 
 exports[`Built in routes with simple config should handle GET request to magic async html: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]

--- a/test/e2e/__snapshots__/built-in-routes.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/built-in-routes.test.js.snap.webpack4
@@ -52,6 +52,7 @@ exports[`Built in routes with simple config should handle GET request to magic a
 
 exports[`Built in routes with simple config should handle GET request to magic async html: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",

--- a/test/e2e/__snapshots__/built-in-routes.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/built-in-routes.test.js.snap.webpack5
@@ -52,11 +52,9 @@ exports[`Built in routes with simple config should handle GET request to magic a
 
 exports[`Built in routes with simple config should handle GET request to magic async html: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 

--- a/test/e2e/__snapshots__/built-in-routes.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/built-in-routes.test.js.snap.webpack5
@@ -52,7 +52,7 @@ exports[`Built in routes with simple config should handle GET request to magic a
 
 exports[`Built in routes with simple config should handle GET request to magic async html: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]

--- a/test/e2e/__snapshots__/built-in-routes.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/built-in-routes.test.js.snap.webpack5
@@ -52,6 +52,7 @@ exports[`Built in routes with simple config should handle GET request to magic a
 
 exports[`Built in routes with simple config should handle GET request to magic async html: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",

--- a/test/e2e/__snapshots__/client-reconnect.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/client-reconnect.test.js.snap.webpack4
@@ -2,7 +2,7 @@
 
 exports[`client.reconnect option specified as false should not try to reconnect: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Disconnected!",
@@ -15,7 +15,7 @@ exports[`client.reconnect option specified as false should not try to reconnect:
 
 exports[`client.reconnect option specified as number should try to reconnect 2 times: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Disconnected!",

--- a/test/e2e/__snapshots__/client-reconnect.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/client-reconnect.test.js.snap.webpack4
@@ -2,6 +2,7 @@
 
 exports[`client.reconnect option specified as false should not try to reconnect: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -16,6 +17,7 @@ exports[`client.reconnect option specified as false should not try to reconnect:
 
 exports[`client.reconnect option specified as number should try to reconnect 2 times: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",

--- a/test/e2e/__snapshots__/client-reconnect.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/client-reconnect.test.js.snap.webpack4
@@ -2,11 +2,9 @@
 
 exports[`client.reconnect option specified as false should not try to reconnect: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] Disconnected!",
 ]
 `;
@@ -17,11 +15,9 @@ exports[`client.reconnect option specified as false should not try to reconnect:
 
 exports[`client.reconnect option specified as number should try to reconnect 2 times: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] Disconnected!",
   "[webpack-dev-server] Trying to reconnect...",
   "WebSocket connection to 'ws://127.0.0.1:8163/ws' failed: Error in connection establishment: net::ERR_CONNECTION_REFUSED",

--- a/test/e2e/__snapshots__/client-reconnect.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/client-reconnect.test.js.snap.webpack5
@@ -2,7 +2,7 @@
 
 exports[`client.reconnect option specified as false should not try to reconnect: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Disconnected!",
@@ -15,7 +15,7 @@ exports[`client.reconnect option specified as false should not try to reconnect:
 
 exports[`client.reconnect option specified as number should try to reconnect 2 times: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Disconnected!",

--- a/test/e2e/__snapshots__/client-reconnect.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/client-reconnect.test.js.snap.webpack5
@@ -2,6 +2,7 @@
 
 exports[`client.reconnect option specified as false should not try to reconnect: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -16,6 +17,7 @@ exports[`client.reconnect option specified as false should not try to reconnect:
 
 exports[`client.reconnect option specified as number should try to reconnect 2 times: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",

--- a/test/e2e/__snapshots__/client-reconnect.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/client-reconnect.test.js.snap.webpack5
@@ -2,11 +2,9 @@
 
 exports[`client.reconnect option specified as false should not try to reconnect: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] Disconnected!",
 ]
 `;
@@ -17,11 +15,9 @@ exports[`client.reconnect option specified as false should not try to reconnect:
 
 exports[`client.reconnect option specified as number should try to reconnect 2 times: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] Disconnected!",
   "[webpack-dev-server] Trying to reconnect...",
   "WebSocket connection to 'ws://127.0.0.1:8163/ws' failed: Error in connection establishment: net::ERR_CONNECTION_REFUSED",

--- a/test/e2e/__snapshots__/entry.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/entry.test.js.snap.webpack4
@@ -2,11 +2,9 @@
 
 exports[`entry should work with dynamic async entry: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -14,11 +12,9 @@ exports[`entry should work with dynamic async entry: page errors 1`] = `Array []
 
 exports[`entry should work with dynamic entry: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -26,11 +22,9 @@ exports[`entry should work with dynamic entry: page errors 1`] = `Array []`;
 
 exports[`entry should work with multiple entries #2: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Bar.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -38,11 +32,9 @@ exports[`entry should work with multiple entries #2: page errors 1`] = `Array []
 
 exports[`entry should work with multiple entries: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -50,12 +42,10 @@ exports[`entry should work with multiple entries: page errors 1`] = `Array []`;
 
 exports[`entry should work with single array entry: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "Bar.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -63,11 +53,9 @@ exports[`entry should work with single array entry: page errors 1`] = `Array []`
 
 exports[`entry should work with single entry: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 

--- a/test/e2e/__snapshots__/entry.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/entry.test.js.snap.webpack4
@@ -2,6 +2,7 @@
 
 exports[`entry should work with dynamic async entry: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -13,6 +14,7 @@ exports[`entry should work with dynamic async entry: page errors 1`] = `Array []
 
 exports[`entry should work with dynamic entry: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -24,6 +26,7 @@ exports[`entry should work with dynamic entry: page errors 1`] = `Array []`;
 
 exports[`entry should work with multiple entries #2: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Bar.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -35,6 +38,7 @@ exports[`entry should work with multiple entries #2: page errors 1`] = `Array []
 
 exports[`entry should work with multiple entries: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -46,6 +50,7 @@ exports[`entry should work with multiple entries: page errors 1`] = `Array []`;
 
 exports[`entry should work with single array entry: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "Bar.",
@@ -58,6 +63,7 @@ exports[`entry should work with single array entry: page errors 1`] = `Array []`
 
 exports[`entry should work with single entry: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",

--- a/test/e2e/__snapshots__/entry.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/entry.test.js.snap.webpack4
@@ -2,7 +2,7 @@
 
 exports[`entry should work with dynamic async entry: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -12,7 +12,7 @@ exports[`entry should work with dynamic async entry: page errors 1`] = `Array []
 
 exports[`entry should work with dynamic entry: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -22,7 +22,7 @@ exports[`entry should work with dynamic entry: page errors 1`] = `Array []`;
 
 exports[`entry should work with multiple entries #2: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Bar.",
 ]
@@ -32,7 +32,7 @@ exports[`entry should work with multiple entries #2: page errors 1`] = `Array []
 
 exports[`entry should work with multiple entries: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -42,7 +42,7 @@ exports[`entry should work with multiple entries: page errors 1`] = `Array []`;
 
 exports[`entry should work with single array entry: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "Bar.",
@@ -53,7 +53,7 @@ exports[`entry should work with single array entry: page errors 1`] = `Array []`
 
 exports[`entry should work with single entry: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]

--- a/test/e2e/__snapshots__/entry.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/entry.test.js.snap.webpack5
@@ -2,6 +2,7 @@
 
 exports[`entry should work with dynamic async entry: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -13,6 +14,7 @@ exports[`entry should work with dynamic async entry: page errors 1`] = `Array []
 
 exports[`entry should work with dynamic entry: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -24,6 +26,7 @@ exports[`entry should work with dynamic entry: page errors 1`] = `Array []`;
 
 exports[`entry should work with empty: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -35,6 +38,7 @@ exports[`entry should work with empty: page errors 1`] = `Array []`;
 
 exports[`entry should work with multiple entries #2: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Bar.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -46,6 +50,7 @@ exports[`entry should work with multiple entries #2: page errors 1`] = `Array []
 
 exports[`entry should work with multiple entries and "dependOn": console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Bar.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -58,6 +63,7 @@ exports[`entry should work with multiple entries and "dependOn": page errors 1`]
 
 exports[`entry should work with multiple entries: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -69,6 +75,7 @@ exports[`entry should work with multiple entries: page errors 1`] = `Array []`;
 
 exports[`entry should work with object entry: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -80,6 +87,7 @@ exports[`entry should work with object entry: page errors 1`] = `Array []`;
 
 exports[`entry should work with single array entry: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "Bar.",
@@ -92,6 +100,7 @@ exports[`entry should work with single array entry: page errors 1`] = `Array []`
 
 exports[`entry should work with single entry: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",

--- a/test/e2e/__snapshots__/entry.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/entry.test.js.snap.webpack5
@@ -2,11 +2,9 @@
 
 exports[`entry should work with dynamic async entry: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -14,11 +12,9 @@ exports[`entry should work with dynamic async entry: page errors 1`] = `Array []
 
 exports[`entry should work with dynamic entry: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -26,11 +22,9 @@ exports[`entry should work with dynamic entry: page errors 1`] = `Array []`;
 
 exports[`entry should work with empty: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -38,11 +32,9 @@ exports[`entry should work with empty: page errors 1`] = `Array []`;
 
 exports[`entry should work with multiple entries #2: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Bar.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -50,11 +42,9 @@ exports[`entry should work with multiple entries #2: page errors 1`] = `Array []
 
 exports[`entry should work with multiple entries and "dependOn": console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Bar.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
   "Hey.",
 ]
 `;
@@ -63,11 +53,9 @@ exports[`entry should work with multiple entries and "dependOn": page errors 1`]
 
 exports[`entry should work with multiple entries: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -75,11 +63,9 @@ exports[`entry should work with multiple entries: page errors 1`] = `Array []`;
 
 exports[`entry should work with object entry: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -87,12 +73,10 @@ exports[`entry should work with object entry: page errors 1`] = `Array []`;
 
 exports[`entry should work with single array entry: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "Bar.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -100,11 +84,9 @@ exports[`entry should work with single array entry: page errors 1`] = `Array []`
 
 exports[`entry should work with single entry: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 

--- a/test/e2e/__snapshots__/entry.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/entry.test.js.snap.webpack5
@@ -2,7 +2,7 @@
 
 exports[`entry should work with dynamic async entry: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -12,7 +12,7 @@ exports[`entry should work with dynamic async entry: page errors 1`] = `Array []
 
 exports[`entry should work with dynamic entry: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -22,7 +22,7 @@ exports[`entry should work with dynamic entry: page errors 1`] = `Array []`;
 
 exports[`entry should work with empty: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -32,7 +32,7 @@ exports[`entry should work with empty: page errors 1`] = `Array []`;
 
 exports[`entry should work with multiple entries #2: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Bar.",
 ]
@@ -42,7 +42,7 @@ exports[`entry should work with multiple entries #2: page errors 1`] = `Array []
 
 exports[`entry should work with multiple entries and "dependOn": console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Bar.",
   "Hey.",
@@ -53,7 +53,7 @@ exports[`entry should work with multiple entries and "dependOn": page errors 1`]
 
 exports[`entry should work with multiple entries: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -63,7 +63,7 @@ exports[`entry should work with multiple entries: page errors 1`] = `Array []`;
 
 exports[`entry should work with object entry: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -73,7 +73,7 @@ exports[`entry should work with object entry: page errors 1`] = `Array []`;
 
 exports[`entry should work with single array entry: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "Bar.",
@@ -84,7 +84,7 @@ exports[`entry should work with single array entry: page errors 1`] = `Array []`
 
 exports[`entry should work with single entry: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]

--- a/test/e2e/__snapshots__/headers.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/headers.test.js.snap.webpack4
@@ -2,11 +2,9 @@
 
 exports[`headers option as a function returning an array should handle GET request with headers: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -20,11 +18,9 @@ exports[`headers option as a function returning an array should handle GET reque
 
 exports[`headers option as a function should handle GET request with headers as a function: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -39,11 +35,9 @@ exports[`headers option as a function should handle GET request with headers as 
 
 exports[`headers option as a string and support HEAD request should handle HEAD request with headers: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -55,11 +49,9 @@ exports[`headers option as a string and support HEAD request should handle HEAD 
 
 exports[`headers option as a string should handle GET request with headers: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -71,11 +63,9 @@ exports[`headers option as a string should handle GET request with headers: resp
 
 exports[`headers option as an array of objects should handle GET request with headers: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -89,11 +79,9 @@ exports[`headers option as an array of objects should handle GET request with he
 
 exports[`headers option as an array should handle GET request with headers as an array: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -108,11 +96,9 @@ exports[`headers option as an array should handle GET request with headers as an
 
 exports[`headers option dev middleware headers take precedence for dev middleware output files should handle GET request with headers as a function: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 

--- a/test/e2e/__snapshots__/headers.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/headers.test.js.snap.webpack4
@@ -2,7 +2,7 @@
 
 exports[`headers option as a function returning an array should handle GET request with headers: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -18,7 +18,7 @@ exports[`headers option as a function returning an array should handle GET reque
 
 exports[`headers option as a function should handle GET request with headers as a function: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -35,7 +35,7 @@ exports[`headers option as a function should handle GET request with headers as 
 
 exports[`headers option as a string and support HEAD request should handle HEAD request with headers: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -49,7 +49,7 @@ exports[`headers option as a string and support HEAD request should handle HEAD 
 
 exports[`headers option as a string should handle GET request with headers: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -63,7 +63,7 @@ exports[`headers option as a string should handle GET request with headers: resp
 
 exports[`headers option as an array of objects should handle GET request with headers: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -79,7 +79,7 @@ exports[`headers option as an array of objects should handle GET request with he
 
 exports[`headers option as an array should handle GET request with headers as an array: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -96,7 +96,7 @@ exports[`headers option as an array should handle GET request with headers as an
 
 exports[`headers option dev middleware headers take precedence for dev middleware output files should handle GET request with headers as a function: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]

--- a/test/e2e/__snapshots__/headers.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/headers.test.js.snap.webpack4
@@ -2,6 +2,7 @@
 
 exports[`headers option as a function returning an array should handle GET request with headers: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -19,6 +20,7 @@ exports[`headers option as a function returning an array should handle GET reque
 
 exports[`headers option as a function should handle GET request with headers as a function: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -37,6 +39,7 @@ exports[`headers option as a function should handle GET request with headers as 
 
 exports[`headers option as a string and support HEAD request should handle HEAD request with headers: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -52,6 +55,7 @@ exports[`headers option as a string and support HEAD request should handle HEAD 
 
 exports[`headers option as a string should handle GET request with headers: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -67,6 +71,7 @@ exports[`headers option as a string should handle GET request with headers: resp
 
 exports[`headers option as an array of objects should handle GET request with headers: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -84,6 +89,7 @@ exports[`headers option as an array of objects should handle GET request with he
 
 exports[`headers option as an array should handle GET request with headers as an array: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -102,6 +108,7 @@ exports[`headers option as an array should handle GET request with headers as an
 
 exports[`headers option dev middleware headers take precedence for dev middleware output files should handle GET request with headers as a function: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",

--- a/test/e2e/__snapshots__/headers.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/headers.test.js.snap.webpack5
@@ -2,11 +2,9 @@
 
 exports[`headers option as a function returning an array should handle GET request with headers: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -20,11 +18,9 @@ exports[`headers option as a function returning an array should handle GET reque
 
 exports[`headers option as a function should handle GET request with headers as a function: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -39,11 +35,9 @@ exports[`headers option as a function should handle GET request with headers as 
 
 exports[`headers option as a string and support HEAD request should handle HEAD request with headers: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -55,11 +49,9 @@ exports[`headers option as a string and support HEAD request should handle HEAD 
 
 exports[`headers option as a string should handle GET request with headers: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -71,11 +63,9 @@ exports[`headers option as a string should handle GET request with headers: resp
 
 exports[`headers option as an array of objects should handle GET request with headers: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -89,11 +79,9 @@ exports[`headers option as an array of objects should handle GET request with he
 
 exports[`headers option as an array should handle GET request with headers as an array: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -108,11 +96,9 @@ exports[`headers option as an array should handle GET request with headers as an
 
 exports[`headers option dev middleware headers take precedence for dev middleware output files should handle GET request with headers as a function: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 

--- a/test/e2e/__snapshots__/headers.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/headers.test.js.snap.webpack5
@@ -2,7 +2,7 @@
 
 exports[`headers option as a function returning an array should handle GET request with headers: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -18,7 +18,7 @@ exports[`headers option as a function returning an array should handle GET reque
 
 exports[`headers option as a function should handle GET request with headers as a function: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -35,7 +35,7 @@ exports[`headers option as a function should handle GET request with headers as 
 
 exports[`headers option as a string and support HEAD request should handle HEAD request with headers: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -49,7 +49,7 @@ exports[`headers option as a string and support HEAD request should handle HEAD 
 
 exports[`headers option as a string should handle GET request with headers: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -63,7 +63,7 @@ exports[`headers option as a string should handle GET request with headers: resp
 
 exports[`headers option as an array of objects should handle GET request with headers: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -79,7 +79,7 @@ exports[`headers option as an array of objects should handle GET request with he
 
 exports[`headers option as an array should handle GET request with headers as an array: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -96,7 +96,7 @@ exports[`headers option as an array should handle GET request with headers as an
 
 exports[`headers option dev middleware headers take precedence for dev middleware output files should handle GET request with headers as a function: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]

--- a/test/e2e/__snapshots__/headers.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/headers.test.js.snap.webpack5
@@ -2,6 +2,7 @@
 
 exports[`headers option as a function returning an array should handle GET request with headers: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -19,6 +20,7 @@ exports[`headers option as a function returning an array should handle GET reque
 
 exports[`headers option as a function should handle GET request with headers as a function: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -37,6 +39,7 @@ exports[`headers option as a function should handle GET request with headers as 
 
 exports[`headers option as a string and support HEAD request should handle HEAD request with headers: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -52,6 +55,7 @@ exports[`headers option as a string and support HEAD request should handle HEAD 
 
 exports[`headers option as a string should handle GET request with headers: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -67,6 +71,7 @@ exports[`headers option as a string should handle GET request with headers: resp
 
 exports[`headers option as an array of objects should handle GET request with headers: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -84,6 +89,7 @@ exports[`headers option as an array of objects should handle GET request with he
 
 exports[`headers option as an array should handle GET request with headers as an array: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -102,6 +108,7 @@ exports[`headers option as an array should handle GET request with headers as an
 
 exports[`headers option dev middleware headers take precedence for dev middleware output files should handle GET request with headers as a function: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",

--- a/test/e2e/__snapshots__/host.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/host.test.js.snap.webpack4
@@ -2,7 +2,7 @@
 
 exports[`host should work using "::" host and "auto" port: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -12,7 +12,7 @@ exports[`host should work using "::" host and "auto" port: page errors 1`] = `Ar
 
 exports[`host should work using "::" host and port as number: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -22,7 +22,7 @@ exports[`host should work using "::" host and port as number: page errors 1`] = 
 
 exports[`host should work using "::" host and port as string: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -32,7 +32,7 @@ exports[`host should work using "::" host and port as string: page errors 1`] = 
 
 exports[`host should work using "::1" host and "auto" port: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -42,7 +42,7 @@ exports[`host should work using "::1" host and "auto" port: page errors 1`] = `A
 
 exports[`host should work using "::1" host and port as number: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -52,7 +52,7 @@ exports[`host should work using "::1" host and port as number: page errors 1`] =
 
 exports[`host should work using "::1" host and port as string: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -62,7 +62,7 @@ exports[`host should work using "::1" host and port as string: page errors 1`] =
 
 exports[`host should work using "<not-specified>" host and "auto" port: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -72,7 +72,7 @@ exports[`host should work using "<not-specified>" host and "auto" port: page err
 
 exports[`host should work using "<not-specified>" host and port as number: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -82,7 +82,7 @@ exports[`host should work using "<not-specified>" host and port as number: page 
 
 exports[`host should work using "<not-specified>" host and port as string: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -92,7 +92,7 @@ exports[`host should work using "<not-specified>" host and port as string: page 
 
 exports[`host should work using "0.0.0.0" host and "auto" port: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -102,7 +102,7 @@ exports[`host should work using "0.0.0.0" host and "auto" port: page errors 1`] 
 
 exports[`host should work using "0.0.0.0" host and port as number: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -112,7 +112,7 @@ exports[`host should work using "0.0.0.0" host and port as number: page errors 1
 
 exports[`host should work using "0.0.0.0" host and port as string: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -122,7 +122,7 @@ exports[`host should work using "0.0.0.0" host and port as string: page errors 1
 
 exports[`host should work using "127.0.0.1" host and "auto" port: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -132,7 +132,7 @@ exports[`host should work using "127.0.0.1" host and "auto" port: page errors 1`
 
 exports[`host should work using "127.0.0.1" host and port as number: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -142,7 +142,7 @@ exports[`host should work using "127.0.0.1" host and port as number: page errors
 
 exports[`host should work using "127.0.0.1" host and port as string: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -152,7 +152,7 @@ exports[`host should work using "127.0.0.1" host and port as string: page errors
 
 exports[`host should work using "local-ip" host and "auto" port: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -162,7 +162,7 @@ exports[`host should work using "local-ip" host and "auto" port: page errors 1`]
 
 exports[`host should work using "local-ip" host and port as number: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -172,7 +172,7 @@ exports[`host should work using "local-ip" host and port as number: page errors 
 
 exports[`host should work using "local-ip" host and port as string: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -182,7 +182,7 @@ exports[`host should work using "local-ip" host and port as string: page errors 
 
 exports[`host should work using "local-ipv4" host and "auto" port: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -192,7 +192,7 @@ exports[`host should work using "local-ipv4" host and "auto" port: page errors 1
 
 exports[`host should work using "local-ipv4" host and port as number: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -202,7 +202,7 @@ exports[`host should work using "local-ipv4" host and port as number: page error
 
 exports[`host should work using "local-ipv4" host and port as string: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -212,7 +212,7 @@ exports[`host should work using "local-ipv4" host and port as string: page error
 
 exports[`host should work using "local-ipv6" host and "auto" port: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -222,7 +222,7 @@ exports[`host should work using "local-ipv6" host and "auto" port: page errors 1
 
 exports[`host should work using "local-ipv6" host and port as number: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -232,7 +232,7 @@ exports[`host should work using "local-ipv6" host and port as number: page error
 
 exports[`host should work using "local-ipv6" host and port as string: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -242,7 +242,7 @@ exports[`host should work using "local-ipv6" host and port as string: page error
 
 exports[`host should work using "localhost" host and "auto" port: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -252,7 +252,7 @@ exports[`host should work using "localhost" host and "auto" port: page errors 1`
 
 exports[`host should work using "localhost" host and port as number: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -262,7 +262,7 @@ exports[`host should work using "localhost" host and port as number: page errors
 
 exports[`host should work using "localhost" host and port as string: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -272,7 +272,7 @@ exports[`host should work using "localhost" host and port as string: page errors
 
 exports[`host should work using "undefined" host and "auto" port: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -282,7 +282,7 @@ exports[`host should work using "undefined" host and "auto" port: page errors 1`
 
 exports[`host should work using "undefined" host and port as number: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -292,7 +292,7 @@ exports[`host should work using "undefined" host and port as number: page errors
 
 exports[`host should work using "undefined" host and port as string: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]

--- a/test/e2e/__snapshots__/host.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/host.test.js.snap.webpack4
@@ -2,11 +2,9 @@
 
 exports[`host should work using "::" host and "auto" port: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -14,11 +12,9 @@ exports[`host should work using "::" host and "auto" port: page errors 1`] = `Ar
 
 exports[`host should work using "::" host and port as number: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -26,11 +22,9 @@ exports[`host should work using "::" host and port as number: page errors 1`] = 
 
 exports[`host should work using "::" host and port as string: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -38,11 +32,9 @@ exports[`host should work using "::" host and port as string: page errors 1`] = 
 
 exports[`host should work using "::1" host and "auto" port: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -50,11 +42,9 @@ exports[`host should work using "::1" host and "auto" port: page errors 1`] = `A
 
 exports[`host should work using "::1" host and port as number: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -62,11 +52,9 @@ exports[`host should work using "::1" host and port as number: page errors 1`] =
 
 exports[`host should work using "::1" host and port as string: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -74,11 +62,9 @@ exports[`host should work using "::1" host and port as string: page errors 1`] =
 
 exports[`host should work using "<not-specified>" host and "auto" port: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -86,11 +72,9 @@ exports[`host should work using "<not-specified>" host and "auto" port: page err
 
 exports[`host should work using "<not-specified>" host and port as number: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -98,11 +82,9 @@ exports[`host should work using "<not-specified>" host and port as number: page 
 
 exports[`host should work using "<not-specified>" host and port as string: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -110,11 +92,9 @@ exports[`host should work using "<not-specified>" host and port as string: page 
 
 exports[`host should work using "0.0.0.0" host and "auto" port: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -122,11 +102,9 @@ exports[`host should work using "0.0.0.0" host and "auto" port: page errors 1`] 
 
 exports[`host should work using "0.0.0.0" host and port as number: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -134,11 +112,9 @@ exports[`host should work using "0.0.0.0" host and port as number: page errors 1
 
 exports[`host should work using "0.0.0.0" host and port as string: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -146,11 +122,9 @@ exports[`host should work using "0.0.0.0" host and port as string: page errors 1
 
 exports[`host should work using "127.0.0.1" host and "auto" port: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -158,11 +132,9 @@ exports[`host should work using "127.0.0.1" host and "auto" port: page errors 1`
 
 exports[`host should work using "127.0.0.1" host and port as number: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -170,11 +142,9 @@ exports[`host should work using "127.0.0.1" host and port as number: page errors
 
 exports[`host should work using "127.0.0.1" host and port as string: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -182,11 +152,9 @@ exports[`host should work using "127.0.0.1" host and port as string: page errors
 
 exports[`host should work using "local-ip" host and "auto" port: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -194,11 +162,9 @@ exports[`host should work using "local-ip" host and "auto" port: page errors 1`]
 
 exports[`host should work using "local-ip" host and port as number: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -206,11 +172,9 @@ exports[`host should work using "local-ip" host and port as number: page errors 
 
 exports[`host should work using "local-ip" host and port as string: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -218,11 +182,9 @@ exports[`host should work using "local-ip" host and port as string: page errors 
 
 exports[`host should work using "local-ipv4" host and "auto" port: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -230,11 +192,9 @@ exports[`host should work using "local-ipv4" host and "auto" port: page errors 1
 
 exports[`host should work using "local-ipv4" host and port as number: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -242,11 +202,9 @@ exports[`host should work using "local-ipv4" host and port as number: page error
 
 exports[`host should work using "local-ipv4" host and port as string: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -254,11 +212,9 @@ exports[`host should work using "local-ipv4" host and port as string: page error
 
 exports[`host should work using "local-ipv6" host and "auto" port: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -266,11 +222,9 @@ exports[`host should work using "local-ipv6" host and "auto" port: page errors 1
 
 exports[`host should work using "local-ipv6" host and port as number: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -278,11 +232,9 @@ exports[`host should work using "local-ipv6" host and port as number: page error
 
 exports[`host should work using "local-ipv6" host and port as string: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -290,11 +242,9 @@ exports[`host should work using "local-ipv6" host and port as string: page error
 
 exports[`host should work using "localhost" host and "auto" port: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -302,11 +252,9 @@ exports[`host should work using "localhost" host and "auto" port: page errors 1`
 
 exports[`host should work using "localhost" host and port as number: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -314,11 +262,9 @@ exports[`host should work using "localhost" host and port as number: page errors
 
 exports[`host should work using "localhost" host and port as string: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -326,11 +272,9 @@ exports[`host should work using "localhost" host and port as string: page errors
 
 exports[`host should work using "undefined" host and "auto" port: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -338,11 +282,9 @@ exports[`host should work using "undefined" host and "auto" port: page errors 1`
 
 exports[`host should work using "undefined" host and port as number: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -350,11 +292,9 @@ exports[`host should work using "undefined" host and port as number: page errors
 
 exports[`host should work using "undefined" host and port as string: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 

--- a/test/e2e/__snapshots__/host.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/host.test.js.snap.webpack4
@@ -2,6 +2,7 @@
 
 exports[`host should work using "::" host and "auto" port: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -13,6 +14,7 @@ exports[`host should work using "::" host and "auto" port: page errors 1`] = `Ar
 
 exports[`host should work using "::" host and port as number: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -24,6 +26,7 @@ exports[`host should work using "::" host and port as number: page errors 1`] = 
 
 exports[`host should work using "::" host and port as string: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -35,6 +38,7 @@ exports[`host should work using "::" host and port as string: page errors 1`] = 
 
 exports[`host should work using "::1" host and "auto" port: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -46,6 +50,7 @@ exports[`host should work using "::1" host and "auto" port: page errors 1`] = `A
 
 exports[`host should work using "::1" host and port as number: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -57,6 +62,7 @@ exports[`host should work using "::1" host and port as number: page errors 1`] =
 
 exports[`host should work using "::1" host and port as string: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -68,6 +74,7 @@ exports[`host should work using "::1" host and port as string: page errors 1`] =
 
 exports[`host should work using "<not-specified>" host and "auto" port: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -79,6 +86,7 @@ exports[`host should work using "<not-specified>" host and "auto" port: page err
 
 exports[`host should work using "<not-specified>" host and port as number: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -90,6 +98,7 @@ exports[`host should work using "<not-specified>" host and port as number: page 
 
 exports[`host should work using "<not-specified>" host and port as string: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -101,6 +110,7 @@ exports[`host should work using "<not-specified>" host and port as string: page 
 
 exports[`host should work using "0.0.0.0" host and "auto" port: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -112,6 +122,7 @@ exports[`host should work using "0.0.0.0" host and "auto" port: page errors 1`] 
 
 exports[`host should work using "0.0.0.0" host and port as number: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -123,6 +134,7 @@ exports[`host should work using "0.0.0.0" host and port as number: page errors 1
 
 exports[`host should work using "0.0.0.0" host and port as string: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -134,6 +146,7 @@ exports[`host should work using "0.0.0.0" host and port as string: page errors 1
 
 exports[`host should work using "127.0.0.1" host and "auto" port: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -145,6 +158,7 @@ exports[`host should work using "127.0.0.1" host and "auto" port: page errors 1`
 
 exports[`host should work using "127.0.0.1" host and port as number: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -156,6 +170,7 @@ exports[`host should work using "127.0.0.1" host and port as number: page errors
 
 exports[`host should work using "127.0.0.1" host and port as string: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -167,6 +182,7 @@ exports[`host should work using "127.0.0.1" host and port as string: page errors
 
 exports[`host should work using "local-ip" host and "auto" port: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -178,6 +194,7 @@ exports[`host should work using "local-ip" host and "auto" port: page errors 1`]
 
 exports[`host should work using "local-ip" host and port as number: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -189,6 +206,7 @@ exports[`host should work using "local-ip" host and port as number: page errors 
 
 exports[`host should work using "local-ip" host and port as string: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -200,6 +218,7 @@ exports[`host should work using "local-ip" host and port as string: page errors 
 
 exports[`host should work using "local-ipv4" host and "auto" port: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -211,6 +230,7 @@ exports[`host should work using "local-ipv4" host and "auto" port: page errors 1
 
 exports[`host should work using "local-ipv4" host and port as number: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -222,6 +242,7 @@ exports[`host should work using "local-ipv4" host and port as number: page error
 
 exports[`host should work using "local-ipv4" host and port as string: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -233,6 +254,7 @@ exports[`host should work using "local-ipv4" host and port as string: page error
 
 exports[`host should work using "local-ipv6" host and "auto" port: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -244,6 +266,7 @@ exports[`host should work using "local-ipv6" host and "auto" port: page errors 1
 
 exports[`host should work using "local-ipv6" host and port as number: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -255,6 +278,7 @@ exports[`host should work using "local-ipv6" host and port as number: page error
 
 exports[`host should work using "local-ipv6" host and port as string: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -266,6 +290,7 @@ exports[`host should work using "local-ipv6" host and port as string: page error
 
 exports[`host should work using "localhost" host and "auto" port: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -277,6 +302,7 @@ exports[`host should work using "localhost" host and "auto" port: page errors 1`
 
 exports[`host should work using "localhost" host and port as number: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -288,6 +314,7 @@ exports[`host should work using "localhost" host and port as number: page errors
 
 exports[`host should work using "localhost" host and port as string: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -299,6 +326,7 @@ exports[`host should work using "localhost" host and port as string: page errors
 
 exports[`host should work using "undefined" host and "auto" port: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -310,6 +338,7 @@ exports[`host should work using "undefined" host and "auto" port: page errors 1`
 
 exports[`host should work using "undefined" host and port as number: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -321,6 +350,7 @@ exports[`host should work using "undefined" host and port as number: page errors
 
 exports[`host should work using "undefined" host and port as string: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",

--- a/test/e2e/__snapshots__/host.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/host.test.js.snap.webpack5
@@ -2,7 +2,7 @@
 
 exports[`host should work using "::" host and "auto" port: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -12,7 +12,7 @@ exports[`host should work using "::" host and "auto" port: page errors 1`] = `Ar
 
 exports[`host should work using "::" host and port as number: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -22,7 +22,7 @@ exports[`host should work using "::" host and port as number: page errors 1`] = 
 
 exports[`host should work using "::" host and port as string: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -32,7 +32,7 @@ exports[`host should work using "::" host and port as string: page errors 1`] = 
 
 exports[`host should work using "::1" host and "auto" port: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -42,7 +42,7 @@ exports[`host should work using "::1" host and "auto" port: page errors 1`] = `A
 
 exports[`host should work using "::1" host and port as number: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -52,7 +52,7 @@ exports[`host should work using "::1" host and port as number: page errors 1`] =
 
 exports[`host should work using "::1" host and port as string: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -62,7 +62,7 @@ exports[`host should work using "::1" host and port as string: page errors 1`] =
 
 exports[`host should work using "<not-specified>" host and "auto" port: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -72,7 +72,7 @@ exports[`host should work using "<not-specified>" host and "auto" port: page err
 
 exports[`host should work using "<not-specified>" host and port as number: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -82,7 +82,7 @@ exports[`host should work using "<not-specified>" host and port as number: page 
 
 exports[`host should work using "<not-specified>" host and port as string: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -92,7 +92,7 @@ exports[`host should work using "<not-specified>" host and port as string: page 
 
 exports[`host should work using "0.0.0.0" host and "auto" port: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -102,7 +102,7 @@ exports[`host should work using "0.0.0.0" host and "auto" port: page errors 1`] 
 
 exports[`host should work using "0.0.0.0" host and port as number: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -112,7 +112,7 @@ exports[`host should work using "0.0.0.0" host and port as number: page errors 1
 
 exports[`host should work using "0.0.0.0" host and port as string: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -122,7 +122,7 @@ exports[`host should work using "0.0.0.0" host and port as string: page errors 1
 
 exports[`host should work using "127.0.0.1" host and "auto" port: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -132,7 +132,7 @@ exports[`host should work using "127.0.0.1" host and "auto" port: page errors 1`
 
 exports[`host should work using "127.0.0.1" host and port as number: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -142,7 +142,7 @@ exports[`host should work using "127.0.0.1" host and port as number: page errors
 
 exports[`host should work using "127.0.0.1" host and port as string: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -152,7 +152,7 @@ exports[`host should work using "127.0.0.1" host and port as string: page errors
 
 exports[`host should work using "local-ip" host and "auto" port: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -162,7 +162,7 @@ exports[`host should work using "local-ip" host and "auto" port: page errors 1`]
 
 exports[`host should work using "local-ip" host and port as number: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -172,7 +172,7 @@ exports[`host should work using "local-ip" host and port as number: page errors 
 
 exports[`host should work using "local-ip" host and port as string: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -182,7 +182,7 @@ exports[`host should work using "local-ip" host and port as string: page errors 
 
 exports[`host should work using "local-ipv4" host and "auto" port: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -192,7 +192,7 @@ exports[`host should work using "local-ipv4" host and "auto" port: page errors 1
 
 exports[`host should work using "local-ipv4" host and port as number: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -202,7 +202,7 @@ exports[`host should work using "local-ipv4" host and port as number: page error
 
 exports[`host should work using "local-ipv4" host and port as string: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -212,7 +212,7 @@ exports[`host should work using "local-ipv4" host and port as string: page error
 
 exports[`host should work using "local-ipv6" host and "auto" port: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -222,7 +222,7 @@ exports[`host should work using "local-ipv6" host and "auto" port: page errors 1
 
 exports[`host should work using "local-ipv6" host and port as number: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -232,7 +232,7 @@ exports[`host should work using "local-ipv6" host and port as number: page error
 
 exports[`host should work using "local-ipv6" host and port as string: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -242,7 +242,7 @@ exports[`host should work using "local-ipv6" host and port as string: page error
 
 exports[`host should work using "localhost" host and "auto" port: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -252,7 +252,7 @@ exports[`host should work using "localhost" host and "auto" port: page errors 1`
 
 exports[`host should work using "localhost" host and port as number: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -262,7 +262,7 @@ exports[`host should work using "localhost" host and port as number: page errors
 
 exports[`host should work using "localhost" host and port as string: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -272,7 +272,7 @@ exports[`host should work using "localhost" host and port as string: page errors
 
 exports[`host should work using "undefined" host and "auto" port: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -282,7 +282,7 @@ exports[`host should work using "undefined" host and "auto" port: page errors 1`
 
 exports[`host should work using "undefined" host and port as number: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -292,7 +292,7 @@ exports[`host should work using "undefined" host and port as number: page errors
 
 exports[`host should work using "undefined" host and port as string: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]

--- a/test/e2e/__snapshots__/host.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/host.test.js.snap.webpack5
@@ -2,11 +2,9 @@
 
 exports[`host should work using "::" host and "auto" port: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -14,11 +12,9 @@ exports[`host should work using "::" host and "auto" port: page errors 1`] = `Ar
 
 exports[`host should work using "::" host and port as number: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -26,11 +22,9 @@ exports[`host should work using "::" host and port as number: page errors 1`] = 
 
 exports[`host should work using "::" host and port as string: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -38,11 +32,9 @@ exports[`host should work using "::" host and port as string: page errors 1`] = 
 
 exports[`host should work using "::1" host and "auto" port: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -50,11 +42,9 @@ exports[`host should work using "::1" host and "auto" port: page errors 1`] = `A
 
 exports[`host should work using "::1" host and port as number: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -62,11 +52,9 @@ exports[`host should work using "::1" host and port as number: page errors 1`] =
 
 exports[`host should work using "::1" host and port as string: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -74,11 +62,9 @@ exports[`host should work using "::1" host and port as string: page errors 1`] =
 
 exports[`host should work using "<not-specified>" host and "auto" port: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -86,11 +72,9 @@ exports[`host should work using "<not-specified>" host and "auto" port: page err
 
 exports[`host should work using "<not-specified>" host and port as number: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -98,11 +82,9 @@ exports[`host should work using "<not-specified>" host and port as number: page 
 
 exports[`host should work using "<not-specified>" host and port as string: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -110,11 +92,9 @@ exports[`host should work using "<not-specified>" host and port as string: page 
 
 exports[`host should work using "0.0.0.0" host and "auto" port: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -122,11 +102,9 @@ exports[`host should work using "0.0.0.0" host and "auto" port: page errors 1`] 
 
 exports[`host should work using "0.0.0.0" host and port as number: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -134,11 +112,9 @@ exports[`host should work using "0.0.0.0" host and port as number: page errors 1
 
 exports[`host should work using "0.0.0.0" host and port as string: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -146,11 +122,9 @@ exports[`host should work using "0.0.0.0" host and port as string: page errors 1
 
 exports[`host should work using "127.0.0.1" host and "auto" port: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -158,11 +132,9 @@ exports[`host should work using "127.0.0.1" host and "auto" port: page errors 1`
 
 exports[`host should work using "127.0.0.1" host and port as number: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -170,11 +142,9 @@ exports[`host should work using "127.0.0.1" host and port as number: page errors
 
 exports[`host should work using "127.0.0.1" host and port as string: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -182,11 +152,9 @@ exports[`host should work using "127.0.0.1" host and port as string: page errors
 
 exports[`host should work using "local-ip" host and "auto" port: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -194,11 +162,9 @@ exports[`host should work using "local-ip" host and "auto" port: page errors 1`]
 
 exports[`host should work using "local-ip" host and port as number: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -206,11 +172,9 @@ exports[`host should work using "local-ip" host and port as number: page errors 
 
 exports[`host should work using "local-ip" host and port as string: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -218,11 +182,9 @@ exports[`host should work using "local-ip" host and port as string: page errors 
 
 exports[`host should work using "local-ipv4" host and "auto" port: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -230,11 +192,9 @@ exports[`host should work using "local-ipv4" host and "auto" port: page errors 1
 
 exports[`host should work using "local-ipv4" host and port as number: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -242,11 +202,9 @@ exports[`host should work using "local-ipv4" host and port as number: page error
 
 exports[`host should work using "local-ipv4" host and port as string: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -254,11 +212,9 @@ exports[`host should work using "local-ipv4" host and port as string: page error
 
 exports[`host should work using "local-ipv6" host and "auto" port: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -266,11 +222,9 @@ exports[`host should work using "local-ipv6" host and "auto" port: page errors 1
 
 exports[`host should work using "local-ipv6" host and port as number: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -278,11 +232,9 @@ exports[`host should work using "local-ipv6" host and port as number: page error
 
 exports[`host should work using "local-ipv6" host and port as string: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -290,11 +242,9 @@ exports[`host should work using "local-ipv6" host and port as string: page error
 
 exports[`host should work using "localhost" host and "auto" port: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -302,11 +252,9 @@ exports[`host should work using "localhost" host and "auto" port: page errors 1`
 
 exports[`host should work using "localhost" host and port as number: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -314,11 +262,9 @@ exports[`host should work using "localhost" host and port as number: page errors
 
 exports[`host should work using "localhost" host and port as string: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -326,11 +272,9 @@ exports[`host should work using "localhost" host and port as string: page errors
 
 exports[`host should work using "undefined" host and "auto" port: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -338,11 +282,9 @@ exports[`host should work using "undefined" host and "auto" port: page errors 1`
 
 exports[`host should work using "undefined" host and port as number: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -350,11 +292,9 @@ exports[`host should work using "undefined" host and port as number: page errors
 
 exports[`host should work using "undefined" host and port as string: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 

--- a/test/e2e/__snapshots__/host.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/host.test.js.snap.webpack5
@@ -2,6 +2,7 @@
 
 exports[`host should work using "::" host and "auto" port: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -13,6 +14,7 @@ exports[`host should work using "::" host and "auto" port: page errors 1`] = `Ar
 
 exports[`host should work using "::" host and port as number: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -24,6 +26,7 @@ exports[`host should work using "::" host and port as number: page errors 1`] = 
 
 exports[`host should work using "::" host and port as string: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -35,6 +38,7 @@ exports[`host should work using "::" host and port as string: page errors 1`] = 
 
 exports[`host should work using "::1" host and "auto" port: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -46,6 +50,7 @@ exports[`host should work using "::1" host and "auto" port: page errors 1`] = `A
 
 exports[`host should work using "::1" host and port as number: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -57,6 +62,7 @@ exports[`host should work using "::1" host and port as number: page errors 1`] =
 
 exports[`host should work using "::1" host and port as string: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -68,6 +74,7 @@ exports[`host should work using "::1" host and port as string: page errors 1`] =
 
 exports[`host should work using "<not-specified>" host and "auto" port: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -79,6 +86,7 @@ exports[`host should work using "<not-specified>" host and "auto" port: page err
 
 exports[`host should work using "<not-specified>" host and port as number: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -90,6 +98,7 @@ exports[`host should work using "<not-specified>" host and port as number: page 
 
 exports[`host should work using "<not-specified>" host and port as string: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -101,6 +110,7 @@ exports[`host should work using "<not-specified>" host and port as string: page 
 
 exports[`host should work using "0.0.0.0" host and "auto" port: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -112,6 +122,7 @@ exports[`host should work using "0.0.0.0" host and "auto" port: page errors 1`] 
 
 exports[`host should work using "0.0.0.0" host and port as number: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -123,6 +134,7 @@ exports[`host should work using "0.0.0.0" host and port as number: page errors 1
 
 exports[`host should work using "0.0.0.0" host and port as string: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -134,6 +146,7 @@ exports[`host should work using "0.0.0.0" host and port as string: page errors 1
 
 exports[`host should work using "127.0.0.1" host and "auto" port: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -145,6 +158,7 @@ exports[`host should work using "127.0.0.1" host and "auto" port: page errors 1`
 
 exports[`host should work using "127.0.0.1" host and port as number: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -156,6 +170,7 @@ exports[`host should work using "127.0.0.1" host and port as number: page errors
 
 exports[`host should work using "127.0.0.1" host and port as string: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -167,6 +182,7 @@ exports[`host should work using "127.0.0.1" host and port as string: page errors
 
 exports[`host should work using "local-ip" host and "auto" port: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -178,6 +194,7 @@ exports[`host should work using "local-ip" host and "auto" port: page errors 1`]
 
 exports[`host should work using "local-ip" host and port as number: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -189,6 +206,7 @@ exports[`host should work using "local-ip" host and port as number: page errors 
 
 exports[`host should work using "local-ip" host and port as string: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -200,6 +218,7 @@ exports[`host should work using "local-ip" host and port as string: page errors 
 
 exports[`host should work using "local-ipv4" host and "auto" port: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -211,6 +230,7 @@ exports[`host should work using "local-ipv4" host and "auto" port: page errors 1
 
 exports[`host should work using "local-ipv4" host and port as number: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -222,6 +242,7 @@ exports[`host should work using "local-ipv4" host and port as number: page error
 
 exports[`host should work using "local-ipv4" host and port as string: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -233,6 +254,7 @@ exports[`host should work using "local-ipv4" host and port as string: page error
 
 exports[`host should work using "local-ipv6" host and "auto" port: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -244,6 +266,7 @@ exports[`host should work using "local-ipv6" host and "auto" port: page errors 1
 
 exports[`host should work using "local-ipv6" host and port as number: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -255,6 +278,7 @@ exports[`host should work using "local-ipv6" host and port as number: page error
 
 exports[`host should work using "local-ipv6" host and port as string: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -266,6 +290,7 @@ exports[`host should work using "local-ipv6" host and port as string: page error
 
 exports[`host should work using "localhost" host and "auto" port: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -277,6 +302,7 @@ exports[`host should work using "localhost" host and "auto" port: page errors 1`
 
 exports[`host should work using "localhost" host and port as number: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -288,6 +314,7 @@ exports[`host should work using "localhost" host and port as number: page errors
 
 exports[`host should work using "localhost" host and port as string: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -299,6 +326,7 @@ exports[`host should work using "localhost" host and port as string: page errors
 
 exports[`host should work using "undefined" host and "auto" port: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -310,6 +338,7 @@ exports[`host should work using "undefined" host and "auto" port: page errors 1`
 
 exports[`host should work using "undefined" host and port as number: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -321,6 +350,7 @@ exports[`host should work using "undefined" host and port as number: page errors
 
 exports[`host should work using "undefined" host and port as string: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",

--- a/test/e2e/__snapshots__/hot-and-live-reload.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/hot-and-live-reload.test.js.snap.webpack4
@@ -2,7 +2,7 @@
 
 exports[`hot and live reload should not refresh content when hot and no live reload disabled (default): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Overlay enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
 ]
 `;
@@ -11,7 +11,7 @@ exports[`hot and live reload should not refresh content when hot and no live rel
 
 exports[`hot and live reload should not refresh content when hot and no live reload disabled (sockjs): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Overlay enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
 ]
 `;
@@ -20,7 +20,7 @@ exports[`hot and live reload should not refresh content when hot and no live rel
 
 exports[`hot and live reload should not refresh content when hot and no live reload disabled (ws): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Overlay enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
 ]
 `;
@@ -29,10 +29,8 @@ exports[`hot and live reload should not refresh content when hot and no live rel
 
 exports[`hot and live reload should work and allow to disable hot module replacement and live reload using the "webpack-dev-server-hot=false&webpack-dev-server-live-reload=false" (default): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
 ]
 `;
@@ -41,16 +39,12 @@ exports[`hot and live reload should work and allow to disable hot module replace
 
 exports[`hot and live reload should work and allow to disable hot module replacement using the "webpack-dev-server-hot=false" (default): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -58,8 +52,7 @@ exports[`hot and live reload should work and allow to disable hot module replace
 
 exports[`hot and live reload should work and allow to disable live reload using the "webpack-dev-server-live-reload=false" (default): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
-  "[webpack-dev-server] Live Reloading enabled.",
+  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
 ]
 `;
@@ -72,10 +65,8 @@ exports[`hot and live reload should work and do nothing when web socket server d
 
 exports[`hot and live reload should work and refresh content using hot module replacement (default): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
   "[HMR] Checking for updates on the server...",
@@ -91,10 +82,8 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when hot enabled (default): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
   "[HMR] Checking for updates on the server...",
@@ -110,10 +99,8 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when hot enabled (sockjs): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
   "[HMR] Checking for updates on the server...",
@@ -129,10 +116,8 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when hot enabled (ws): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
   "[HMR] Checking for updates on the server...",
@@ -148,10 +133,8 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when live reload and hot enabled (sockjs): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
   "[HMR] Checking for updates on the server...",
@@ -167,10 +150,8 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when live reload and hot enabled (ws): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
   "[HMR] Checking for updates on the server...",
@@ -186,9 +167,8 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when live reload disabled and hot enabled (default): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
   "[HMR] Checking for updates on the server...",
@@ -204,9 +184,8 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when live reload disabled and hot enabled (sockjs): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
   "[HMR] Checking for updates on the server...",
@@ -222,9 +201,8 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when live reload disabled and hot enabled (ws): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
   "[HMR] Checking for updates on the server...",
@@ -240,10 +218,8 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when live reload enabled (default): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
   "[HMR] Checking for updates on the server...",
@@ -259,10 +235,8 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when live reload enabled (sockjs): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
   "[HMR] Checking for updates on the server...",
@@ -278,10 +252,8 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when live reload enabled (ws): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
   "[HMR] Checking for updates on the server...",
@@ -297,10 +269,8 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when live reload enabled and hot disabled (default): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
   "[HMR] Checking for updates on the server...",
@@ -316,12 +286,10 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using live reload (default): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
-  "[webpack-dev-server] Live Reloading enabled.",
+  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
-  "[webpack-dev-server] Live Reloading enabled.",
+  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
 ]
 `;
 
@@ -329,12 +297,10 @@ exports[`hot and live reload should work and refresh content using live reload (
 
 exports[`hot and live reload should work and refresh content using live reload when live reload disabled and hot enabled (sockjs): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
-  "[webpack-dev-server] Live Reloading enabled.",
+  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
-  "[webpack-dev-server] Live Reloading enabled.",
+  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
 ]
 `;
 
@@ -342,12 +308,10 @@ exports[`hot and live reload should work and refresh content using live reload w
 
 exports[`hot and live reload should work and refresh content using live reload when live reload enabled and hot disabled (ws): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
-  "[webpack-dev-server] Live Reloading enabled.",
+  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
-  "[webpack-dev-server] Live Reloading enabled.",
+  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
 ]
 `;
 
@@ -356,8 +320,6 @@ exports[`hot and live reload should work and refresh content using live reload w
 exports[`hot and live reload should work with manual client setup (default): console messages 1`] = `
 Array [
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
   "[HMR] Checking for updates on the server...",
@@ -374,11 +336,9 @@ exports[`hot and live reload should work with manual client setup (default): pag
 exports[`hot and live reload should work with manual client setup and allow to disable hot module replacement (default): console messages 1`] = `
 Array [
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -395,7 +355,7 @@ exports[`hot and live reload should work with manual client setup and allow to d
 exports[`hot and live reload should work with manual client setup and allow to enable hot module replacement (default): console messages 1`] = `
 Array [
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
+  "[webpack-dev-server] server started with Hot Module Replacement enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
   "[HMR] Checking for updates on the server...",
@@ -411,10 +371,10 @@ exports[`hot and live reload should work with manual client setup and allow to e
 
 exports[`hot and live reload should work with manual client setup and allow to enable live reload (default): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Live Reloading enabled.",
+  "[webpack-dev-server] server started with Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
-  "[webpack-dev-server] Live Reloading enabled.",
+  "[webpack-dev-server] server started with Live Reloading enabled.",
 ]
 `;
 
@@ -422,9 +382,8 @@ exports[`hot and live reload should work with manual client setup and allow to e
 
 exports[`hot disabled HMR plugin should NOT register the HMR plugin before compilation is complete: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
   "Hey.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -434,11 +393,9 @@ exports[`hot disabled HMR plugin should NOT register the HMR plugin before compi
 
 exports[`multi compiler hot config HMR plugin should register the HMR plugin before compilation is complete: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -448,11 +405,9 @@ exports[`multi compiler hot config HMR plugin should register the HMR plugin bef
 
 exports[`simple hot config HMR plugin should register the HMR plugin before compilation is complete: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -462,11 +417,9 @@ exports[`simple hot config HMR plugin should register the HMR plugin before comp
 
 exports[`simple hot config HMR plugin with already added HMR plugin should register the HMR plugin before compilation is complete: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 

--- a/test/e2e/__snapshots__/hot-and-live-reload.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/hot-and-live-reload.test.js.snap.webpack4
@@ -2,6 +2,7 @@
 
 exports[`hot and live reload should not refresh content when hot and no live reload disabled (default): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[webpack-dev-server] App updated. Recompiling...",
 ]
 `;
@@ -10,6 +11,7 @@ exports[`hot and live reload should not refresh content when hot and no live rel
 
 exports[`hot and live reload should not refresh content when hot and no live reload disabled (sockjs): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[webpack-dev-server] App updated. Recompiling...",
 ]
 `;
@@ -18,6 +20,7 @@ exports[`hot and live reload should not refresh content when hot and no live rel
 
 exports[`hot and live reload should not refresh content when hot and no live reload disabled (ws): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[webpack-dev-server] App updated. Recompiling...",
 ]
 `;
@@ -26,6 +29,7 @@ exports[`hot and live reload should not refresh content when hot and no live rel
 
 exports[`hot and live reload should work and allow to disable hot module replacement and live reload using the "webpack-dev-server-hot=false&webpack-dev-server-live-reload=false" (default): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] Live Reloading enabled.",
@@ -37,11 +41,13 @@ exports[`hot and live reload should work and allow to disable hot module replace
 
 exports[`hot and live reload should work and allow to disable hot module replacement using the "webpack-dev-server-hot=false" (default): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] Live Reloading enabled.",
@@ -52,6 +58,7 @@ exports[`hot and live reload should work and allow to disable hot module replace
 
 exports[`hot and live reload should work and allow to disable live reload using the "webpack-dev-server-live-reload=false" (default): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
 ]
@@ -65,6 +72,7 @@ exports[`hot and live reload should work and do nothing when web socket server d
 
 exports[`hot and live reload should work and refresh content using hot module replacement (default): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] Live Reloading enabled.",
@@ -83,6 +91,7 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when hot enabled (default): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] Live Reloading enabled.",
@@ -101,6 +110,7 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when hot enabled (sockjs): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] Live Reloading enabled.",
@@ -119,6 +129,7 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when hot enabled (ws): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] Live Reloading enabled.",
@@ -137,6 +148,7 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when live reload and hot enabled (sockjs): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] Live Reloading enabled.",
@@ -155,6 +167,7 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when live reload and hot enabled (ws): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] Live Reloading enabled.",
@@ -173,6 +186,7 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when live reload disabled and hot enabled (default): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
@@ -190,6 +204,7 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when live reload disabled and hot enabled (sockjs): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
@@ -207,6 +222,7 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when live reload disabled and hot enabled (ws): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
@@ -224,6 +240,7 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when live reload enabled (default): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] Live Reloading enabled.",
@@ -242,6 +259,7 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when live reload enabled (sockjs): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] Live Reloading enabled.",
@@ -260,6 +278,7 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when live reload enabled (ws): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] Live Reloading enabled.",
@@ -278,6 +297,7 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when live reload enabled and hot disabled (default): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] Live Reloading enabled.",
@@ -296,9 +316,11 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using live reload (default): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
@@ -307,9 +329,11 @@ exports[`hot and live reload should work and refresh content using live reload (
 
 exports[`hot and live reload should work and refresh content using live reload when live reload disabled and hot enabled (sockjs): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
@@ -318,9 +342,11 @@ exports[`hot and live reload should work and refresh content using live reload w
 
 exports[`hot and live reload should work and refresh content using live reload when live reload enabled and hot disabled (ws): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
@@ -396,6 +422,7 @@ exports[`hot and live reload should work with manual client setup and allow to e
 
 exports[`hot disabled HMR plugin should NOT register the HMR plugin before compilation is complete: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hey.",
   "[webpack-dev-server] Live Reloading enabled.",
 ]
@@ -407,6 +434,7 @@ exports[`hot disabled HMR plugin should NOT register the HMR plugin before compi
 
 exports[`multi compiler hot config HMR plugin should register the HMR plugin before compilation is complete: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -420,6 +448,7 @@ exports[`multi compiler hot config HMR plugin should register the HMR plugin bef
 
 exports[`simple hot config HMR plugin should register the HMR plugin before compilation is complete: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -433,6 +462,7 @@ exports[`simple hot config HMR plugin should register the HMR plugin before comp
 
 exports[`simple hot config HMR plugin with already added HMR plugin should register the HMR plugin before compilation is complete: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",

--- a/test/e2e/__snapshots__/hot-and-live-reload.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/hot-and-live-reload.test.js.snap.webpack4
@@ -2,7 +2,7 @@
 
 exports[`hot and live reload should not refresh content when hot and no live reload disabled (default): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading disabled, Progress disabled, Overlay enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
 ]
 `;
@@ -11,7 +11,7 @@ exports[`hot and live reload should not refresh content when hot and no live rel
 
 exports[`hot and live reload should not refresh content when hot and no live reload disabled (sockjs): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading disabled, Progress disabled, Overlay enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
 ]
 `;
@@ -20,7 +20,7 @@ exports[`hot and live reload should not refresh content when hot and no live rel
 
 exports[`hot and live reload should not refresh content when hot and no live reload disabled (ws): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading disabled, Progress disabled, Overlay enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
 ]
 `;
@@ -29,7 +29,7 @@ exports[`hot and live reload should not refresh content when hot and no live rel
 
 exports[`hot and live reload should work and allow to disable hot module replacement and live reload using the "webpack-dev-server-hot=false&webpack-dev-server-live-reload=false" (default): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] App updated. Recompiling...",
 ]
@@ -39,11 +39,11 @@ exports[`hot and live reload should work and allow to disable hot module replace
 
 exports[`hot and live reload should work and allow to disable hot module replacement using the "webpack-dev-server-hot=false" (default): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
 ]
 `;
@@ -52,7 +52,7 @@ exports[`hot and live reload should work and allow to disable hot module replace
 
 exports[`hot and live reload should work and allow to disable live reload using the "webpack-dev-server-live-reload=false" (default): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
 ]
 `;
@@ -65,7 +65,7 @@ exports[`hot and live reload should work and do nothing when web socket server d
 
 exports[`hot and live reload should work and refresh content using hot module replacement (default): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
@@ -82,7 +82,7 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when hot enabled (default): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
@@ -99,7 +99,7 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when hot enabled (sockjs): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
@@ -116,7 +116,7 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when hot enabled (ws): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
@@ -133,7 +133,7 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when live reload and hot enabled (sockjs): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
@@ -150,7 +150,7 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when live reload and hot enabled (ws): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
@@ -167,7 +167,7 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when live reload disabled and hot enabled (default): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading disabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
@@ -184,7 +184,7 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when live reload disabled and hot enabled (sockjs): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading disabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
@@ -201,7 +201,7 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when live reload disabled and hot enabled (ws): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading disabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
@@ -218,7 +218,7 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when live reload enabled (default): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
@@ -235,7 +235,7 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when live reload enabled (sockjs): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
@@ -252,7 +252,7 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when live reload enabled (ws): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
@@ -269,7 +269,7 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when live reload enabled and hot disabled (default): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
@@ -286,10 +286,10 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using live reload (default): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
-  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
 ]
 `;
 
@@ -297,10 +297,10 @@ exports[`hot and live reload should work and refresh content using live reload (
 
 exports[`hot and live reload should work and refresh content using live reload when live reload disabled and hot enabled (sockjs): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
-  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
 ]
 `;
 
@@ -308,10 +308,10 @@ exports[`hot and live reload should work and refresh content using live reload w
 
 exports[`hot and live reload should work and refresh content using live reload when live reload enabled and hot disabled (ws): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
-  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
 ]
 `;
 
@@ -320,6 +320,7 @@ exports[`hot and live reload should work and refresh content using live reload w
 exports[`hot and live reload should work with manual client setup (default): console messages 1`] = `
 Array [
   "[HMR] Waiting for update signal from WDS...",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading disabled, Progress disabled, Overlay disabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
   "[HMR] Checking for updates on the server...",
@@ -336,9 +337,11 @@ exports[`hot and live reload should work with manual client setup (default): pag
 exports[`hot and live reload should work with manual client setup and allow to disable hot module replacement (default): console messages 1`] = `
 Array [
   "[HMR] Waiting for update signal from WDS...",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading disabled, Progress disabled, Overlay disabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
   "[HMR] Waiting for update signal from WDS...",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading disabled, Progress disabled, Overlay disabled.",
 ]
 `;
 
@@ -346,6 +349,7 @@ exports[`hot and live reload should work with manual client setup and allow to d
 
 exports[`hot and live reload should work with manual client setup and allow to disable live reload (default): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading disabled, Progress disabled, Overlay disabled.",
   "[webpack-dev-server] App updated. Recompiling...",
 ]
 `;
@@ -355,7 +359,7 @@ exports[`hot and live reload should work with manual client setup and allow to d
 exports[`hot and live reload should work with manual client setup and allow to enable hot module replacement (default): console messages 1`] = `
 Array [
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] server started with Hot Module Replacement enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading disabled, Progress disabled, Overlay disabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
   "[HMR] Checking for updates on the server...",
@@ -371,10 +375,10 @@ exports[`hot and live reload should work with manual client setup and allow to e
 
 exports[`hot and live reload should work with manual client setup and allow to enable live reload (default): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Live Reloading enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading enabled, Progress disabled, Overlay disabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
-  "[webpack-dev-server] server started with Live Reloading enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading enabled, Progress disabled, Overlay disabled.",
 ]
 `;
 
@@ -382,7 +386,7 @@ exports[`hot and live reload should work with manual client setup and allow to e
 
 exports[`hot disabled HMR plugin should NOT register the HMR plugin before compilation is complete: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -393,7 +397,7 @@ exports[`hot disabled HMR plugin should NOT register the HMR plugin before compi
 
 exports[`multi compiler hot config HMR plugin should register the HMR plugin before compilation is complete: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -405,7 +409,7 @@ exports[`multi compiler hot config HMR plugin should register the HMR plugin bef
 
 exports[`simple hot config HMR plugin should register the HMR plugin before compilation is complete: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -417,7 +421,7 @@ exports[`simple hot config HMR plugin should register the HMR plugin before comp
 
 exports[`simple hot config HMR plugin with already added HMR plugin should register the HMR plugin before compilation is complete: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]

--- a/test/e2e/__snapshots__/hot-and-live-reload.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/hot-and-live-reload.test.js.snap.webpack5
@@ -2,7 +2,7 @@
 
 exports[`hot and live reload should not refresh content when hot and no live reload disabled (default): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Overlay enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
 ]
 `;
@@ -11,7 +11,7 @@ exports[`hot and live reload should not refresh content when hot and no live rel
 
 exports[`hot and live reload should not refresh content when hot and no live reload disabled (sockjs): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Overlay enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
 ]
 `;
@@ -20,7 +20,7 @@ exports[`hot and live reload should not refresh content when hot and no live rel
 
 exports[`hot and live reload should not refresh content when hot and no live reload disabled (ws): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Overlay enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
 ]
 `;
@@ -29,10 +29,8 @@ exports[`hot and live reload should not refresh content when hot and no live rel
 
 exports[`hot and live reload should work and allow to disable hot module replacement and live reload using the "webpack-dev-server-hot=false&webpack-dev-server-live-reload=false" (default): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
 ]
 `;
@@ -41,16 +39,12 @@ exports[`hot and live reload should work and allow to disable hot module replace
 
 exports[`hot and live reload should work and allow to disable hot module replacement using the "webpack-dev-server-hot=false" (default): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -58,8 +52,7 @@ exports[`hot and live reload should work and allow to disable hot module replace
 
 exports[`hot and live reload should work and allow to disable live reload using the "webpack-dev-server-live-reload=false" (default): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
-  "[webpack-dev-server] Live Reloading enabled.",
+  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
 ]
 `;
@@ -72,10 +65,8 @@ exports[`hot and live reload should work and do nothing when web socket server d
 
 exports[`hot and live reload should work and refresh content using hot module replacement (default): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
   "[HMR] Checking for updates on the server...",
@@ -91,10 +82,8 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when hot enabled (default): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
   "[HMR] Checking for updates on the server...",
@@ -110,10 +99,8 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when hot enabled (sockjs): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
   "[HMR] Checking for updates on the server...",
@@ -129,10 +116,8 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when hot enabled (ws): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
   "[HMR] Checking for updates on the server...",
@@ -148,10 +133,8 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when live reload and hot enabled (sockjs): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
   "[HMR] Checking for updates on the server...",
@@ -167,10 +150,8 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when live reload and hot enabled (ws): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
   "[HMR] Checking for updates on the server...",
@@ -186,9 +167,8 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when live reload disabled and hot enabled (default): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
   "[HMR] Checking for updates on the server...",
@@ -204,9 +184,8 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when live reload disabled and hot enabled (sockjs): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
   "[HMR] Checking for updates on the server...",
@@ -222,9 +201,8 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when live reload disabled and hot enabled (ws): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
   "[HMR] Checking for updates on the server...",
@@ -240,10 +218,8 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when live reload enabled (default): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
   "[HMR] Checking for updates on the server...",
@@ -259,10 +235,8 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when live reload enabled (sockjs): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
   "[HMR] Checking for updates on the server...",
@@ -278,10 +252,8 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when live reload enabled (ws): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
   "[HMR] Checking for updates on the server...",
@@ -297,10 +269,8 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when live reload enabled and hot disabled (default): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
   "[HMR] Checking for updates on the server...",
@@ -316,12 +286,10 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using live reload (default): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
-  "[webpack-dev-server] Live Reloading enabled.",
+  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
-  "[webpack-dev-server] Live Reloading enabled.",
+  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
 ]
 `;
 
@@ -329,12 +297,10 @@ exports[`hot and live reload should work and refresh content using live reload (
 
 exports[`hot and live reload should work and refresh content using live reload when live reload disabled and hot enabled (sockjs): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
-  "[webpack-dev-server] Live Reloading enabled.",
+  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
-  "[webpack-dev-server] Live Reloading enabled.",
+  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
 ]
 `;
 
@@ -342,12 +308,10 @@ exports[`hot and live reload should work and refresh content using live reload w
 
 exports[`hot and live reload should work and refresh content using live reload when live reload enabled and hot disabled (ws): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
-  "[webpack-dev-server] Live Reloading enabled.",
+  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
-  "[webpack-dev-server] Live Reloading enabled.",
+  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
 ]
 `;
 
@@ -356,8 +320,6 @@ exports[`hot and live reload should work and refresh content using live reload w
 exports[`hot and live reload should work with manual client setup (default): console messages 1`] = `
 Array [
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
   "[HMR] Checking for updates on the server...",
@@ -374,11 +336,9 @@ exports[`hot and live reload should work with manual client setup (default): pag
 exports[`hot and live reload should work with manual client setup and allow to disable hot module replacement (default): console messages 1`] = `
 Array [
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -395,7 +355,7 @@ exports[`hot and live reload should work with manual client setup and allow to d
 exports[`hot and live reload should work with manual client setup and allow to enable hot module replacement (default): console messages 1`] = `
 Array [
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
+  "[webpack-dev-server] server started with Hot Module Replacement enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
   "[HMR] Checking for updates on the server...",
@@ -411,10 +371,10 @@ exports[`hot and live reload should work with manual client setup and allow to e
 
 exports[`hot and live reload should work with manual client setup and allow to enable live reload (default): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Live Reloading enabled.",
+  "[webpack-dev-server] server started with Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
-  "[webpack-dev-server] Live Reloading enabled.",
+  "[webpack-dev-server] server started with Live Reloading enabled.",
 ]
 `;
 
@@ -422,9 +382,8 @@ exports[`hot and live reload should work with manual client setup and allow to e
 
 exports[`hot disabled HMR plugin should NOT register the HMR plugin before compilation is complete: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
   "Hey.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -434,11 +393,9 @@ exports[`hot disabled HMR plugin should NOT register the HMR plugin before compi
 
 exports[`multi compiler hot config HMR plugin should register the HMR plugin before compilation is complete: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -448,11 +405,9 @@ exports[`multi compiler hot config HMR plugin should register the HMR plugin bef
 
 exports[`simple hot config HMR plugin should register the HMR plugin before compilation is complete: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -462,11 +417,9 @@ exports[`simple hot config HMR plugin should register the HMR plugin before comp
 
 exports[`simple hot config HMR plugin with already added HMR plugin should register the HMR plugin before compilation is complete: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 

--- a/test/e2e/__snapshots__/hot-and-live-reload.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/hot-and-live-reload.test.js.snap.webpack5
@@ -2,6 +2,7 @@
 
 exports[`hot and live reload should not refresh content when hot and no live reload disabled (default): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[webpack-dev-server] App updated. Recompiling...",
 ]
 `;
@@ -10,6 +11,7 @@ exports[`hot and live reload should not refresh content when hot and no live rel
 
 exports[`hot and live reload should not refresh content when hot and no live reload disabled (sockjs): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[webpack-dev-server] App updated. Recompiling...",
 ]
 `;
@@ -18,6 +20,7 @@ exports[`hot and live reload should not refresh content when hot and no live rel
 
 exports[`hot and live reload should not refresh content when hot and no live reload disabled (ws): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[webpack-dev-server] App updated. Recompiling...",
 ]
 `;
@@ -26,6 +29,7 @@ exports[`hot and live reload should not refresh content when hot and no live rel
 
 exports[`hot and live reload should work and allow to disable hot module replacement and live reload using the "webpack-dev-server-hot=false&webpack-dev-server-live-reload=false" (default): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] Live Reloading enabled.",
@@ -37,11 +41,13 @@ exports[`hot and live reload should work and allow to disable hot module replace
 
 exports[`hot and live reload should work and allow to disable hot module replacement using the "webpack-dev-server-hot=false" (default): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] Live Reloading enabled.",
@@ -52,6 +58,7 @@ exports[`hot and live reload should work and allow to disable hot module replace
 
 exports[`hot and live reload should work and allow to disable live reload using the "webpack-dev-server-live-reload=false" (default): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
 ]
@@ -65,6 +72,7 @@ exports[`hot and live reload should work and do nothing when web socket server d
 
 exports[`hot and live reload should work and refresh content using hot module replacement (default): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] Live Reloading enabled.",
@@ -83,6 +91,7 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when hot enabled (default): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] Live Reloading enabled.",
@@ -101,6 +110,7 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when hot enabled (sockjs): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] Live Reloading enabled.",
@@ -119,6 +129,7 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when hot enabled (ws): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] Live Reloading enabled.",
@@ -137,6 +148,7 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when live reload and hot enabled (sockjs): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] Live Reloading enabled.",
@@ -155,6 +167,7 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when live reload and hot enabled (ws): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] Live Reloading enabled.",
@@ -173,6 +186,7 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when live reload disabled and hot enabled (default): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
@@ -190,6 +204,7 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when live reload disabled and hot enabled (sockjs): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
@@ -207,6 +222,7 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when live reload disabled and hot enabled (ws): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
@@ -224,6 +240,7 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when live reload enabled (default): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] Live Reloading enabled.",
@@ -242,6 +259,7 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when live reload enabled (sockjs): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] Live Reloading enabled.",
@@ -260,6 +278,7 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when live reload enabled (ws): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] Live Reloading enabled.",
@@ -278,6 +297,7 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when live reload enabled and hot disabled (default): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] Live Reloading enabled.",
@@ -296,9 +316,11 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using live reload (default): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
@@ -307,9 +329,11 @@ exports[`hot and live reload should work and refresh content using live reload (
 
 exports[`hot and live reload should work and refresh content using live reload when live reload disabled and hot enabled (sockjs): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
@@ -318,9 +342,11 @@ exports[`hot and live reload should work and refresh content using live reload w
 
 exports[`hot and live reload should work and refresh content using live reload when live reload enabled and hot disabled (ws): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
@@ -396,6 +422,7 @@ exports[`hot and live reload should work with manual client setup and allow to e
 
 exports[`hot disabled HMR plugin should NOT register the HMR plugin before compilation is complete: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hey.",
   "[webpack-dev-server] Live Reloading enabled.",
 ]
@@ -407,6 +434,7 @@ exports[`hot disabled HMR plugin should NOT register the HMR plugin before compi
 
 exports[`multi compiler hot config HMR plugin should register the HMR plugin before compilation is complete: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -420,6 +448,7 @@ exports[`multi compiler hot config HMR plugin should register the HMR plugin bef
 
 exports[`simple hot config HMR plugin should register the HMR plugin before compilation is complete: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -433,6 +462,7 @@ exports[`simple hot config HMR plugin should register the HMR plugin before comp
 
 exports[`simple hot config HMR plugin with already added HMR plugin should register the HMR plugin before compilation is complete: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",

--- a/test/e2e/__snapshots__/hot-and-live-reload.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/hot-and-live-reload.test.js.snap.webpack5
@@ -2,7 +2,7 @@
 
 exports[`hot and live reload should not refresh content when hot and no live reload disabled (default): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading disabled, Progress disabled, Overlay enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
 ]
 `;
@@ -11,7 +11,7 @@ exports[`hot and live reload should not refresh content when hot and no live rel
 
 exports[`hot and live reload should not refresh content when hot and no live reload disabled (sockjs): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading disabled, Progress disabled, Overlay enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
 ]
 `;
@@ -20,7 +20,7 @@ exports[`hot and live reload should not refresh content when hot and no live rel
 
 exports[`hot and live reload should not refresh content when hot and no live reload disabled (ws): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading disabled, Progress disabled, Overlay enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
 ]
 `;
@@ -29,7 +29,7 @@ exports[`hot and live reload should not refresh content when hot and no live rel
 
 exports[`hot and live reload should work and allow to disable hot module replacement and live reload using the "webpack-dev-server-hot=false&webpack-dev-server-live-reload=false" (default): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] App updated. Recompiling...",
 ]
@@ -39,11 +39,11 @@ exports[`hot and live reload should work and allow to disable hot module replace
 
 exports[`hot and live reload should work and allow to disable hot module replacement using the "webpack-dev-server-hot=false" (default): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
 ]
 `;
@@ -52,7 +52,7 @@ exports[`hot and live reload should work and allow to disable hot module replace
 
 exports[`hot and live reload should work and allow to disable live reload using the "webpack-dev-server-live-reload=false" (default): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
 ]
 `;
@@ -65,7 +65,7 @@ exports[`hot and live reload should work and do nothing when web socket server d
 
 exports[`hot and live reload should work and refresh content using hot module replacement (default): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
@@ -82,7 +82,7 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when hot enabled (default): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
@@ -99,7 +99,7 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when hot enabled (sockjs): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
@@ -116,7 +116,7 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when hot enabled (ws): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
@@ -133,7 +133,7 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when live reload and hot enabled (sockjs): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
@@ -150,7 +150,7 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when live reload and hot enabled (ws): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
@@ -167,7 +167,7 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when live reload disabled and hot enabled (default): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading disabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
@@ -184,7 +184,7 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when live reload disabled and hot enabled (sockjs): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading disabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
@@ -201,7 +201,7 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when live reload disabled and hot enabled (ws): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading disabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
@@ -218,7 +218,7 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when live reload enabled (default): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
@@ -235,7 +235,7 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when live reload enabled (sockjs): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
@@ -252,7 +252,7 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when live reload enabled (ws): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
@@ -269,7 +269,7 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using hot module replacement when live reload enabled and hot disabled (default): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
@@ -286,10 +286,10 @@ exports[`hot and live reload should work and refresh content using hot module re
 
 exports[`hot and live reload should work and refresh content using live reload (default): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
-  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
 ]
 `;
 
@@ -297,10 +297,10 @@ exports[`hot and live reload should work and refresh content using live reload (
 
 exports[`hot and live reload should work and refresh content using live reload when live reload disabled and hot enabled (sockjs): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
-  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
 ]
 `;
 
@@ -308,10 +308,10 @@ exports[`hot and live reload should work and refresh content using live reload w
 
 exports[`hot and live reload should work and refresh content using live reload when live reload enabled and hot disabled (ws): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
-  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
 ]
 `;
 
@@ -320,6 +320,7 @@ exports[`hot and live reload should work and refresh content using live reload w
 exports[`hot and live reload should work with manual client setup (default): console messages 1`] = `
 Array [
   "[HMR] Waiting for update signal from WDS...",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading disabled, Progress disabled, Overlay disabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
   "[HMR] Checking for updates on the server...",
@@ -336,9 +337,11 @@ exports[`hot and live reload should work with manual client setup (default): pag
 exports[`hot and live reload should work with manual client setup and allow to disable hot module replacement (default): console messages 1`] = `
 Array [
   "[HMR] Waiting for update signal from WDS...",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading disabled, Progress disabled, Overlay disabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
   "[HMR] Waiting for update signal from WDS...",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading disabled, Progress disabled, Overlay disabled.",
 ]
 `;
 
@@ -346,6 +349,7 @@ exports[`hot and live reload should work with manual client setup and allow to d
 
 exports[`hot and live reload should work with manual client setup and allow to disable live reload (default): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading disabled, Progress disabled, Overlay disabled.",
   "[webpack-dev-server] App updated. Recompiling...",
 ]
 `;
@@ -355,7 +359,7 @@ exports[`hot and live reload should work with manual client setup and allow to d
 exports[`hot and live reload should work with manual client setup and allow to enable hot module replacement (default): console messages 1`] = `
 Array [
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] server started with Hot Module Replacement enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading disabled, Progress disabled, Overlay disabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
   "[HMR] Checking for updates on the server...",
@@ -371,10 +375,10 @@ exports[`hot and live reload should work with manual client setup and allow to e
 
 exports[`hot and live reload should work with manual client setup and allow to enable live reload (default): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Live Reloading enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading enabled, Progress disabled, Overlay disabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
-  "[webpack-dev-server] server started with Live Reloading enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading enabled, Progress disabled, Overlay disabled.",
 ]
 `;
 
@@ -382,7 +386,7 @@ exports[`hot and live reload should work with manual client setup and allow to e
 
 exports[`hot disabled HMR plugin should NOT register the HMR plugin before compilation is complete: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -393,7 +397,7 @@ exports[`hot disabled HMR plugin should NOT register the HMR plugin before compi
 
 exports[`multi compiler hot config HMR plugin should register the HMR plugin before compilation is complete: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -405,7 +409,7 @@ exports[`multi compiler hot config HMR plugin should register the HMR plugin bef
 
 exports[`simple hot config HMR plugin should register the HMR plugin before compilation is complete: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -417,7 +421,7 @@ exports[`simple hot config HMR plugin should register the HMR plugin before comp
 
 exports[`simple hot config HMR plugin with already added HMR plugin should register the HMR plugin before compilation is complete: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]

--- a/test/e2e/__snapshots__/ipc.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/ipc.test.js.snap.webpack4
@@ -2,11 +2,9 @@
 
 exports[`web socket server URL should work with the "ipc" option using "string" value ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -14,11 +12,9 @@ exports[`web socket server URL should work with the "ipc" option using "string" 
 
 exports[`web socket server URL should work with the "ipc" option using "string" value ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -26,11 +22,9 @@ exports[`web socket server URL should work with the "ipc" option using "string" 
 
 exports[`web socket server URL should work with the "ipc" option using "true" value ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -38,11 +32,9 @@ exports[`web socket server URL should work with the "ipc" option using "true" va
 
 exports[`web socket server URL should work with the "ipc" option using "true" value ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 

--- a/test/e2e/__snapshots__/ipc.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/ipc.test.js.snap.webpack4
@@ -2,6 +2,7 @@
 
 exports[`web socket server URL should work with the "ipc" option using "string" value ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -13,6 +14,7 @@ exports[`web socket server URL should work with the "ipc" option using "string" 
 
 exports[`web socket server URL should work with the "ipc" option using "string" value ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -24,6 +26,7 @@ exports[`web socket server URL should work with the "ipc" option using "string" 
 
 exports[`web socket server URL should work with the "ipc" option using "true" value ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -35,6 +38,7 @@ exports[`web socket server URL should work with the "ipc" option using "true" va
 
 exports[`web socket server URL should work with the "ipc" option using "true" value ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",

--- a/test/e2e/__snapshots__/ipc.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/ipc.test.js.snap.webpack4
@@ -2,7 +2,7 @@
 
 exports[`web socket server URL should work with the "ipc" option using "string" value ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -12,7 +12,7 @@ exports[`web socket server URL should work with the "ipc" option using "string" 
 
 exports[`web socket server URL should work with the "ipc" option using "string" value ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -22,7 +22,7 @@ exports[`web socket server URL should work with the "ipc" option using "string" 
 
 exports[`web socket server URL should work with the "ipc" option using "true" value ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -32,7 +32,7 @@ exports[`web socket server URL should work with the "ipc" option using "true" va
 
 exports[`web socket server URL should work with the "ipc" option using "true" value ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]

--- a/test/e2e/__snapshots__/ipc.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/ipc.test.js.snap.webpack5
@@ -2,11 +2,9 @@
 
 exports[`web socket server URL should work with the "ipc" option using "string" value ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -14,11 +12,9 @@ exports[`web socket server URL should work with the "ipc" option using "string" 
 
 exports[`web socket server URL should work with the "ipc" option using "string" value ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -26,11 +22,9 @@ exports[`web socket server URL should work with the "ipc" option using "string" 
 
 exports[`web socket server URL should work with the "ipc" option using "true" value ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -38,11 +32,9 @@ exports[`web socket server URL should work with the "ipc" option using "true" va
 
 exports[`web socket server URL should work with the "ipc" option using "true" value ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 

--- a/test/e2e/__snapshots__/ipc.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/ipc.test.js.snap.webpack5
@@ -2,6 +2,7 @@
 
 exports[`web socket server URL should work with the "ipc" option using "string" value ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -13,6 +14,7 @@ exports[`web socket server URL should work with the "ipc" option using "string" 
 
 exports[`web socket server URL should work with the "ipc" option using "string" value ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -24,6 +26,7 @@ exports[`web socket server URL should work with the "ipc" option using "string" 
 
 exports[`web socket server URL should work with the "ipc" option using "true" value ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -35,6 +38,7 @@ exports[`web socket server URL should work with the "ipc" option using "true" va
 
 exports[`web socket server URL should work with the "ipc" option using "true" value ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",

--- a/test/e2e/__snapshots__/ipc.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/ipc.test.js.snap.webpack5
@@ -2,7 +2,7 @@
 
 exports[`web socket server URL should work with the "ipc" option using "string" value ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -12,7 +12,7 @@ exports[`web socket server URL should work with the "ipc" option using "string" 
 
 exports[`web socket server URL should work with the "ipc" option using "string" value ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -22,7 +22,7 @@ exports[`web socket server URL should work with the "ipc" option using "string" 
 
 exports[`web socket server URL should work with the "ipc" option using "true" value ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -32,7 +32,7 @@ exports[`web socket server URL should work with the "ipc" option using "true" va
 
 exports[`web socket server URL should work with the "ipc" option using "true" value ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]

--- a/test/e2e/__snapshots__/logging.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/logging.test.js.snap.webpack4
@@ -2,14 +2,14 @@
 
 exports[`logging should work and do not log messages about hot and live reloading is enabled (sockjs) 1`] = `
 Array [
-  "[webpack-dev-server] server started with Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading disabled, Progress disabled, Overlay enabled.",
   "Hey.",
 ]
 `;
 
 exports[`logging should work and do not log messages about hot and live reloading is enabled (ws) 1`] = `
 Array [
-  "[webpack-dev-server] server started with Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading disabled, Progress disabled, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -38,14 +38,14 @@ Error from compilation",
 
 exports[`logging should work and log message about live reloading is enabled (sockjs) 1`] = `
 Array [
-  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "Hey.",
 ]
 `;
 
 exports[`logging should work and log message about live reloading is enabled (ws) 1`] = `
 Array [
-  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -100,7 +100,7 @@ Array [
 
 exports[`logging should work and log messages about hot is enabled (sockjs) 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading disabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -108,7 +108,7 @@ Array [
 
 exports[`logging should work and log messages about hot is enabled (ws) 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading disabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]

--- a/test/e2e/__snapshots__/logging.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/logging.test.js.snap.webpack4
@@ -2,25 +2,23 @@
 
 exports[`logging should work and do not log messages about hot and live reloading is enabled (sockjs) 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Overlay enabled.",
   "Hey.",
 ]
 `;
 
 exports[`logging should work and do not log messages about hot and live reloading is enabled (ws) 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Overlay enabled.",
   "Hey.",
 ]
 `;
 
 exports[`logging should work and log errors by default (sockjs) 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] Errors while compiling. Reload prevented.",
   "[webpack-dev-server] ERROR
 Error from compilation",
@@ -29,11 +27,9 @@ Error from compilation",
 
 exports[`logging should work and log errors by default (ws) 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] Errors while compiling. Reload prevented.",
   "[webpack-dev-server] ERROR
 Error from compilation",
@@ -42,101 +38,85 @@ Error from compilation",
 
 exports[`logging should work and log message about live reloading is enabled (sockjs) 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
   "Hey.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`logging should work and log message about live reloading is enabled (ws) 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
   "Hey.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`logging should work and log messages about hot and live reloading is enabled (sockjs) 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`logging should work and log messages about hot and live reloading is enabled (sockjs) 2`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`logging should work and log messages about hot and live reloading is enabled (sockjs) 3`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`logging should work and log messages about hot and live reloading is enabled (ws) 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`logging should work and log messages about hot and live reloading is enabled (ws) 2`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`logging should work and log messages about hot and live reloading is enabled (ws) 3`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`logging should work and log messages about hot is enabled (sockjs) 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
 ]
 `;
 
 exports[`logging should work and log messages about hot is enabled (ws) 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
 ]
 `;
 
 exports[`logging should work and log only error (sockjs) 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "Hey.",
   "[webpack-dev-server] Errors while compiling. Reload prevented.",
   "[webpack-dev-server] ERROR
@@ -146,7 +126,7 @@ Error from compilation",
 
 exports[`logging should work and log only error (ws) 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "Hey.",
   "[webpack-dev-server] Errors while compiling. Reload prevented.",
   "[webpack-dev-server] ERROR
@@ -156,39 +136,31 @@ Error from compilation",
 
 exports[`logging should work and log static changes (sockjs) 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] \\"<cwd>/test/fixtures/client-config/static/foo.txt\\" from static directory was changed. Reloading...",
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`logging should work and log static changes (ws) 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] \\"<cwd>/test/fixtures/client-config/static/foo.txt\\" from static directory was changed. Reloading...",
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`logging should work and log warning and errors (sockjs) 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "Hey.",
   "[webpack-dev-server] Warnings while compiling.",
   "[webpack-dev-server] WARNING
@@ -201,7 +173,7 @@ Error from compilation",
 
 exports[`logging should work and log warning and errors (ws) 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "Hey.",
   "[webpack-dev-server] Warnings while compiling.",
   "[webpack-dev-server] WARNING
@@ -214,11 +186,9 @@ Error from compilation",
 
 exports[`logging should work and log warnings by default (sockjs) 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] Warnings while compiling.",
   "[webpack-dev-server] WARNING
 Warning from compilation",
@@ -227,11 +197,9 @@ Warning from compilation",
 
 exports[`logging should work and log warnings by default (ws) 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] Warnings while compiling.",
   "[webpack-dev-server] WARNING
 Warning from compilation",
@@ -240,74 +208,62 @@ Warning from compilation",
 
 exports[`logging should work when the "client.logging" is "info" (sockjs) 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`logging should work when the "client.logging" is "info" (ws) 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`logging should work when the "client.logging" is "log" (sockjs) 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`logging should work when the "client.logging" is "log" (ws) 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`logging should work when the "client.logging" is "none" (sockjs) 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "Hey.",
 ]
 `;
 
 exports[`logging should work when the "client.logging" is "none" (ws) 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "Hey.",
 ]
 `;
 
 exports[`logging should work when the "client.logging" is "verbose" (sockjs) 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`logging should work when the "client.logging" is "verbose" (ws) 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;

--- a/test/e2e/__snapshots__/logging.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/logging.test.js.snap.webpack4
@@ -2,18 +2,21 @@
 
 exports[`logging should work and do not log messages about hot and live reloading is enabled (sockjs) 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hey.",
 ]
 `;
 
 exports[`logging should work and do not log messages about hot and live reloading is enabled (ws) 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hey.",
 ]
 `;
 
 exports[`logging should work and log errors by default (sockjs) 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -26,6 +29,7 @@ Error from compilation",
 
 exports[`logging should work and log errors by default (ws) 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -38,6 +42,7 @@ Error from compilation",
 
 exports[`logging should work and log message about live reloading is enabled (sockjs) 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hey.",
   "[webpack-dev-server] Live Reloading enabled.",
 ]
@@ -45,6 +50,7 @@ Array [
 
 exports[`logging should work and log message about live reloading is enabled (ws) 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hey.",
   "[webpack-dev-server] Live Reloading enabled.",
 ]
@@ -52,6 +58,7 @@ Array [
 
 exports[`logging should work and log messages about hot and live reloading is enabled (sockjs) 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -61,6 +68,7 @@ Array [
 
 exports[`logging should work and log messages about hot and live reloading is enabled (sockjs) 2`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -70,6 +78,7 @@ Array [
 
 exports[`logging should work and log messages about hot and live reloading is enabled (sockjs) 3`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -79,6 +88,7 @@ Array [
 
 exports[`logging should work and log messages about hot and live reloading is enabled (ws) 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -88,6 +98,7 @@ Array [
 
 exports[`logging should work and log messages about hot and live reloading is enabled (ws) 2`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -97,6 +108,7 @@ Array [
 
 exports[`logging should work and log messages about hot and live reloading is enabled (ws) 3`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -106,6 +118,7 @@ Array [
 
 exports[`logging should work and log messages about hot is enabled (sockjs) 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -114,6 +127,7 @@ Array [
 
 exports[`logging should work and log messages about hot is enabled (ws) 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -122,6 +136,7 @@ Array [
 
 exports[`logging should work and log only error (sockjs) 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hey.",
   "[webpack-dev-server] Errors while compiling. Reload prevented.",
   "[webpack-dev-server] ERROR
@@ -131,6 +146,7 @@ Error from compilation",
 
 exports[`logging should work and log only error (ws) 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hey.",
   "[webpack-dev-server] Errors while compiling. Reload prevented.",
   "[webpack-dev-server] ERROR
@@ -140,11 +156,13 @@ Error from compilation",
 
 exports[`logging should work and log static changes (sockjs) 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] \\"<cwd>/test/fixtures/client-config/static/foo.txt\\" from static directory was changed. Reloading...",
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -154,11 +172,13 @@ Array [
 
 exports[`logging should work and log static changes (ws) 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] \\"<cwd>/test/fixtures/client-config/static/foo.txt\\" from static directory was changed. Reloading...",
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -168,6 +188,7 @@ Array [
 
 exports[`logging should work and log warning and errors (sockjs) 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hey.",
   "[webpack-dev-server] Warnings while compiling.",
   "[webpack-dev-server] WARNING
@@ -180,6 +201,7 @@ Error from compilation",
 
 exports[`logging should work and log warning and errors (ws) 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hey.",
   "[webpack-dev-server] Warnings while compiling.",
   "[webpack-dev-server] WARNING
@@ -192,6 +214,7 @@ Error from compilation",
 
 exports[`logging should work and log warnings by default (sockjs) 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -204,6 +227,7 @@ Warning from compilation",
 
 exports[`logging should work and log warnings by default (ws) 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -216,6 +240,7 @@ Warning from compilation",
 
 exports[`logging should work when the "client.logging" is "info" (sockjs) 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -225,6 +250,7 @@ Array [
 
 exports[`logging should work when the "client.logging" is "info" (ws) 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -234,6 +260,7 @@ Array [
 
 exports[`logging should work when the "client.logging" is "log" (sockjs) 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -243,6 +270,7 @@ Array [
 
 exports[`logging should work when the "client.logging" is "log" (ws) 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -252,18 +280,21 @@ Array [
 
 exports[`logging should work when the "client.logging" is "none" (sockjs) 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hey.",
 ]
 `;
 
 exports[`logging should work when the "client.logging" is "none" (ws) 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hey.",
 ]
 `;
 
 exports[`logging should work when the "client.logging" is "verbose" (sockjs) 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -273,6 +304,7 @@ Array [
 
 exports[`logging should work when the "client.logging" is "verbose" (ws) 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",

--- a/test/e2e/__snapshots__/logging.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/logging.test.js.snap.webpack4
@@ -16,7 +16,7 @@ Array [
 
 exports[`logging should work and log errors by default (sockjs) 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Errors while compiling. Reload prevented.",
@@ -27,7 +27,7 @@ Error from compilation",
 
 exports[`logging should work and log errors by default (ws) 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Errors while compiling. Reload prevented.",
@@ -52,7 +52,7 @@ Array [
 
 exports[`logging should work and log messages about hot and live reloading is enabled (sockjs) 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -60,7 +60,7 @@ Array [
 
 exports[`logging should work and log messages about hot and live reloading is enabled (sockjs) 2`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -68,7 +68,7 @@ Array [
 
 exports[`logging should work and log messages about hot and live reloading is enabled (sockjs) 3`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -76,7 +76,7 @@ Array [
 
 exports[`logging should work and log messages about hot and live reloading is enabled (ws) 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -84,7 +84,7 @@ Array [
 
 exports[`logging should work and log messages about hot and live reloading is enabled (ws) 2`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -92,7 +92,7 @@ Array [
 
 exports[`logging should work and log messages about hot and live reloading is enabled (ws) 3`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -116,7 +116,7 @@ Array [
 
 exports[`logging should work and log only error (sockjs) 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "Hey.",
   "[webpack-dev-server] Errors while compiling. Reload prevented.",
   "[webpack-dev-server] ERROR
@@ -126,7 +126,7 @@ Error from compilation",
 
 exports[`logging should work and log only error (ws) 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "Hey.",
   "[webpack-dev-server] Errors while compiling. Reload prevented.",
   "[webpack-dev-server] ERROR
@@ -136,11 +136,11 @@ Error from compilation",
 
 exports[`logging should work and log static changes (sockjs) 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] \\"<cwd>/test/fixtures/client-config/static/foo.txt\\" from static directory was changed. Reloading...",
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -148,11 +148,11 @@ Array [
 
 exports[`logging should work and log static changes (ws) 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] \\"<cwd>/test/fixtures/client-config/static/foo.txt\\" from static directory was changed. Reloading...",
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -160,7 +160,7 @@ Array [
 
 exports[`logging should work and log warning and errors (sockjs) 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "Hey.",
   "[webpack-dev-server] Warnings while compiling.",
   "[webpack-dev-server] WARNING
@@ -173,7 +173,7 @@ Error from compilation",
 
 exports[`logging should work and log warning and errors (ws) 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "Hey.",
   "[webpack-dev-server] Warnings while compiling.",
   "[webpack-dev-server] WARNING
@@ -186,7 +186,7 @@ Error from compilation",
 
 exports[`logging should work and log warnings by default (sockjs) 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Warnings while compiling.",
@@ -197,7 +197,7 @@ Warning from compilation",
 
 exports[`logging should work and log warnings by default (ws) 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Warnings while compiling.",
@@ -208,7 +208,7 @@ Warning from compilation",
 
 exports[`logging should work when the "client.logging" is "info" (sockjs) 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -216,7 +216,7 @@ Array [
 
 exports[`logging should work when the "client.logging" is "info" (ws) 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -224,7 +224,7 @@ Array [
 
 exports[`logging should work when the "client.logging" is "log" (sockjs) 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -232,7 +232,7 @@ Array [
 
 exports[`logging should work when the "client.logging" is "log" (ws) 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -240,21 +240,21 @@ Array [
 
 exports[`logging should work when the "client.logging" is "none" (sockjs) 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "Hey.",
 ]
 `;
 
 exports[`logging should work when the "client.logging" is "none" (ws) 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "Hey.",
 ]
 `;
 
 exports[`logging should work when the "client.logging" is "verbose" (sockjs) 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -262,7 +262,7 @@ Array [
 
 exports[`logging should work when the "client.logging" is "verbose" (ws) 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]

--- a/test/e2e/__snapshots__/logging.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/logging.test.js.snap.webpack5
@@ -2,14 +2,14 @@
 
 exports[`logging should work and do not log messages about hot and live reloading is enabled (sockjs) 1`] = `
 Array [
-  "[webpack-dev-server] server started with Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading disabled, Progress disabled, Overlay enabled.",
   "Hey.",
 ]
 `;
 
 exports[`logging should work and do not log messages about hot and live reloading is enabled (ws) 1`] = `
 Array [
-  "[webpack-dev-server] server started with Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading disabled, Progress disabled, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -38,14 +38,14 @@ Error from compilation",
 
 exports[`logging should work and log message about live reloading is enabled (sockjs) 1`] = `
 Array [
-  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "Hey.",
 ]
 `;
 
 exports[`logging should work and log message about live reloading is enabled (ws) 1`] = `
 Array [
-  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -100,7 +100,7 @@ Array [
 
 exports[`logging should work and log messages about hot is enabled (sockjs) 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading disabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -108,7 +108,7 @@ Array [
 
 exports[`logging should work and log messages about hot is enabled (ws) 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading disabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]

--- a/test/e2e/__snapshots__/logging.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/logging.test.js.snap.webpack5
@@ -2,25 +2,23 @@
 
 exports[`logging should work and do not log messages about hot and live reloading is enabled (sockjs) 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Overlay enabled.",
   "Hey.",
 ]
 `;
 
 exports[`logging should work and do not log messages about hot and live reloading is enabled (ws) 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Overlay enabled.",
   "Hey.",
 ]
 `;
 
 exports[`logging should work and log errors by default (sockjs) 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] Errors while compiling. Reload prevented.",
   "[webpack-dev-server] ERROR
 Error from compilation",
@@ -29,11 +27,9 @@ Error from compilation",
 
 exports[`logging should work and log errors by default (ws) 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] Errors while compiling. Reload prevented.",
   "[webpack-dev-server] ERROR
 Error from compilation",
@@ -42,101 +38,85 @@ Error from compilation",
 
 exports[`logging should work and log message about live reloading is enabled (sockjs) 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
   "Hey.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`logging should work and log message about live reloading is enabled (ws) 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
   "Hey.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`logging should work and log messages about hot and live reloading is enabled (sockjs) 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`logging should work and log messages about hot and live reloading is enabled (sockjs) 2`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`logging should work and log messages about hot and live reloading is enabled (sockjs) 3`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`logging should work and log messages about hot and live reloading is enabled (ws) 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`logging should work and log messages about hot and live reloading is enabled (ws) 2`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`logging should work and log messages about hot and live reloading is enabled (ws) 3`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`logging should work and log messages about hot is enabled (sockjs) 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
 ]
 `;
 
 exports[`logging should work and log messages about hot is enabled (ws) 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
 ]
 `;
 
 exports[`logging should work and log only error (sockjs) 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "Hey.",
   "[webpack-dev-server] Errors while compiling. Reload prevented.",
   "[webpack-dev-server] ERROR
@@ -146,7 +126,7 @@ Error from compilation",
 
 exports[`logging should work and log only error (ws) 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "Hey.",
   "[webpack-dev-server] Errors while compiling. Reload prevented.",
   "[webpack-dev-server] ERROR
@@ -156,39 +136,31 @@ Error from compilation",
 
 exports[`logging should work and log static changes (sockjs) 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] \\"<cwd>/test/fixtures/client-config/static/foo.txt\\" from static directory was changed. Reloading...",
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`logging should work and log static changes (ws) 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] \\"<cwd>/test/fixtures/client-config/static/foo.txt\\" from static directory was changed. Reloading...",
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`logging should work and log warning and errors (sockjs) 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "Hey.",
   "[webpack-dev-server] Warnings while compiling.",
   "[webpack-dev-server] WARNING
@@ -201,7 +173,7 @@ Error from compilation",
 
 exports[`logging should work and log warning and errors (ws) 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "Hey.",
   "[webpack-dev-server] Warnings while compiling.",
   "[webpack-dev-server] WARNING
@@ -214,11 +186,9 @@ Error from compilation",
 
 exports[`logging should work and log warnings by default (sockjs) 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] Warnings while compiling.",
   "[webpack-dev-server] WARNING
 Warning from compilation",
@@ -227,11 +197,9 @@ Warning from compilation",
 
 exports[`logging should work and log warnings by default (ws) 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] Warnings while compiling.",
   "[webpack-dev-server] WARNING
 Warning from compilation",
@@ -240,74 +208,62 @@ Warning from compilation",
 
 exports[`logging should work when the "client.logging" is "info" (sockjs) 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`logging should work when the "client.logging" is "info" (ws) 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`logging should work when the "client.logging" is "log" (sockjs) 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`logging should work when the "client.logging" is "log" (ws) 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`logging should work when the "client.logging" is "none" (sockjs) 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "Hey.",
 ]
 `;
 
 exports[`logging should work when the "client.logging" is "none" (ws) 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "Hey.",
 ]
 `;
 
 exports[`logging should work when the "client.logging" is "verbose" (sockjs) 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`logging should work when the "client.logging" is "verbose" (ws) 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;

--- a/test/e2e/__snapshots__/logging.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/logging.test.js.snap.webpack5
@@ -2,18 +2,21 @@
 
 exports[`logging should work and do not log messages about hot and live reloading is enabled (sockjs) 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hey.",
 ]
 `;
 
 exports[`logging should work and do not log messages about hot and live reloading is enabled (ws) 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hey.",
 ]
 `;
 
 exports[`logging should work and log errors by default (sockjs) 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -26,6 +29,7 @@ Error from compilation",
 
 exports[`logging should work and log errors by default (ws) 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -38,6 +42,7 @@ Error from compilation",
 
 exports[`logging should work and log message about live reloading is enabled (sockjs) 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hey.",
   "[webpack-dev-server] Live Reloading enabled.",
 ]
@@ -45,6 +50,7 @@ Array [
 
 exports[`logging should work and log message about live reloading is enabled (ws) 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hey.",
   "[webpack-dev-server] Live Reloading enabled.",
 ]
@@ -52,6 +58,7 @@ Array [
 
 exports[`logging should work and log messages about hot and live reloading is enabled (sockjs) 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -61,6 +68,7 @@ Array [
 
 exports[`logging should work and log messages about hot and live reloading is enabled (sockjs) 2`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -70,6 +78,7 @@ Array [
 
 exports[`logging should work and log messages about hot and live reloading is enabled (sockjs) 3`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -79,6 +88,7 @@ Array [
 
 exports[`logging should work and log messages about hot and live reloading is enabled (ws) 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -88,6 +98,7 @@ Array [
 
 exports[`logging should work and log messages about hot and live reloading is enabled (ws) 2`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -97,6 +108,7 @@ Array [
 
 exports[`logging should work and log messages about hot and live reloading is enabled (ws) 3`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -106,6 +118,7 @@ Array [
 
 exports[`logging should work and log messages about hot is enabled (sockjs) 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -114,6 +127,7 @@ Array [
 
 exports[`logging should work and log messages about hot is enabled (ws) 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -122,6 +136,7 @@ Array [
 
 exports[`logging should work and log only error (sockjs) 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hey.",
   "[webpack-dev-server] Errors while compiling. Reload prevented.",
   "[webpack-dev-server] ERROR
@@ -131,6 +146,7 @@ Error from compilation",
 
 exports[`logging should work and log only error (ws) 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hey.",
   "[webpack-dev-server] Errors while compiling. Reload prevented.",
   "[webpack-dev-server] ERROR
@@ -140,11 +156,13 @@ Error from compilation",
 
 exports[`logging should work and log static changes (sockjs) 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] \\"<cwd>/test/fixtures/client-config/static/foo.txt\\" from static directory was changed. Reloading...",
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -154,11 +172,13 @@ Array [
 
 exports[`logging should work and log static changes (ws) 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] \\"<cwd>/test/fixtures/client-config/static/foo.txt\\" from static directory was changed. Reloading...",
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -168,6 +188,7 @@ Array [
 
 exports[`logging should work and log warning and errors (sockjs) 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hey.",
   "[webpack-dev-server] Warnings while compiling.",
   "[webpack-dev-server] WARNING
@@ -180,6 +201,7 @@ Error from compilation",
 
 exports[`logging should work and log warning and errors (ws) 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hey.",
   "[webpack-dev-server] Warnings while compiling.",
   "[webpack-dev-server] WARNING
@@ -192,6 +214,7 @@ Error from compilation",
 
 exports[`logging should work and log warnings by default (sockjs) 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -204,6 +227,7 @@ Warning from compilation",
 
 exports[`logging should work and log warnings by default (ws) 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -216,6 +240,7 @@ Warning from compilation",
 
 exports[`logging should work when the "client.logging" is "info" (sockjs) 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -225,6 +250,7 @@ Array [
 
 exports[`logging should work when the "client.logging" is "info" (ws) 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -234,6 +260,7 @@ Array [
 
 exports[`logging should work when the "client.logging" is "log" (sockjs) 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -243,6 +270,7 @@ Array [
 
 exports[`logging should work when the "client.logging" is "log" (ws) 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -252,18 +280,21 @@ Array [
 
 exports[`logging should work when the "client.logging" is "none" (sockjs) 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hey.",
 ]
 `;
 
 exports[`logging should work when the "client.logging" is "none" (ws) 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hey.",
 ]
 `;
 
 exports[`logging should work when the "client.logging" is "verbose" (sockjs) 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -273,6 +304,7 @@ Array [
 
 exports[`logging should work when the "client.logging" is "verbose" (ws) 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",

--- a/test/e2e/__snapshots__/logging.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/logging.test.js.snap.webpack5
@@ -16,7 +16,7 @@ Array [
 
 exports[`logging should work and log errors by default (sockjs) 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Errors while compiling. Reload prevented.",
@@ -27,7 +27,7 @@ Error from compilation",
 
 exports[`logging should work and log errors by default (ws) 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Errors while compiling. Reload prevented.",
@@ -52,7 +52,7 @@ Array [
 
 exports[`logging should work and log messages about hot and live reloading is enabled (sockjs) 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -60,7 +60,7 @@ Array [
 
 exports[`logging should work and log messages about hot and live reloading is enabled (sockjs) 2`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -68,7 +68,7 @@ Array [
 
 exports[`logging should work and log messages about hot and live reloading is enabled (sockjs) 3`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -76,7 +76,7 @@ Array [
 
 exports[`logging should work and log messages about hot and live reloading is enabled (ws) 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -84,7 +84,7 @@ Array [
 
 exports[`logging should work and log messages about hot and live reloading is enabled (ws) 2`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -92,7 +92,7 @@ Array [
 
 exports[`logging should work and log messages about hot and live reloading is enabled (ws) 3`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -116,7 +116,7 @@ Array [
 
 exports[`logging should work and log only error (sockjs) 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "Hey.",
   "[webpack-dev-server] Errors while compiling. Reload prevented.",
   "[webpack-dev-server] ERROR
@@ -126,7 +126,7 @@ Error from compilation",
 
 exports[`logging should work and log only error (ws) 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "Hey.",
   "[webpack-dev-server] Errors while compiling. Reload prevented.",
   "[webpack-dev-server] ERROR
@@ -136,11 +136,11 @@ Error from compilation",
 
 exports[`logging should work and log static changes (sockjs) 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] \\"<cwd>/test/fixtures/client-config/static/foo.txt\\" from static directory was changed. Reloading...",
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -148,11 +148,11 @@ Array [
 
 exports[`logging should work and log static changes (ws) 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] \\"<cwd>/test/fixtures/client-config/static/foo.txt\\" from static directory was changed. Reloading...",
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -160,7 +160,7 @@ Array [
 
 exports[`logging should work and log warning and errors (sockjs) 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "Hey.",
   "[webpack-dev-server] Warnings while compiling.",
   "[webpack-dev-server] WARNING
@@ -173,7 +173,7 @@ Error from compilation",
 
 exports[`logging should work and log warning and errors (ws) 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "Hey.",
   "[webpack-dev-server] Warnings while compiling.",
   "[webpack-dev-server] WARNING
@@ -186,7 +186,7 @@ Error from compilation",
 
 exports[`logging should work and log warnings by default (sockjs) 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Warnings while compiling.",
@@ -197,7 +197,7 @@ Warning from compilation",
 
 exports[`logging should work and log warnings by default (ws) 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Warnings while compiling.",
@@ -208,7 +208,7 @@ Warning from compilation",
 
 exports[`logging should work when the "client.logging" is "info" (sockjs) 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -216,7 +216,7 @@ Array [
 
 exports[`logging should work when the "client.logging" is "info" (ws) 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -224,7 +224,7 @@ Array [
 
 exports[`logging should work when the "client.logging" is "log" (sockjs) 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -232,7 +232,7 @@ Array [
 
 exports[`logging should work when the "client.logging" is "log" (ws) 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -240,21 +240,21 @@ Array [
 
 exports[`logging should work when the "client.logging" is "none" (sockjs) 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "Hey.",
 ]
 `;
 
 exports[`logging should work when the "client.logging" is "none" (ws) 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "Hey.",
 ]
 `;
 
 exports[`logging should work when the "client.logging" is "verbose" (sockjs) 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -262,7 +262,7 @@ Array [
 
 exports[`logging should work when the "client.logging" is "verbose" (ws) 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]

--- a/test/e2e/__snapshots__/magic-html.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/magic-html.test.js.snap.webpack4
@@ -26,7 +26,7 @@ exports[`magicHtml option disabled should not handle HEAD request to magic async
 
 exports[`magicHtml option enabled should handle GET request to magic async html: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]

--- a/test/e2e/__snapshots__/magic-html.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/magic-html.test.js.snap.webpack4
@@ -26,11 +26,9 @@ exports[`magicHtml option disabled should not handle HEAD request to magic async
 
 exports[`magicHtml option enabled should handle GET request to magic async html: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 

--- a/test/e2e/__snapshots__/magic-html.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/magic-html.test.js.snap.webpack4
@@ -26,6 +26,7 @@ exports[`magicHtml option disabled should not handle HEAD request to magic async
 
 exports[`magicHtml option enabled should handle GET request to magic async html: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",

--- a/test/e2e/__snapshots__/magic-html.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/magic-html.test.js.snap.webpack5
@@ -26,7 +26,7 @@ exports[`magicHtml option disabled should not handle HEAD request to magic async
 
 exports[`magicHtml option enabled should handle GET request to magic async html: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]

--- a/test/e2e/__snapshots__/magic-html.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/magic-html.test.js.snap.webpack5
@@ -26,11 +26,9 @@ exports[`magicHtml option disabled should not handle HEAD request to magic async
 
 exports[`magicHtml option enabled should handle GET request to magic async html: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 

--- a/test/e2e/__snapshots__/magic-html.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/magic-html.test.js.snap.webpack5
@@ -26,6 +26,7 @@ exports[`magicHtml option disabled should not handle HEAD request to magic async
 
 exports[`magicHtml option enabled should handle GET request to magic async html: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",

--- a/test/e2e/__snapshots__/multi-compiler.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/multi-compiler.test.js.snap.webpack4
@@ -2,7 +2,7 @@
 
 exports[`multi compiler should work with one web target configuration and do nothing: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -12,7 +12,7 @@ exports[`multi compiler should work with one web target configuration and do not
 
 exports[`multi compiler should work with universal configuration and do nothing: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hello from the browser",
 ]
@@ -22,7 +22,7 @@ exports[`multi compiler should work with universal configuration and do nothing:
 
 exports[`multi compiler should work with universal configuration when hot and live reloads are enabled, and do hot reload for browser compiler by default when browser entry changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hello from the browser",
   "[webpack-dev-server] App updated. Recompiling...",
@@ -32,7 +32,7 @@ Array [
   "[HMR] Error: Aborted because ./browser.js is not accepted
 Update propagation: ./browser.js -> 0
     <stack>",
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hello from the browser",
 ]
@@ -42,7 +42,7 @@ exports[`multi compiler should work with universal configuration when hot and li
 
 exports[`multi compiler should work with universal configuration when only hot reload is enabled, and do hot reload for browser compiler when browser entry changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading disabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hello from the browser",
   "[webpack-dev-server] App updated. Recompiling...",
@@ -64,22 +64,22 @@ exports[`multi compiler should work with universal configuration when only hot r
 
 exports[`multi compiler should work with universal configuration when only live reload is enabled, and do live reload for browser compiler when changing browser and server entries: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "Hello from the browser",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
-  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "Hello from the browser",
 ]
 `;
 
 exports[`multi compiler should work with universal configuration when only live reload is enabled, and do live reload for browser compiler when changing browser and server entries: console messages 2`] = `
 Array [
-  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "Hello from the browser",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
-  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "Hello from the browser",
 ]
 `;
@@ -90,22 +90,22 @@ exports[`multi compiler should work with universal configuration when only live 
 
 exports[`multi compiler should work with universal configuration when only live reload is enabled, and do live reload for browser compiler when changing server and browser entries: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "Hello from the browser",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
-  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "Hello from the browser",
 ]
 `;
 
 exports[`multi compiler should work with universal configuration when only live reload is enabled, and do live reload for browser compiler when changing server and browser entries: console messages 2`] = `
 Array [
-  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "Hello from the browser",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
-  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "Hello from the browser",
 ]
 `;
@@ -116,7 +116,7 @@ exports[`multi compiler should work with universal configuration when only live 
 
 exports[`multi compiler should work with web target configurations and do nothing: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "one",
 ]
@@ -124,7 +124,7 @@ Array [
 
 exports[`multi compiler should work with web target configurations and do nothing: console messages 2`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "two",
 ]
@@ -136,7 +136,7 @@ exports[`multi compiler should work with web target configurations and do nothin
 
 exports[`multi compiler should work with web target configurations when hot and live reloads are enabled, and do hot reload by default when changing own entries: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "one",
   "[webpack-dev-server] App updated. Recompiling...",
@@ -146,7 +146,7 @@ Array [
   "[HMR] Error: Aborted because ./one.js is not accepted
 Update propagation: ./one.js -> 0
     <stack>",
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "one",
 ]
@@ -154,7 +154,7 @@ Update propagation: ./one.js -> 0
 
 exports[`multi compiler should work with web target configurations when hot and live reloads are enabled, and do hot reload by default when changing own entries: console messages 2`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "two",
   "[webpack-dev-server] App updated. Recompiling...",
@@ -164,7 +164,7 @@ Array [
   "[HMR] Error: Aborted because ./two.js is not accepted
 Update propagation: ./two.js -> 0
     <stack>",
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "two",
 ]
@@ -176,7 +176,7 @@ exports[`multi compiler should work with web target configurations when hot and 
 
 exports[`multi compiler should work with web target configurations when only hot reload is enabled, and do hot reload when changing own entries: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading disabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "one",
   "[webpack-dev-server] App updated. Recompiling...",
@@ -186,7 +186,7 @@ Array [
   "[HMR] Error: Aborted because ./one.js is not accepted
 Update propagation: ./one.js -> 0
     <stack>",
-  "[webpack-dev-server] server started with Hot Module Replacement, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading disabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "one",
 ]
@@ -194,7 +194,7 @@ Update propagation: ./one.js -> 0
 
 exports[`multi compiler should work with web target configurations when only hot reload is enabled, and do hot reload when changing own entries: console messages 2`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading disabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "two",
   "[webpack-dev-server] App updated. Recompiling...",
@@ -204,7 +204,7 @@ Array [
   "[HMR] Error: Aborted because ./two.js is not accepted
 Update propagation: ./two.js -> 0
     <stack>",
-  "[webpack-dev-server] server started with Hot Module Replacement, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading disabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "two",
 ]
@@ -216,22 +216,22 @@ exports[`multi compiler should work with web target configurations when only hot
 
 exports[`multi compiler should work with web target configurations when only live reload is enabled and do live reload when changing other entries: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "one",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
-  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "one",
 ]
 `;
 
 exports[`multi compiler should work with web target configurations when only live reload is enabled and do live reload when changing other entries: console messages 2`] = `
 Array [
-  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "two",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
-  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "two",
 ]
 `;
@@ -242,22 +242,22 @@ exports[`multi compiler should work with web target configurations when only liv
 
 exports[`multi compiler should work with web target configurations when only live reload is enabled, and do live reload when changing own entries: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "one",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
-  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "one",
 ]
 `;
 
 exports[`multi compiler should work with web target configurations when only live reload is enabled, and do live reload when changing own entries: console messages 2`] = `
 Array [
-  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "two",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
-  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "two",
 ]
 `;

--- a/test/e2e/__snapshots__/multi-compiler.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/multi-compiler.test.js.snap.webpack4
@@ -30,7 +30,7 @@ Array [
   "[HMR] Checking for updates on the server...",
   "[HMR] Cannot apply update. Need to do a full reload!",
   "[HMR] Error: Aborted because ./browser.js is not accepted
-Update propagation: ./browser.js
+Update propagation: ./browser.js -> 0
     <stack>",
   "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
@@ -50,14 +50,10 @@ Array [
   "[HMR] Checking for updates on the server...",
   "[HMR] Cannot apply update. Need to do a full reload!",
   "[HMR] Error: Aborted because ./browser.js is not accepted
-Update propagation: ./browser.js
-    at applyHandler (http://127.0.0.1:8103/browser.js:1034:31)
-    at http://127.0.0.1:8103/browser.js:733:21
-    at Array.map (<anonymous>)
-    at internalApply (http://127.0.0.1:8103/browser.js:732:54)
-    at http://127.0.0.1:8103/browser.js:702:26
-    at waitForBlockingPromises (http://127.0.0.1:8103/browser.js:656:48)
-    at http://127.0.0.1:8103/browser.js:700:24",
+Update propagation: ./browser.js -> 0
+    at hotApplyInternal (http://127.0.0.1:8103/browser.js:508:30)
+    at hotApply (http://127.0.0.1:8103/browser.js:362:19)
+    at http://127.0.0.1:8103/browser.js:337:22",
   "[webpack-dev-server] server started with Hot Module Replacement, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hello from the browser",
@@ -148,7 +144,7 @@ Array [
   "[HMR] Checking for updates on the server...",
   "[HMR] Cannot apply update. Need to do a full reload!",
   "[HMR] Error: Aborted because ./one.js is not accepted
-Update propagation: ./one.js
+Update propagation: ./one.js -> 0
     <stack>",
   "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
@@ -166,7 +162,7 @@ Array [
   "[HMR] Checking for updates on the server...",
   "[HMR] Cannot apply update. Need to do a full reload!",
   "[HMR] Error: Aborted because ./two.js is not accepted
-Update propagation: ./two.js
+Update propagation: ./two.js -> 0
     <stack>",
   "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
@@ -188,7 +184,7 @@ Array [
   "[HMR] Checking for updates on the server...",
   "[HMR] Cannot apply update. Need to do a full reload!",
   "[HMR] Error: Aborted because ./one.js is not accepted
-Update propagation: ./one.js
+Update propagation: ./one.js -> 0
     <stack>",
   "[webpack-dev-server] server started with Hot Module Replacement, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
@@ -206,7 +202,7 @@ Array [
   "[HMR] Checking for updates on the server...",
   "[HMR] Cannot apply update. Need to do a full reload!",
   "[HMR] Error: Aborted because ./two.js is not accepted
-Update propagation: ./two.js
+Update propagation: ./two.js -> 0
     <stack>",
   "[webpack-dev-server] server started with Hot Module Replacement, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",

--- a/test/e2e/__snapshots__/multi-compiler.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/multi-compiler.test.js.snap.webpack4
@@ -2,6 +2,7 @@
 
 exports[`multi compiler should work with one web target configuration and do nothing: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -13,6 +14,7 @@ exports[`multi compiler should work with one web target configuration and do not
 
 exports[`multi compiler should work with universal configuration and do nothing: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hello from the browser",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -24,6 +26,7 @@ exports[`multi compiler should work with universal configuration and do nothing:
 
 exports[`multi compiler should work with universal configuration when hot and live reloads are enabled, and do hot reload for browser compiler by default when browser entry changed: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hello from the browser",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -35,6 +38,7 @@ Array [
   "[HMR] Error: Aborted because ./browser.js is not accepted
 Update propagation: ./browser.js -> 0
     <stack>",
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hello from the browser",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -46,6 +50,7 @@ exports[`multi compiler should work with universal configuration when hot and li
 
 exports[`multi compiler should work with universal configuration when only hot reload is enabled, and do hot reload for browser compiler when browser entry changed: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hello from the browser",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -68,10 +73,12 @@ exports[`multi compiler should work with universal configuration when only hot r
 
 exports[`multi compiler should work with universal configuration when only live reload is enabled, and do live reload for browser compiler when changing browser and server entries: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hello from the browser",
   "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hello from the browser",
   "[webpack-dev-server] Live Reloading enabled.",
 ]
@@ -79,10 +86,12 @@ Array [
 
 exports[`multi compiler should work with universal configuration when only live reload is enabled, and do live reload for browser compiler when changing browser and server entries: console messages 2`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hello from the browser",
   "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hello from the browser",
   "[webpack-dev-server] Live Reloading enabled.",
 ]
@@ -94,10 +103,12 @@ exports[`multi compiler should work with universal configuration when only live 
 
 exports[`multi compiler should work with universal configuration when only live reload is enabled, and do live reload for browser compiler when changing server and browser entries: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hello from the browser",
   "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hello from the browser",
   "[webpack-dev-server] Live Reloading enabled.",
 ]
@@ -105,10 +116,12 @@ Array [
 
 exports[`multi compiler should work with universal configuration when only live reload is enabled, and do live reload for browser compiler when changing server and browser entries: console messages 2`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hello from the browser",
   "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hello from the browser",
   "[webpack-dev-server] Live Reloading enabled.",
 ]
@@ -120,6 +133,7 @@ exports[`multi compiler should work with universal configuration when only live 
 
 exports[`multi compiler should work with web target configurations and do nothing: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "one",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -129,6 +143,7 @@ Array [
 
 exports[`multi compiler should work with web target configurations and do nothing: console messages 2`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "two",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -142,6 +157,7 @@ exports[`multi compiler should work with web target configurations and do nothin
 
 exports[`multi compiler should work with web target configurations when hot and live reloads are enabled, and do hot reload by default when changing own entries: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "one",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -153,6 +169,7 @@ Array [
   "[HMR] Error: Aborted because ./one.js is not accepted
 Update propagation: ./one.js -> 0
     <stack>",
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "one",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -162,6 +179,7 @@ Update propagation: ./one.js -> 0
 
 exports[`multi compiler should work with web target configurations when hot and live reloads are enabled, and do hot reload by default when changing own entries: console messages 2`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "two",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -173,6 +191,7 @@ Array [
   "[HMR] Error: Aborted because ./two.js is not accepted
 Update propagation: ./two.js -> 0
     <stack>",
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "two",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -186,6 +205,7 @@ exports[`multi compiler should work with web target configurations when hot and 
 
 exports[`multi compiler should work with web target configurations when only hot reload is enabled, and do hot reload when changing own entries: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "one",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -196,6 +216,7 @@ Array [
   "[HMR] Error: Aborted because ./one.js is not accepted
 Update propagation: ./one.js -> 0
     <stack>",
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "one",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -204,6 +225,7 @@ Update propagation: ./one.js -> 0
 
 exports[`multi compiler should work with web target configurations when only hot reload is enabled, and do hot reload when changing own entries: console messages 2`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "two",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -214,6 +236,7 @@ Array [
   "[HMR] Error: Aborted because ./two.js is not accepted
 Update propagation: ./two.js -> 0
     <stack>",
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "two",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -226,10 +249,12 @@ exports[`multi compiler should work with web target configurations when only hot
 
 exports[`multi compiler should work with web target configurations when only live reload is enabled and do live reload when changing other entries: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "one",
   "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "one",
   "[webpack-dev-server] Live Reloading enabled.",
 ]
@@ -237,10 +262,12 @@ Array [
 
 exports[`multi compiler should work with web target configurations when only live reload is enabled and do live reload when changing other entries: console messages 2`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "two",
   "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "two",
   "[webpack-dev-server] Live Reloading enabled.",
 ]
@@ -252,10 +279,12 @@ exports[`multi compiler should work with web target configurations when only liv
 
 exports[`multi compiler should work with web target configurations when only live reload is enabled, and do live reload when changing own entries: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "one",
   "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "one",
   "[webpack-dev-server] Live Reloading enabled.",
 ]
@@ -263,10 +292,12 @@ Array [
 
 exports[`multi compiler should work with web target configurations when only live reload is enabled, and do live reload when changing own entries: console messages 2`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "two",
   "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "two",
   "[webpack-dev-server] Live Reloading enabled.",
 ]

--- a/test/e2e/__snapshots__/multi-compiler.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/multi-compiler.test.js.snap.webpack4
@@ -54,7 +54,7 @@ Update propagation: ./browser.js -> 0
     at hotApplyInternal (http://127.0.0.1:8103/browser.js:508:30)
     at hotApply (http://127.0.0.1:8103/browser.js:362:19)
     at http://127.0.0.1:8103/browser.js:337:22",
-  "[webpack-dev-server] server started with Hot Module Replacement, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading disabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hello from the browser",
 ]

--- a/test/e2e/__snapshots__/multi-compiler.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/multi-compiler.test.js.snap.webpack4
@@ -63,6 +63,7 @@ Update propagation: ./browser.js -> 0
     at hotApplyInternal (http://127.0.0.1:8103/browser.js:508:30)
     at hotApply (http://127.0.0.1:8103/browser.js:362:19)
     at http://127.0.0.1:8103/browser.js:337:22",
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hello from the browser",
   "[webpack-dev-server] Hot Module Replacement enabled.",

--- a/test/e2e/__snapshots__/multi-compiler.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/multi-compiler.test.js.snap.webpack4
@@ -2,11 +2,9 @@
 
 exports[`multi compiler should work with one web target configuration and do nothing: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -14,11 +12,9 @@ exports[`multi compiler should work with one web target configuration and do not
 
 exports[`multi compiler should work with universal configuration and do nothing: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hello from the browser",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -26,23 +22,19 @@ exports[`multi compiler should work with universal configuration and do nothing:
 
 exports[`multi compiler should work with universal configuration when hot and live reloads are enabled, and do hot reload for browser compiler by default when browser entry changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hello from the browser",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
   "[HMR] Checking for updates on the server...",
   "[HMR] Cannot apply update. Need to do a full reload!",
   "[HMR] Error: Aborted because ./browser.js is not accepted
-Update propagation: ./browser.js -> 0
+Update propagation: ./browser.js
     <stack>",
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hello from the browser",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -50,23 +42,25 @@ exports[`multi compiler should work with universal configuration when hot and li
 
 exports[`multi compiler should work with universal configuration when only hot reload is enabled, and do hot reload for browser compiler when browser entry changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hello from the browser",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
   "[HMR] Checking for updates on the server...",
   "[HMR] Cannot apply update. Need to do a full reload!",
   "[HMR] Error: Aborted because ./browser.js is not accepted
-Update propagation: ./browser.js -> 0
-    at hotApplyInternal (http://127.0.0.1:8103/browser.js:508:30)
-    at hotApply (http://127.0.0.1:8103/browser.js:362:19)
-    at http://127.0.0.1:8103/browser.js:337:22",
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+Update propagation: ./browser.js
+    at applyHandler (http://127.0.0.1:8103/browser.js:1034:31)
+    at http://127.0.0.1:8103/browser.js:733:21
+    at Array.map (<anonymous>)
+    at internalApply (http://127.0.0.1:8103/browser.js:732:54)
+    at http://127.0.0.1:8103/browser.js:702:26
+    at waitForBlockingPromises (http://127.0.0.1:8103/browser.js:656:48)
+    at http://127.0.0.1:8103/browser.js:700:24",
+  "[webpack-dev-server] server started with Hot Module Replacement, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hello from the browser",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
 ]
 `;
 
@@ -74,27 +68,23 @@ exports[`multi compiler should work with universal configuration when only hot r
 
 exports[`multi compiler should work with universal configuration when only live reload is enabled, and do live reload for browser compiler when changing browser and server entries: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
   "Hello from the browser",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
   "Hello from the browser",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`multi compiler should work with universal configuration when only live reload is enabled, and do live reload for browser compiler when changing browser and server entries: console messages 2`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
   "Hello from the browser",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
   "Hello from the browser",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -104,27 +94,23 @@ exports[`multi compiler should work with universal configuration when only live 
 
 exports[`multi compiler should work with universal configuration when only live reload is enabled, and do live reload for browser compiler when changing server and browser entries: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
   "Hello from the browser",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
   "Hello from the browser",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`multi compiler should work with universal configuration when only live reload is enabled, and do live reload for browser compiler when changing server and browser entries: console messages 2`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
   "Hello from the browser",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
   "Hello from the browser",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -134,21 +120,17 @@ exports[`multi compiler should work with universal configuration when only live 
 
 exports[`multi compiler should work with web target configurations and do nothing: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "one",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`multi compiler should work with web target configurations and do nothing: console messages 2`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "two",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -158,45 +140,37 @@ exports[`multi compiler should work with web target configurations and do nothin
 
 exports[`multi compiler should work with web target configurations when hot and live reloads are enabled, and do hot reload by default when changing own entries: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "one",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
   "[HMR] Checking for updates on the server...",
   "[HMR] Cannot apply update. Need to do a full reload!",
   "[HMR] Error: Aborted because ./one.js is not accepted
-Update propagation: ./one.js -> 0
+Update propagation: ./one.js
     <stack>",
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "one",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`multi compiler should work with web target configurations when hot and live reloads are enabled, and do hot reload by default when changing own entries: console messages 2`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "two",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
   "[HMR] Checking for updates on the server...",
   "[HMR] Cannot apply update. Need to do a full reload!",
   "[HMR] Error: Aborted because ./two.js is not accepted
-Update propagation: ./two.js -> 0
+Update propagation: ./two.js
     <stack>",
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "two",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -206,41 +180,37 @@ exports[`multi compiler should work with web target configurations when hot and 
 
 exports[`multi compiler should work with web target configurations when only hot reload is enabled, and do hot reload when changing own entries: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "one",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
   "[HMR] Checking for updates on the server...",
   "[HMR] Cannot apply update. Need to do a full reload!",
   "[HMR] Error: Aborted because ./one.js is not accepted
-Update propagation: ./one.js -> 0
+Update propagation: ./one.js
     <stack>",
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "one",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
 ]
 `;
 
 exports[`multi compiler should work with web target configurations when only hot reload is enabled, and do hot reload when changing own entries: console messages 2`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "two",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
   "[HMR] Checking for updates on the server...",
   "[HMR] Cannot apply update. Need to do a full reload!",
   "[HMR] Error: Aborted because ./two.js is not accepted
-Update propagation: ./two.js -> 0
+Update propagation: ./two.js
     <stack>",
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "two",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
 ]
 `;
 
@@ -250,27 +220,25 @@ exports[`multi compiler should work with web target configurations when only hot
 
 exports[`multi compiler should work with web target configurations when only live reload is enabled and do live reload when changing other entries: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
   "one",
-  "[webpack-dev-server] Live Reloading enabled.",
+  "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] Nothing changed.",
+  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
   "one",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`multi compiler should work with web target configurations when only live reload is enabled and do live reload when changing other entries: console messages 2`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
   "two",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
   "two",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -280,27 +248,23 @@ exports[`multi compiler should work with web target configurations when only liv
 
 exports[`multi compiler should work with web target configurations when only live reload is enabled, and do live reload when changing own entries: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
   "one",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
   "one",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`multi compiler should work with web target configurations when only live reload is enabled, and do live reload when changing own entries: console messages 2`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
   "two",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
   "two",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 

--- a/test/e2e/__snapshots__/multi-compiler.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/multi-compiler.test.js.snap.webpack4
@@ -223,9 +223,7 @@ Array [
   "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
   "one",
   "[webpack-dev-server] App updated. Recompiling...",
-  "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
-  "[webpack-dev-server] Nothing changed.",
   "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
   "one",
 ]

--- a/test/e2e/__snapshots__/multi-compiler.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/multi-compiler.test.js.snap.webpack5
@@ -26,6 +26,7 @@ exports[`multi compiler should work with universal configuration and do nothing:
 
 exports[`multi compiler should work with universal configuration when hot and live reloads are enabled, and do hot reload for browser compiler by default when browser entry changed: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hello from the browser",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -37,6 +38,7 @@ Array [
   "[HMR] Error: Aborted because ./browser.js is not accepted
 Update propagation: ./browser.js
     <stack>",
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hello from the browser",
   "[webpack-dev-server] Hot Module Replacement enabled.",

--- a/test/e2e/__snapshots__/multi-compiler.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/multi-compiler.test.js.snap.webpack5
@@ -65,6 +65,7 @@ Update propagation: ./browser.js
     at http://127.0.0.1:8103/browser.js:702:26
     at waitForBlockingPromises (http://127.0.0.1:8103/browser.js:656:48)
     at http://127.0.0.1:8103/browser.js:700:24",
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hello from the browser",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -227,6 +228,7 @@ Update propagation: ./one.js
 
 exports[`multi compiler should work with web target configurations when only hot reload is enabled, and do hot reload when changing own entries: console messages 2`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "two",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -237,6 +239,7 @@ Array [
   "[HMR] Error: Aborted because ./two.js is not accepted
 Update propagation: ./two.js
     <stack>",
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "two",
   "[webpack-dev-server] Hot Module Replacement enabled.",

--- a/test/e2e/__snapshots__/multi-compiler.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/multi-compiler.test.js.snap.webpack5
@@ -2,7 +2,7 @@
 
 exports[`multi compiler should work with one web target configuration and do nothing: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -12,7 +12,7 @@ exports[`multi compiler should work with one web target configuration and do not
 
 exports[`multi compiler should work with universal configuration and do nothing: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hello from the browser",
 ]
@@ -22,7 +22,7 @@ exports[`multi compiler should work with universal configuration and do nothing:
 
 exports[`multi compiler should work with universal configuration when hot and live reloads are enabled, and do hot reload for browser compiler by default when browser entry changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hello from the browser",
   "[webpack-dev-server] App updated. Recompiling...",
@@ -32,7 +32,7 @@ Array [
   "[HMR] Error: Aborted because ./browser.js is not accepted
 Update propagation: ./browser.js
     <stack>",
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hello from the browser",
 ]
@@ -42,7 +42,7 @@ exports[`multi compiler should work with universal configuration when hot and li
 
 exports[`multi compiler should work with universal configuration when only hot reload is enabled, and do hot reload for browser compiler when browser entry changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading disabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hello from the browser",
   "[webpack-dev-server] App updated. Recompiling...",
@@ -58,7 +58,7 @@ Update propagation: ./browser.js
     at http://127.0.0.1:8103/browser.js:702:26
     at waitForBlockingPromises (http://127.0.0.1:8103/browser.js:656:48)
     at http://127.0.0.1:8103/browser.js:700:24",
-  "[webpack-dev-server] server started with Hot Module Replacement, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading disabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hello from the browser",
 ]
@@ -68,22 +68,22 @@ exports[`multi compiler should work with universal configuration when only hot r
 
 exports[`multi compiler should work with universal configuration when only live reload is enabled, and do live reload for browser compiler when changing browser and server entries: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "Hello from the browser",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
-  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "Hello from the browser",
 ]
 `;
 
 exports[`multi compiler should work with universal configuration when only live reload is enabled, and do live reload for browser compiler when changing browser and server entries: console messages 2`] = `
 Array [
-  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "Hello from the browser",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
-  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "Hello from the browser",
 ]
 `;
@@ -94,22 +94,22 @@ exports[`multi compiler should work with universal configuration when only live 
 
 exports[`multi compiler should work with universal configuration when only live reload is enabled, and do live reload for browser compiler when changing server and browser entries: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "Hello from the browser",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
-  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "Hello from the browser",
 ]
 `;
 
 exports[`multi compiler should work with universal configuration when only live reload is enabled, and do live reload for browser compiler when changing server and browser entries: console messages 2`] = `
 Array [
-  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "Hello from the browser",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
-  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "Hello from the browser",
 ]
 `;
@@ -120,7 +120,7 @@ exports[`multi compiler should work with universal configuration when only live 
 
 exports[`multi compiler should work with web target configurations and do nothing: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "one",
 ]
@@ -128,7 +128,7 @@ Array [
 
 exports[`multi compiler should work with web target configurations and do nothing: console messages 2`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "two",
 ]
@@ -140,7 +140,7 @@ exports[`multi compiler should work with web target configurations and do nothin
 
 exports[`multi compiler should work with web target configurations when hot and live reloads are enabled, and do hot reload by default when changing own entries: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "one",
   "[webpack-dev-server] App updated. Recompiling...",
@@ -150,7 +150,7 @@ Array [
   "[HMR] Error: Aborted because ./one.js is not accepted
 Update propagation: ./one.js
     <stack>",
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "one",
 ]
@@ -158,7 +158,7 @@ Update propagation: ./one.js
 
 exports[`multi compiler should work with web target configurations when hot and live reloads are enabled, and do hot reload by default when changing own entries: console messages 2`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "two",
   "[webpack-dev-server] App updated. Recompiling...",
@@ -168,7 +168,7 @@ Array [
   "[HMR] Error: Aborted because ./two.js is not accepted
 Update propagation: ./two.js
     <stack>",
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "two",
 ]
@@ -180,7 +180,7 @@ exports[`multi compiler should work with web target configurations when hot and 
 
 exports[`multi compiler should work with web target configurations when only hot reload is enabled, and do hot reload when changing own entries: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading disabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "one",
   "[webpack-dev-server] App updated. Recompiling...",
@@ -190,7 +190,7 @@ Array [
   "[HMR] Error: Aborted because ./one.js is not accepted
 Update propagation: ./one.js
     <stack>",
-  "[webpack-dev-server] server started with Hot Module Replacement, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading disabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "one",
 ]
@@ -198,7 +198,7 @@ Update propagation: ./one.js
 
 exports[`multi compiler should work with web target configurations when only hot reload is enabled, and do hot reload when changing own entries: console messages 2`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading disabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "two",
   "[webpack-dev-server] App updated. Recompiling...",
@@ -208,7 +208,7 @@ Array [
   "[HMR] Error: Aborted because ./two.js is not accepted
 Update propagation: ./two.js
     <stack>",
-  "[webpack-dev-server] server started with Hot Module Replacement, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading disabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "two",
 ]
@@ -220,22 +220,22 @@ exports[`multi compiler should work with web target configurations when only hot
 
 exports[`multi compiler should work with web target configurations when only live reload is enabled and do live reload when changing other entries: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "one",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
-  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "one",
 ]
 `;
 
 exports[`multi compiler should work with web target configurations when only live reload is enabled and do live reload when changing other entries: console messages 2`] = `
 Array [
-  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "two",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
-  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "two",
 ]
 `;
@@ -246,22 +246,22 @@ exports[`multi compiler should work with web target configurations when only liv
 
 exports[`multi compiler should work with web target configurations when only live reload is enabled, and do live reload when changing own entries: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "one",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
-  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "one",
 ]
 `;
 
 exports[`multi compiler should work with web target configurations when only live reload is enabled, and do live reload when changing own entries: console messages 2`] = `
 Array [
-  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "two",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
-  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement disabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "two",
 ]
 `;

--- a/test/e2e/__snapshots__/multi-compiler.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/multi-compiler.test.js.snap.webpack5
@@ -2,11 +2,9 @@
 
 exports[`multi compiler should work with one web target configuration and do nothing: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -14,11 +12,9 @@ exports[`multi compiler should work with one web target configuration and do not
 
 exports[`multi compiler should work with universal configuration and do nothing: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hello from the browser",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -26,11 +22,9 @@ exports[`multi compiler should work with universal configuration and do nothing:
 
 exports[`multi compiler should work with universal configuration when hot and live reloads are enabled, and do hot reload for browser compiler by default when browser entry changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hello from the browser",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
   "[HMR] Checking for updates on the server...",
@@ -38,11 +32,9 @@ Array [
   "[HMR] Error: Aborted because ./browser.js is not accepted
 Update propagation: ./browser.js
     <stack>",
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hello from the browser",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -50,10 +42,9 @@ exports[`multi compiler should work with universal configuration when hot and li
 
 exports[`multi compiler should work with universal configuration when only hot reload is enabled, and do hot reload for browser compiler when browser entry changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hello from the browser",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
   "[HMR] Checking for updates on the server...",
@@ -67,10 +58,9 @@ Update propagation: ./browser.js
     at http://127.0.0.1:8103/browser.js:702:26
     at waitForBlockingPromises (http://127.0.0.1:8103/browser.js:656:48)
     at http://127.0.0.1:8103/browser.js:700:24",
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hello from the browser",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
 ]
 `;
 
@@ -78,27 +68,23 @@ exports[`multi compiler should work with universal configuration when only hot r
 
 exports[`multi compiler should work with universal configuration when only live reload is enabled, and do live reload for browser compiler when changing browser and server entries: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
   "Hello from the browser",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
   "Hello from the browser",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`multi compiler should work with universal configuration when only live reload is enabled, and do live reload for browser compiler when changing browser and server entries: console messages 2`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
   "Hello from the browser",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
   "Hello from the browser",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -108,27 +94,23 @@ exports[`multi compiler should work with universal configuration when only live 
 
 exports[`multi compiler should work with universal configuration when only live reload is enabled, and do live reload for browser compiler when changing server and browser entries: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
   "Hello from the browser",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
   "Hello from the browser",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`multi compiler should work with universal configuration when only live reload is enabled, and do live reload for browser compiler when changing server and browser entries: console messages 2`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
   "Hello from the browser",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
   "Hello from the browser",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -138,21 +120,17 @@ exports[`multi compiler should work with universal configuration when only live 
 
 exports[`multi compiler should work with web target configurations and do nothing: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "one",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`multi compiler should work with web target configurations and do nothing: console messages 2`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "two",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -162,11 +140,9 @@ exports[`multi compiler should work with web target configurations and do nothin
 
 exports[`multi compiler should work with web target configurations when hot and live reloads are enabled, and do hot reload by default when changing own entries: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "one",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
   "[HMR] Checking for updates on the server...",
@@ -174,21 +150,17 @@ Array [
   "[HMR] Error: Aborted because ./one.js is not accepted
 Update propagation: ./one.js
     <stack>",
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "one",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`multi compiler should work with web target configurations when hot and live reloads are enabled, and do hot reload by default when changing own entries: console messages 2`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "two",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
   "[HMR] Checking for updates on the server...",
@@ -196,11 +168,9 @@ Array [
   "[HMR] Error: Aborted because ./two.js is not accepted
 Update propagation: ./two.js
     <stack>",
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "two",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -210,10 +180,9 @@ exports[`multi compiler should work with web target configurations when hot and 
 
 exports[`multi compiler should work with web target configurations when only hot reload is enabled, and do hot reload when changing own entries: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "one",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
   "[HMR] Checking for updates on the server...",
@@ -221,19 +190,17 @@ Array [
   "[HMR] Error: Aborted because ./one.js is not accepted
 Update propagation: ./one.js
     <stack>",
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "one",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
 ]
 `;
 
 exports[`multi compiler should work with web target configurations when only hot reload is enabled, and do hot reload when changing own entries: console messages 2`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "two",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App hot update...",
   "[HMR] Checking for updates on the server...",
@@ -241,10 +208,9 @@ Array [
   "[HMR] Error: Aborted because ./two.js is not accepted
 Update propagation: ./two.js
     <stack>",
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "two",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
 ]
 `;
 
@@ -254,27 +220,25 @@ exports[`multi compiler should work with web target configurations when only hot
 
 exports[`multi compiler should work with web target configurations when only live reload is enabled and do live reload when changing other entries: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
   "one",
-  "[webpack-dev-server] Live Reloading enabled.",
+  "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] Nothing changed.",
+  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
   "one",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`multi compiler should work with web target configurations when only live reload is enabled and do live reload when changing other entries: console messages 2`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
   "two",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
   "two",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -284,27 +248,23 @@ exports[`multi compiler should work with web target configurations when only liv
 
 exports[`multi compiler should work with web target configurations when only live reload is enabled, and do live reload when changing own entries: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
   "one",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
   "one",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`multi compiler should work with web target configurations when only live reload is enabled, and do live reload when changing own entries: console messages 2`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
   "two",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
   "two",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 

--- a/test/e2e/__snapshots__/multi-compiler.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/multi-compiler.test.js.snap.webpack5
@@ -2,6 +2,7 @@
 
 exports[`multi compiler should work with one web target configuration and do nothing: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -13,6 +14,7 @@ exports[`multi compiler should work with one web target configuration and do not
 
 exports[`multi compiler should work with universal configuration and do nothing: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hello from the browser",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -46,6 +48,7 @@ exports[`multi compiler should work with universal configuration when hot and li
 
 exports[`multi compiler should work with universal configuration when only hot reload is enabled, and do hot reload for browser compiler when browser entry changed: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hello from the browser",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -72,10 +75,12 @@ exports[`multi compiler should work with universal configuration when only hot r
 
 exports[`multi compiler should work with universal configuration when only live reload is enabled, and do live reload for browser compiler when changing browser and server entries: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hello from the browser",
   "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hello from the browser",
   "[webpack-dev-server] Live Reloading enabled.",
 ]
@@ -83,10 +88,12 @@ Array [
 
 exports[`multi compiler should work with universal configuration when only live reload is enabled, and do live reload for browser compiler when changing browser and server entries: console messages 2`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hello from the browser",
   "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hello from the browser",
   "[webpack-dev-server] Live Reloading enabled.",
 ]
@@ -98,10 +105,12 @@ exports[`multi compiler should work with universal configuration when only live 
 
 exports[`multi compiler should work with universal configuration when only live reload is enabled, and do live reload for browser compiler when changing server and browser entries: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hello from the browser",
   "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hello from the browser",
   "[webpack-dev-server] Live Reloading enabled.",
 ]
@@ -109,10 +118,12 @@ Array [
 
 exports[`multi compiler should work with universal configuration when only live reload is enabled, and do live reload for browser compiler when changing server and browser entries: console messages 2`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hello from the browser",
   "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hello from the browser",
   "[webpack-dev-server] Live Reloading enabled.",
 ]
@@ -124,6 +135,7 @@ exports[`multi compiler should work with universal configuration when only live 
 
 exports[`multi compiler should work with web target configurations and do nothing: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "one",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -133,6 +145,7 @@ Array [
 
 exports[`multi compiler should work with web target configurations and do nothing: console messages 2`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "two",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -146,6 +159,7 @@ exports[`multi compiler should work with web target configurations and do nothin
 
 exports[`multi compiler should work with web target configurations when hot and live reloads are enabled, and do hot reload by default when changing own entries: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "one",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -157,6 +171,7 @@ Array [
   "[HMR] Error: Aborted because ./one.js is not accepted
 Update propagation: ./one.js
     <stack>",
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "one",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -166,6 +181,7 @@ Update propagation: ./one.js
 
 exports[`multi compiler should work with web target configurations when hot and live reloads are enabled, and do hot reload by default when changing own entries: console messages 2`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "two",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -177,6 +193,7 @@ Array [
   "[HMR] Error: Aborted because ./two.js is not accepted
 Update propagation: ./two.js
     <stack>",
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "two",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -190,6 +207,7 @@ exports[`multi compiler should work with web target configurations when hot and 
 
 exports[`multi compiler should work with web target configurations when only hot reload is enabled, and do hot reload when changing own entries: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "one",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -200,6 +218,7 @@ Array [
   "[HMR] Error: Aborted because ./one.js is not accepted
 Update propagation: ./one.js
     <stack>",
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "one",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -230,10 +249,12 @@ exports[`multi compiler should work with web target configurations when only hot
 
 exports[`multi compiler should work with web target configurations when only live reload is enabled and do live reload when changing other entries: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "one",
   "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "one",
   "[webpack-dev-server] Live Reloading enabled.",
 ]
@@ -241,10 +262,12 @@ Array [
 
 exports[`multi compiler should work with web target configurations when only live reload is enabled and do live reload when changing other entries: console messages 2`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "two",
   "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "two",
   "[webpack-dev-server] Live Reloading enabled.",
 ]
@@ -256,10 +279,12 @@ exports[`multi compiler should work with web target configurations when only liv
 
 exports[`multi compiler should work with web target configurations when only live reload is enabled, and do live reload when changing own entries: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "one",
   "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "one",
   "[webpack-dev-server] Live Reloading enabled.",
 ]
@@ -267,10 +292,12 @@ Array [
 
 exports[`multi compiler should work with web target configurations when only live reload is enabled, and do live reload when changing own entries: console messages 2`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "two",
   "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "two",
   "[webpack-dev-server] Live Reloading enabled.",
 ]

--- a/test/e2e/__snapshots__/multi-compiler.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/multi-compiler.test.js.snap.webpack5
@@ -223,9 +223,7 @@ Array [
   "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
   "one",
   "[webpack-dev-server] App updated. Recompiling...",
-  "[webpack-dev-server] App updated. Recompiling...",
   "[webpack-dev-server] App updated. Reloading...",
-  "[webpack-dev-server] Nothing changed.",
   "[webpack-dev-server] server started with Live Reloading, Overlay enabled.",
   "one",
 ]

--- a/test/e2e/__snapshots__/port.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/port.test.js.snap.webpack4
@@ -2,7 +2,7 @@
 
 exports[`port should work using "<not-specified>" port : console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -12,7 +12,7 @@ exports[`port should work using "<not-specified>" port : page errors 1`] = `Arra
 
 exports[`port should work using "0" port : console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -22,7 +22,7 @@ exports[`port should work using "0" port : page errors 1`] = `Array []`;
 
 exports[`port should work using "8161" port : console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -30,7 +30,7 @@ Array [
 
 exports[`port should work using "8161" port : console messages 2`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -42,7 +42,7 @@ exports[`port should work using "8161" port : page errors 2`] = `Array []`;
 
 exports[`port should work using "auto" port : console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -52,7 +52,7 @@ exports[`port should work using "auto" port : page errors 1`] = `Array []`;
 
 exports[`port should work using "undefined" port : console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]

--- a/test/e2e/__snapshots__/port.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/port.test.js.snap.webpack4
@@ -2,11 +2,9 @@
 
 exports[`port should work using "<not-specified>" port : console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -14,11 +12,9 @@ exports[`port should work using "<not-specified>" port : page errors 1`] = `Arra
 
 exports[`port should work using "0" port : console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -26,21 +22,17 @@ exports[`port should work using "0" port : page errors 1`] = `Array []`;
 
 exports[`port should work using "8161" port : console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`port should work using "8161" port : console messages 2`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -50,11 +42,9 @@ exports[`port should work using "8161" port : page errors 2`] = `Array []`;
 
 exports[`port should work using "auto" port : console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -62,11 +52,9 @@ exports[`port should work using "auto" port : page errors 1`] = `Array []`;
 
 exports[`port should work using "undefined" port : console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 

--- a/test/e2e/__snapshots__/port.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/port.test.js.snap.webpack4
@@ -2,6 +2,7 @@
 
 exports[`port should work using "<not-specified>" port : console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -13,6 +14,7 @@ exports[`port should work using "<not-specified>" port : page errors 1`] = `Arra
 
 exports[`port should work using "0" port : console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -24,6 +26,7 @@ exports[`port should work using "0" port : page errors 1`] = `Array []`;
 
 exports[`port should work using "8161" port : console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -33,6 +36,7 @@ Array [
 
 exports[`port should work using "8161" port : console messages 2`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -46,6 +50,7 @@ exports[`port should work using "8161" port : page errors 2`] = `Array []`;
 
 exports[`port should work using "auto" port : console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -57,6 +62,7 @@ exports[`port should work using "auto" port : page errors 1`] = `Array []`;
 
 exports[`port should work using "undefined" port : console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",

--- a/test/e2e/__snapshots__/port.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/port.test.js.snap.webpack5
@@ -2,7 +2,7 @@
 
 exports[`port should work using "<not-specified>" port : console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -12,7 +12,7 @@ exports[`port should work using "<not-specified>" port : page errors 1`] = `Arra
 
 exports[`port should work using "0" port : console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -22,7 +22,7 @@ exports[`port should work using "0" port : page errors 1`] = `Array []`;
 
 exports[`port should work using "8161" port : console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -30,7 +30,7 @@ Array [
 
 exports[`port should work using "8161" port : console messages 2`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -42,7 +42,7 @@ exports[`port should work using "8161" port : page errors 2`] = `Array []`;
 
 exports[`port should work using "auto" port : console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -52,7 +52,7 @@ exports[`port should work using "auto" port : page errors 1`] = `Array []`;
 
 exports[`port should work using "undefined" port : console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]

--- a/test/e2e/__snapshots__/port.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/port.test.js.snap.webpack5
@@ -2,11 +2,9 @@
 
 exports[`port should work using "<not-specified>" port : console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -14,11 +12,9 @@ exports[`port should work using "<not-specified>" port : page errors 1`] = `Arra
 
 exports[`port should work using "0" port : console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -26,21 +22,17 @@ exports[`port should work using "0" port : page errors 1`] = `Array []`;
 
 exports[`port should work using "8161" port : console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`port should work using "8161" port : console messages 2`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -50,11 +42,9 @@ exports[`port should work using "8161" port : page errors 2`] = `Array []`;
 
 exports[`port should work using "auto" port : console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -62,11 +52,9 @@ exports[`port should work using "auto" port : page errors 1`] = `Array []`;
 
 exports[`port should work using "undefined" port : console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 

--- a/test/e2e/__snapshots__/port.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/port.test.js.snap.webpack5
@@ -2,6 +2,7 @@
 
 exports[`port should work using "<not-specified>" port : console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -13,6 +14,7 @@ exports[`port should work using "<not-specified>" port : page errors 1`] = `Arra
 
 exports[`port should work using "0" port : console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -24,6 +26,7 @@ exports[`port should work using "0" port : page errors 1`] = `Array []`;
 
 exports[`port should work using "8161" port : console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -33,6 +36,7 @@ Array [
 
 exports[`port should work using "8161" port : console messages 2`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -46,6 +50,7 @@ exports[`port should work using "8161" port : page errors 2`] = `Array []`;
 
 exports[`port should work using "auto" port : console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -57,6 +62,7 @@ exports[`port should work using "auto" port : page errors 1`] = `Array []`;
 
 exports[`port should work using "undefined" port : console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",

--- a/test/e2e/__snapshots__/server-and-client-transport.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/server-and-client-transport.test.js.snap.webpack4
@@ -8,6 +8,7 @@ exports[`server and client transport should throw an error on wrong path 1`] = `
 
 exports[`server and client transport should use "sockjs" transport and "sockjs" web socket server 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] Live Reloading enabled.",
@@ -18,6 +19,7 @@ exports[`server and client transport should use "sockjs" transport, when web soc
 
 exports[`server and client transport should use "sockjs" web socket server when specify "sockjs" value 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] Live Reloading enabled.",
@@ -26,6 +28,7 @@ Array [
 
 exports[`server and client transport should use "sockjs" web socket server when specify "sockjs" value using object 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] Live Reloading enabled.",
@@ -34,6 +37,7 @@ Array [
 
 exports[`server and client transport should use "ws" transport and "ws" web socket server 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] Live Reloading enabled.",
@@ -42,6 +46,7 @@ Array [
 
 exports[`server and client transport should use "ws" transport, when web socket server is not specify 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] Live Reloading enabled.",
@@ -50,6 +55,7 @@ Array [
 
 exports[`server and client transport should use "ws" web socket server when specify "ws" value 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] Live Reloading enabled.",
@@ -58,6 +64,7 @@ Array [
 
 exports[`server and client transport should use "ws" web socket server when specify "ws" value using object 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] Live Reloading enabled.",
@@ -66,6 +73,7 @@ Array [
 
 exports[`server and client transport should use custom transport and "sockjs" web socket server 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "open",
   "hot",
@@ -81,6 +89,7 @@ Array [
 
 exports[`server and client transport should use custom web socket server when specify class 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] Live Reloading enabled.",
@@ -89,6 +98,7 @@ Array [
 
 exports[`server and client transport should use custom web socket server when specify class using object 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] Live Reloading enabled.",
@@ -97,6 +107,7 @@ Array [
 
 exports[`server and client transport should use custom web socket server when specify path to class 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] Live Reloading enabled.",
@@ -105,6 +116,7 @@ Array [
 
 exports[`server and client transport should use custom web socket server when specify path to class using object 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] Live Reloading enabled.",
@@ -113,6 +125,7 @@ Array [
 
 exports[`server and client transport should use default web socket server ("ws") 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] Live Reloading enabled.",

--- a/test/e2e/__snapshots__/server-and-client-transport.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/server-and-client-transport.test.js.snap.webpack4
@@ -8,7 +8,7 @@ exports[`server and client transport should throw an error on wrong path 1`] = `
 
 exports[`server and client transport should use "sockjs" transport and "sockjs" web socket server 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
 ]
 `;
@@ -17,49 +17,49 @@ exports[`server and client transport should use "sockjs" transport, when web soc
 
 exports[`server and client transport should use "sockjs" web socket server when specify "sockjs" value 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
 ]
 `;
 
 exports[`server and client transport should use "sockjs" web socket server when specify "sockjs" value using object 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
 ]
 `;
 
 exports[`server and client transport should use "ws" transport and "ws" web socket server 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
 ]
 `;
 
 exports[`server and client transport should use "ws" transport, when web socket server is not specify 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
 ]
 `;
 
 exports[`server and client transport should use "ws" web socket server when specify "ws" value 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
 ]
 `;
 
 exports[`server and client transport should use "ws" web socket server when specify "ws" value using object 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
 ]
 `;
 
 exports[`server and client transport should use custom transport and "sockjs" web socket server 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "open",
   "hot",
@@ -73,35 +73,35 @@ Array [
 
 exports[`server and client transport should use custom web socket server when specify class 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
 ]
 `;
 
 exports[`server and client transport should use custom web socket server when specify class using object 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
 ]
 `;
 
 exports[`server and client transport should use custom web socket server when specify path to class 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
 ]
 `;
 
 exports[`server and client transport should use custom web socket server when specify path to class using object 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
 ]
 `;
 
 exports[`server and client transport should use default web socket server ("ws") 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
 ]
 `;

--- a/test/e2e/__snapshots__/server-and-client-transport.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/server-and-client-transport.test.js.snap.webpack4
@@ -8,10 +8,8 @@ exports[`server and client transport should throw an error on wrong path 1`] = `
 
 exports[`server and client transport should use "sockjs" transport and "sockjs" web socket server 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -19,67 +17,53 @@ exports[`server and client transport should use "sockjs" transport, when web soc
 
 exports[`server and client transport should use "sockjs" web socket server when specify "sockjs" value 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`server and client transport should use "sockjs" web socket server when specify "sockjs" value using object 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`server and client transport should use "ws" transport and "ws" web socket server 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`server and client transport should use "ws" transport, when web socket server is not specify 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`server and client transport should use "ws" web socket server when specify "ws" value 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`server and client transport should use "ws" web socket server when specify "ws" value using object 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`server and client transport should use custom transport and "sockjs" web socket server 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "open",
   "hot",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
   "liveReload",
-  "[webpack-dev-server] Live Reloading enabled.",
   "reconnect",
   "overlay",
   "hash",
@@ -89,45 +73,35 @@ Array [
 
 exports[`server and client transport should use custom web socket server when specify class 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`server and client transport should use custom web socket server when specify class using object 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`server and client transport should use custom web socket server when specify path to class 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`server and client transport should use custom web socket server when specify path to class using object 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`server and client transport should use default web socket server ("ws") 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;

--- a/test/e2e/__snapshots__/server-and-client-transport.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/server-and-client-transport.test.js.snap.webpack5
@@ -8,6 +8,7 @@ exports[`server and client transport should throw an error on wrong path 1`] = `
 
 exports[`server and client transport should use "sockjs" transport and "sockjs" web socket server 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] Live Reloading enabled.",
@@ -18,6 +19,7 @@ exports[`server and client transport should use "sockjs" transport, when web soc
 
 exports[`server and client transport should use "sockjs" web socket server when specify "sockjs" value 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] Live Reloading enabled.",
@@ -26,6 +28,7 @@ Array [
 
 exports[`server and client transport should use "sockjs" web socket server when specify "sockjs" value using object 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] Live Reloading enabled.",
@@ -34,6 +37,7 @@ Array [
 
 exports[`server and client transport should use "ws" transport and "ws" web socket server 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] Live Reloading enabled.",
@@ -42,6 +46,7 @@ Array [
 
 exports[`server and client transport should use "ws" transport, when web socket server is not specify 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] Live Reloading enabled.",
@@ -50,6 +55,7 @@ Array [
 
 exports[`server and client transport should use "ws" web socket server when specify "ws" value 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] Live Reloading enabled.",
@@ -58,6 +64,7 @@ Array [
 
 exports[`server and client transport should use "ws" web socket server when specify "ws" value using object 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] Live Reloading enabled.",
@@ -66,6 +73,7 @@ Array [
 
 exports[`server and client transport should use custom transport and "sockjs" web socket server 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "open",
   "hot",
@@ -81,6 +89,7 @@ Array [
 
 exports[`server and client transport should use custom web socket server when specify class 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] Live Reloading enabled.",
@@ -89,6 +98,7 @@ Array [
 
 exports[`server and client transport should use custom web socket server when specify class using object 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] Live Reloading enabled.",
@@ -97,6 +107,7 @@ Array [
 
 exports[`server and client transport should use custom web socket server when specify path to class 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] Live Reloading enabled.",
@@ -105,6 +116,7 @@ Array [
 
 exports[`server and client transport should use custom web socket server when specify path to class using object 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] Live Reloading enabled.",
@@ -113,6 +125,7 @@ Array [
 
 exports[`server and client transport should use default web socket server ("ws") 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "[webpack-dev-server] Hot Module Replacement enabled.",
   "[webpack-dev-server] Live Reloading enabled.",

--- a/test/e2e/__snapshots__/server-and-client-transport.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/server-and-client-transport.test.js.snap.webpack5
@@ -8,7 +8,7 @@ exports[`server and client transport should throw an error on wrong path 1`] = `
 
 exports[`server and client transport should use "sockjs" transport and "sockjs" web socket server 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
 ]
 `;
@@ -17,49 +17,49 @@ exports[`server and client transport should use "sockjs" transport, when web soc
 
 exports[`server and client transport should use "sockjs" web socket server when specify "sockjs" value 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
 ]
 `;
 
 exports[`server and client transport should use "sockjs" web socket server when specify "sockjs" value using object 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
 ]
 `;
 
 exports[`server and client transport should use "ws" transport and "ws" web socket server 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
 ]
 `;
 
 exports[`server and client transport should use "ws" transport, when web socket server is not specify 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
 ]
 `;
 
 exports[`server and client transport should use "ws" web socket server when specify "ws" value 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
 ]
 `;
 
 exports[`server and client transport should use "ws" web socket server when specify "ws" value using object 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
 ]
 `;
 
 exports[`server and client transport should use custom transport and "sockjs" web socket server 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "open",
   "hot",
@@ -73,35 +73,35 @@ Array [
 
 exports[`server and client transport should use custom web socket server when specify class 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
 ]
 `;
 
 exports[`server and client transport should use custom web socket server when specify class using object 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
 ]
 `;
 
 exports[`server and client transport should use custom web socket server when specify path to class 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
 ]
 `;
 
 exports[`server and client transport should use custom web socket server when specify path to class using object 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
 ]
 `;
 
 exports[`server and client transport should use default web socket server ("ws") 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
 ]
 `;

--- a/test/e2e/__snapshots__/server-and-client-transport.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/server-and-client-transport.test.js.snap.webpack5
@@ -8,10 +8,8 @@ exports[`server and client transport should throw an error on wrong path 1`] = `
 
 exports[`server and client transport should use "sockjs" transport and "sockjs" web socket server 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -19,67 +17,53 @@ exports[`server and client transport should use "sockjs" transport, when web soc
 
 exports[`server and client transport should use "sockjs" web socket server when specify "sockjs" value 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`server and client transport should use "sockjs" web socket server when specify "sockjs" value using object 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`server and client transport should use "ws" transport and "ws" web socket server 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`server and client transport should use "ws" transport, when web socket server is not specify 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`server and client transport should use "ws" web socket server when specify "ws" value 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`server and client transport should use "ws" web socket server when specify "ws" value using object 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`server and client transport should use custom transport and "sockjs" web socket server 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "open",
   "hot",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
   "liveReload",
-  "[webpack-dev-server] Live Reloading enabled.",
   "reconnect",
   "overlay",
   "hash",
@@ -89,45 +73,35 @@ Array [
 
 exports[`server and client transport should use custom web socket server when specify class 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`server and client transport should use custom web socket server when specify class using object 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`server and client transport should use custom web socket server when specify path to class 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`server and client transport should use custom web socket server when specify path to class using object 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`server and client transport should use default web socket server ("ws") 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;

--- a/test/e2e/__snapshots__/setup-exit-signals.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/setup-exit-signals.test.js.snap.webpack4
@@ -2,6 +2,7 @@
 
 exports[`setupExitSignals option should handle 'SIGINT' and 'SIGTERM' signals should close and exit on SIGINT: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -15,6 +16,7 @@ exports[`setupExitSignals option should handle 'SIGINT' and 'SIGTERM' signals sh
 
 exports[`setupExitSignals option should handle 'SIGINT' and 'SIGTERM' signals should close and exit on SIGTERM: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",

--- a/test/e2e/__snapshots__/setup-exit-signals.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/setup-exit-signals.test.js.snap.webpack4
@@ -2,7 +2,7 @@
 
 exports[`setupExitSignals option should handle 'SIGINT' and 'SIGTERM' signals should close and exit on SIGINT: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -14,7 +14,7 @@ exports[`setupExitSignals option should handle 'SIGINT' and 'SIGTERM' signals sh
 
 exports[`setupExitSignals option should handle 'SIGINT' and 'SIGTERM' signals should close and exit on SIGTERM: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]

--- a/test/e2e/__snapshots__/setup-exit-signals.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/setup-exit-signals.test.js.snap.webpack4
@@ -2,11 +2,9 @@
 
 exports[`setupExitSignals option should handle 'SIGINT' and 'SIGTERM' signals should close and exit on SIGINT: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -16,11 +14,9 @@ exports[`setupExitSignals option should handle 'SIGINT' and 'SIGTERM' signals sh
 
 exports[`setupExitSignals option should handle 'SIGINT' and 'SIGTERM' signals should close and exit on SIGTERM: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 

--- a/test/e2e/__snapshots__/setup-exit-signals.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/setup-exit-signals.test.js.snap.webpack5
@@ -2,6 +2,7 @@
 
 exports[`setupExitSignals option should handle 'SIGINT' and 'SIGTERM' signals should close and exit on SIGINT: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -15,6 +16,7 @@ exports[`setupExitSignals option should handle 'SIGINT' and 'SIGTERM' signals sh
 
 exports[`setupExitSignals option should handle 'SIGINT' and 'SIGTERM' signals should close and exit on SIGTERM: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",

--- a/test/e2e/__snapshots__/setup-exit-signals.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/setup-exit-signals.test.js.snap.webpack5
@@ -2,7 +2,7 @@
 
 exports[`setupExitSignals option should handle 'SIGINT' and 'SIGTERM' signals should close and exit on SIGINT: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -14,7 +14,7 @@ exports[`setupExitSignals option should handle 'SIGINT' and 'SIGTERM' signals sh
 
 exports[`setupExitSignals option should handle 'SIGINT' and 'SIGTERM' signals should close and exit on SIGTERM: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]

--- a/test/e2e/__snapshots__/setup-exit-signals.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/setup-exit-signals.test.js.snap.webpack5
@@ -2,11 +2,9 @@
 
 exports[`setupExitSignals option should handle 'SIGINT' and 'SIGTERM' signals should close and exit on SIGINT: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -16,11 +14,9 @@ exports[`setupExitSignals option should handle 'SIGINT' and 'SIGTERM' signals sh
 
 exports[`setupExitSignals option should handle 'SIGINT' and 'SIGTERM' signals should close and exit on SIGTERM: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 

--- a/test/e2e/__snapshots__/stats.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/stats.test.js.snap.webpack4
@@ -1,13 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`stats should work and respect the "ignoreWarnings" option 1`] = `
-Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
-  "[HMR] Waiting for update signal from WDS...",
-  "Hey.",
-]
-`;
-
 exports[`stats should work using "{ assets: false }" value for the "stats" option 1`] = `
 Array [
   "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",

--- a/test/e2e/__snapshots__/stats.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/stats.test.js.snap.webpack4
@@ -2,6 +2,7 @@
 
 exports[`stats should work using "{ assets: false }" value for the "stats" option 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -11,6 +12,7 @@ Array [
 
 exports[`stats should work using "{ assets: false }" value for the "stats" option 2`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -20,6 +22,7 @@ Array [
 
 exports[`stats should work using "{ warningsFilter: 'test' }" value for the "stats" option 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -29,6 +32,7 @@ Array [
 
 exports[`stats should work using "{}" value for the "stats" option 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -38,6 +42,7 @@ Array [
 
 exports[`stats should work using "errors-only" value for the "stats" option 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -47,6 +52,7 @@ Array [
 
 exports[`stats should work using "false" value for the "stats" option 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -56,6 +62,7 @@ Array [
 
 exports[`stats should work using "undefined" value for the "stats" option 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -65,6 +72,7 @@ Array [
 
 exports[`stats should work when "stats" is not specified 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",

--- a/test/e2e/__snapshots__/stats.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/stats.test.js.snap.webpack4
@@ -1,81 +1,73 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`stats should work using "{ assets: false }" value for the "stats" option 1`] = `
+exports[`stats should work and respect the "ignoreWarnings" option 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
+]
+`;
+
+exports[`stats should work using "{ assets: false }" value for the "stats" option 1`] = `
+Array [
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[HMR] Waiting for update signal from WDS...",
+  "Hey.",
 ]
 `;
 
 exports[`stats should work using "{ assets: false }" value for the "stats" option 2`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`stats should work using "{ warningsFilter: 'test' }" value for the "stats" option 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`stats should work using "{}" value for the "stats" option 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`stats should work using "errors-only" value for the "stats" option 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`stats should work using "false" value for the "stats" option 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`stats should work using "undefined" value for the "stats" option 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`stats should work when "stats" is not specified 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;

--- a/test/e2e/__snapshots__/stats.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/stats.test.js.snap.webpack4
@@ -2,7 +2,7 @@
 
 exports[`stats should work using "{ assets: false }" value for the "stats" option 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -10,7 +10,7 @@ Array [
 
 exports[`stats should work using "{ assets: false }" value for the "stats" option 2`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -18,7 +18,7 @@ Array [
 
 exports[`stats should work using "{ warningsFilter: 'test' }" value for the "stats" option 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -26,7 +26,7 @@ Array [
 
 exports[`stats should work using "{}" value for the "stats" option 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -34,7 +34,7 @@ Array [
 
 exports[`stats should work using "errors-only" value for the "stats" option 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -42,7 +42,7 @@ Array [
 
 exports[`stats should work using "false" value for the "stats" option 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -50,7 +50,7 @@ Array [
 
 exports[`stats should work using "undefined" value for the "stats" option 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -58,7 +58,7 @@ Array [
 
 exports[`stats should work when "stats" is not specified 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]

--- a/test/e2e/__snapshots__/stats.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/stats.test.js.snap.webpack5
@@ -2,7 +2,7 @@
 
 exports[`stats should work and respect the "ignoreWarnings" option 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -10,7 +10,7 @@ Array [
 
 exports[`stats should work using "{ assets: false }" value for the "stats" option 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -18,7 +18,7 @@ Array [
 
 exports[`stats should work using "{ assets: false }" value for the "stats" option 2`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -26,7 +26,7 @@ Array [
 
 exports[`stats should work using "{ warningsFilter: 'test' }" value for the "stats" option 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -34,7 +34,7 @@ Array [
 
 exports[`stats should work using "{}" value for the "stats" option 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -42,7 +42,7 @@ Array [
 
 exports[`stats should work using "errors-only" value for the "stats" option 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -50,7 +50,7 @@ Array [
 
 exports[`stats should work using "false" value for the "stats" option 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -58,7 +58,7 @@ Array [
 
 exports[`stats should work using "undefined" value for the "stats" option 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -66,7 +66,7 @@ Array [
 
 exports[`stats should work when "stats" is not specified 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]

--- a/test/e2e/__snapshots__/stats.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/stats.test.js.snap.webpack5
@@ -2,90 +2,72 @@
 
 exports[`stats should work and respect the "ignoreWarnings" option 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`stats should work using "{ assets: false }" value for the "stats" option 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`stats should work using "{ assets: false }" value for the "stats" option 2`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`stats should work using "{ warningsFilter: 'test' }" value for the "stats" option 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`stats should work using "{}" value for the "stats" option 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`stats should work using "errors-only" value for the "stats" option 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`stats should work using "false" value for the "stats" option 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`stats should work using "undefined" value for the "stats" option 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`stats should work when "stats" is not specified 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;

--- a/test/e2e/__snapshots__/stats.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/stats.test.js.snap.webpack5
@@ -2,6 +2,7 @@
 
 exports[`stats should work and respect the "ignoreWarnings" option 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -11,6 +12,7 @@ Array [
 
 exports[`stats should work using "{ assets: false }" value for the "stats" option 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -20,6 +22,7 @@ Array [
 
 exports[`stats should work using "{ assets: false }" value for the "stats" option 2`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -29,6 +32,7 @@ Array [
 
 exports[`stats should work using "{ warningsFilter: 'test' }" value for the "stats" option 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -38,6 +42,7 @@ Array [
 
 exports[`stats should work using "{}" value for the "stats" option 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -47,6 +52,7 @@ Array [
 
 exports[`stats should work using "errors-only" value for the "stats" option 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -56,6 +62,7 @@ Array [
 
 exports[`stats should work using "false" value for the "stats" option 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -65,6 +72,7 @@ Array [
 
 exports[`stats should work using "undefined" value for the "stats" option 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -74,6 +82,7 @@ Array [
 
 exports[`stats should work when "stats" is not specified 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",

--- a/test/e2e/__snapshots__/target.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/target.test.js.snap.webpack4
@@ -2,35 +2,71 @@
 
 exports[`target should work using "async-node" target: console messages 1`] = `Array []`;
 
+exports[`target should work using "browserslist:defaults" target: console messages 1`] = `
+Array [
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[HMR] Waiting for update signal from WDS...",
+  "Hey.",
+]
+`;
+
+exports[`target should work using "browserslist:defaults" target: page errors 1`] = `Array []`;
+
 exports[`target should work using "electron-main" target: console messages 1`] = `Array []`;
 
 exports[`target should work using "electron-preload" target: console messages 1`] = `Array []`;
 
 exports[`target should work using "electron-renderer" target: console messages 1`] = `Array []`;
 
+exports[`target should work using "es5" target: console messages 1`] = `
+Array [
+  "[HMR] Waiting for update signal from WDS...",
+  "Hey.",
+]
+`;
+
+exports[`target should work using "es5" target: page errors 1`] = `Array []`;
+
+exports[`target should work using "false" target: console messages 1`] = `
+Array [
+  "[HMR] Waiting for update signal from WDS...",
+  "Hey.",
+]
+`;
+
+exports[`target should work using "false" target: page errors 1`] = `Array []`;
+
 exports[`target should work using "node" target: console messages 1`] = `Array []`;
 
 exports[`target should work using "node-webkit" target: console messages 1`] = `Array []`;
 
+exports[`target should work using "nwjs" target: console messages 1`] = `Array []`;
+
 exports[`target should work using "web" target: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
 exports[`target should work using "web" target: page errors 1`] = `Array []`;
 
-exports[`target should work using "webworker" target: console messages 1`] = `
+exports[`target should work using "web,es5" target: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
+]
+`;
+
+exports[`target should work using "web,es5" target: page errors 1`] = `Array []`;
+
+exports[`target should work using "webworker" target: console messages 1`] = `
+Array [
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[HMR] Waiting for update signal from WDS...",
+  "Hey.",
 ]
 `;
 

--- a/test/e2e/__snapshots__/target.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/target.test.js.snap.webpack4
@@ -2,45 +2,15 @@
 
 exports[`target should work using "async-node" target: console messages 1`] = `Array []`;
 
-exports[`target should work using "browserslist:defaults" target: console messages 1`] = `
-Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
-  "[HMR] Waiting for update signal from WDS...",
-  "Hey.",
-]
-`;
-
-exports[`target should work using "browserslist:defaults" target: page errors 1`] = `Array []`;
-
 exports[`target should work using "electron-main" target: console messages 1`] = `Array []`;
 
 exports[`target should work using "electron-preload" target: console messages 1`] = `Array []`;
 
 exports[`target should work using "electron-renderer" target: console messages 1`] = `Array []`;
 
-exports[`target should work using "es5" target: console messages 1`] = `
-Array [
-  "[HMR] Waiting for update signal from WDS...",
-  "Hey.",
-]
-`;
-
-exports[`target should work using "es5" target: page errors 1`] = `Array []`;
-
-exports[`target should work using "false" target: console messages 1`] = `
-Array [
-  "[HMR] Waiting for update signal from WDS...",
-  "Hey.",
-]
-`;
-
-exports[`target should work using "false" target: page errors 1`] = `Array []`;
-
 exports[`target should work using "node" target: console messages 1`] = `Array []`;
 
 exports[`target should work using "node-webkit" target: console messages 1`] = `Array []`;
-
-exports[`target should work using "nwjs" target: console messages 1`] = `Array []`;
 
 exports[`target should work using "web" target: console messages 1`] = `
 Array [
@@ -51,16 +21,6 @@ Array [
 `;
 
 exports[`target should work using "web" target: page errors 1`] = `Array []`;
-
-exports[`target should work using "web,es5" target: console messages 1`] = `
-Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
-  "[HMR] Waiting for update signal from WDS...",
-  "Hey.",
-]
-`;
-
-exports[`target should work using "web,es5" target: page errors 1`] = `Array []`;
 
 exports[`target should work using "webworker" target: console messages 1`] = `
 Array [

--- a/test/e2e/__snapshots__/target.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/target.test.js.snap.webpack4
@@ -14,6 +14,7 @@ exports[`target should work using "node-webkit" target: console messages 1`] = `
 
 exports[`target should work using "web" target: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -25,6 +26,7 @@ exports[`target should work using "web" target: page errors 1`] = `Array []`;
 
 exports[`target should work using "webworker" target: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",

--- a/test/e2e/__snapshots__/target.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/target.test.js.snap.webpack4
@@ -14,7 +14,7 @@ exports[`target should work using "node-webkit" target: console messages 1`] = `
 
 exports[`target should work using "web" target: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -24,7 +24,7 @@ exports[`target should work using "web" target: page errors 1`] = `Array []`;
 
 exports[`target should work using "webworker" target: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]

--- a/test/e2e/__snapshots__/target.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/target.test.js.snap.webpack5
@@ -4,11 +4,9 @@ exports[`target should work using "async-node" target: console messages 1`] = `A
 
 exports[`target should work using "browserslist:defaults" target: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -46,11 +44,9 @@ exports[`target should work using "nwjs" target: console messages 1`] = `Array [
 
 exports[`target should work using "web" target: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -58,11 +54,9 @@ exports[`target should work using "web" target: page errors 1`] = `Array []`;
 
 exports[`target should work using "web,es5" target: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -70,11 +64,9 @@ exports[`target should work using "web,es5" target: page errors 1`] = `Array []`
 
 exports[`target should work using "webworker" target: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 

--- a/test/e2e/__snapshots__/target.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/target.test.js.snap.webpack5
@@ -4,6 +4,7 @@ exports[`target should work using "async-node" target: console messages 1`] = `A
 
 exports[`target should work using "browserslist:defaults" target: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -45,6 +46,7 @@ exports[`target should work using "nwjs" target: console messages 1`] = `Array [
 
 exports[`target should work using "web" target: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -56,6 +58,7 @@ exports[`target should work using "web" target: page errors 1`] = `Array []`;
 
 exports[`target should work using "web,es5" target: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -67,6 +70,7 @@ exports[`target should work using "web,es5" target: page errors 1`] = `Array []`
 
 exports[`target should work using "webworker" target: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",

--- a/test/e2e/__snapshots__/target.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/target.test.js.snap.webpack5
@@ -4,7 +4,7 @@ exports[`target should work using "async-node" target: console messages 1`] = `A
 
 exports[`target should work using "browserslist:defaults" target: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -44,7 +44,7 @@ exports[`target should work using "nwjs" target: console messages 1`] = `Array [
 
 exports[`target should work using "web" target: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -54,7 +54,7 @@ exports[`target should work using "web" target: page errors 1`] = `Array []`;
 
 exports[`target should work using "web,es5" target: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -64,7 +64,7 @@ exports[`target should work using "web,es5" target: page errors 1`] = `Array []`
 
 exports[`target should work using "webworker" target: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]

--- a/test/e2e/__snapshots__/watch-files.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/watch-files.test.js.snap.webpack4
@@ -302,6 +302,7 @@ exports[`watchFiles option should work with string and path to directory should 
 
 exports[`watchFiles option should work with string and path to file should reload when file content is changed: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hey.",
 ]
 `;

--- a/test/e2e/__snapshots__/watch-files.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/watch-files.test.js.snap.webpack4
@@ -2,6 +2,7 @@
 
 exports[`watchFiles option should not crash if file doesn't exist should reload when file content is changed: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hey.",
 ]
 `;
@@ -12,6 +13,7 @@ exports[`watchFiles option should not crash if file doesn't exist should reload 
 
 exports[`watchFiles option should work with array config should reload when file content is changed: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hey.",
 ]
 `;
@@ -22,6 +24,7 @@ exports[`watchFiles option should work with array config should reload when file
 
 exports[`watchFiles option should work with object with multiple paths should reload when file content is changed: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hey.",
 ]
 `;
@@ -32,6 +35,7 @@ exports[`watchFiles option should work with object with multiple paths should re
 
 exports[`watchFiles option should work with object with single path should reload when file content is changed: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hey.",
 ]
 `;
@@ -56,6 +60,7 @@ Object {
 
 exports[`watchFiles option should work with options {"interval":400,"poll":200} should reload when file content is changed: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hey.",
 ]
 `;
@@ -80,6 +85,7 @@ Object {
 
 exports[`watchFiles option should work with options {"poll":200} should reload when file content is changed: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hey.",
 ]
 `;
@@ -104,6 +110,7 @@ Object {
 
 exports[`watchFiles option should work with options {"poll":true} should reload when file content is changed: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hey.",
 ]
 `;
@@ -128,6 +135,7 @@ Object {
 
 exports[`watchFiles option should work with options {"usePolling":false,"interval":200,"poll":400} should reload when file content is changed: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hey.",
 ]
 `;
@@ -152,6 +160,7 @@ Object {
 
 exports[`watchFiles option should work with options {"usePolling":false,"poll":200} should reload when file content is changed: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hey.",
 ]
 `;
@@ -176,6 +185,7 @@ Object {
 
 exports[`watchFiles option should work with options {"usePolling":false,"poll":true} should reload when file content is changed: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hey.",
 ]
 `;
@@ -200,6 +210,7 @@ Object {
 
 exports[`watchFiles option should work with options {"usePolling":false} should reload when file content is changed: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hey.",
 ]
 `;
@@ -224,6 +235,7 @@ Object {
 
 exports[`watchFiles option should work with options {"usePolling":true,"interval":200,"poll":400} should reload when file content is changed: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hey.",
 ]
 `;
@@ -248,6 +260,7 @@ Object {
 
 exports[`watchFiles option should work with options {"usePolling":true,"poll":200} should reload when file content is changed: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hey.",
 ]
 `;
@@ -272,6 +285,7 @@ Object {
 
 exports[`watchFiles option should work with options {"usePolling":true} should reload when file content is changed: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hey.",
 ]
 `;
@@ -282,6 +296,7 @@ exports[`watchFiles option should work with options {"usePolling":true} should r
 
 exports[`watchFiles option should work with string and glob should reload when file content is changed: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hey.",
 ]
 `;
@@ -292,6 +307,7 @@ exports[`watchFiles option should work with string and glob should reload when f
 
 exports[`watchFiles option should work with string and path to directory should reload when file content is changed: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hey.",
 ]
 `;

--- a/test/e2e/__snapshots__/watch-files.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/watch-files.test.js.snap.webpack4
@@ -2,7 +2,7 @@
 
 exports[`watchFiles option should not crash if file doesn't exist should reload when file content is changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -13,7 +13,7 @@ exports[`watchFiles option should not crash if file doesn't exist should reload 
 
 exports[`watchFiles option should work with array config should reload when file content is changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -24,7 +24,7 @@ exports[`watchFiles option should work with array config should reload when file
 
 exports[`watchFiles option should work with object with multiple paths should reload when file content is changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -35,7 +35,7 @@ exports[`watchFiles option should work with object with multiple paths should re
 
 exports[`watchFiles option should work with object with single path should reload when file content is changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -60,7 +60,7 @@ Object {
 
 exports[`watchFiles option should work with options {"interval":400,"poll":200} should reload when file content is changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -85,7 +85,7 @@ Object {
 
 exports[`watchFiles option should work with options {"poll":200} should reload when file content is changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -110,7 +110,7 @@ Object {
 
 exports[`watchFiles option should work with options {"poll":true} should reload when file content is changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -135,7 +135,7 @@ Object {
 
 exports[`watchFiles option should work with options {"usePolling":false,"interval":200,"poll":400} should reload when file content is changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -160,7 +160,7 @@ Object {
 
 exports[`watchFiles option should work with options {"usePolling":false,"poll":200} should reload when file content is changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -185,7 +185,7 @@ Object {
 
 exports[`watchFiles option should work with options {"usePolling":false,"poll":true} should reload when file content is changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -210,7 +210,7 @@ Object {
 
 exports[`watchFiles option should work with options {"usePolling":false} should reload when file content is changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -235,7 +235,7 @@ Object {
 
 exports[`watchFiles option should work with options {"usePolling":true,"interval":200,"poll":400} should reload when file content is changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -260,7 +260,7 @@ Object {
 
 exports[`watchFiles option should work with options {"usePolling":true,"poll":200} should reload when file content is changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -285,7 +285,7 @@ Object {
 
 exports[`watchFiles option should work with options {"usePolling":true} should reload when file content is changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -296,7 +296,7 @@ exports[`watchFiles option should work with options {"usePolling":true} should r
 
 exports[`watchFiles option should work with string and glob should reload when file content is changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -307,7 +307,7 @@ exports[`watchFiles option should work with string and glob should reload when f
 
 exports[`watchFiles option should work with string and path to directory should reload when file content is changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -318,7 +318,7 @@ exports[`watchFiles option should work with string and path to directory should 
 
 exports[`watchFiles option should work with string and path to file should reload when file content is changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "Hey.",
 ]
 `;

--- a/test/e2e/__snapshots__/watch-files.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/watch-files.test.js.snap.webpack4
@@ -2,7 +2,7 @@
 
 exports[`watchFiles option should not crash if file doesn't exist should reload when file content is changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -13,7 +13,7 @@ exports[`watchFiles option should not crash if file doesn't exist should reload 
 
 exports[`watchFiles option should work with array config should reload when file content is changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -24,7 +24,7 @@ exports[`watchFiles option should work with array config should reload when file
 
 exports[`watchFiles option should work with object with multiple paths should reload when file content is changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -35,7 +35,7 @@ exports[`watchFiles option should work with object with multiple paths should re
 
 exports[`watchFiles option should work with object with single path should reload when file content is changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -60,7 +60,7 @@ Object {
 
 exports[`watchFiles option should work with options {"interval":400,"poll":200} should reload when file content is changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -85,7 +85,7 @@ Object {
 
 exports[`watchFiles option should work with options {"poll":200} should reload when file content is changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -110,7 +110,7 @@ Object {
 
 exports[`watchFiles option should work with options {"poll":true} should reload when file content is changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -135,7 +135,7 @@ Object {
 
 exports[`watchFiles option should work with options {"usePolling":false,"interval":200,"poll":400} should reload when file content is changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -160,7 +160,7 @@ Object {
 
 exports[`watchFiles option should work with options {"usePolling":false,"poll":200} should reload when file content is changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -185,7 +185,7 @@ Object {
 
 exports[`watchFiles option should work with options {"usePolling":false,"poll":true} should reload when file content is changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -210,7 +210,7 @@ Object {
 
 exports[`watchFiles option should work with options {"usePolling":false} should reload when file content is changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -235,7 +235,7 @@ Object {
 
 exports[`watchFiles option should work with options {"usePolling":true,"interval":200,"poll":400} should reload when file content is changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -260,7 +260,7 @@ Object {
 
 exports[`watchFiles option should work with options {"usePolling":true,"poll":200} should reload when file content is changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -285,7 +285,7 @@ Object {
 
 exports[`watchFiles option should work with options {"usePolling":true} should reload when file content is changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -296,7 +296,7 @@ exports[`watchFiles option should work with options {"usePolling":true} should r
 
 exports[`watchFiles option should work with string and glob should reload when file content is changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -307,7 +307,7 @@ exports[`watchFiles option should work with string and glob should reload when f
 
 exports[`watchFiles option should work with string and path to directory should reload when file content is changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -318,7 +318,7 @@ exports[`watchFiles option should work with string and path to directory should 
 
 exports[`watchFiles option should work with string and path to file should reload when file content is changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "Hey.",
 ]
 `;

--- a/test/e2e/__snapshots__/watch-files.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/watch-files.test.js.snap.webpack5
@@ -2,6 +2,7 @@
 
 exports[`watchFiles option should not crash if file doesn't exist should reload when file content is changed: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hey.",
 ]
 `;
@@ -12,6 +13,7 @@ exports[`watchFiles option should not crash if file doesn't exist should reload 
 
 exports[`watchFiles option should work with array config should reload when file content is changed: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hey.",
 ]
 `;
@@ -22,6 +24,7 @@ exports[`watchFiles option should work with array config should reload when file
 
 exports[`watchFiles option should work with object with multiple paths should reload when file content is changed: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hey.",
 ]
 `;
@@ -32,6 +35,7 @@ exports[`watchFiles option should work with object with multiple paths should re
 
 exports[`watchFiles option should work with object with single path should reload when file content is changed: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hey.",
 ]
 `;
@@ -56,6 +60,7 @@ Object {
 
 exports[`watchFiles option should work with options {"interval":400,"poll":200} should reload when file content is changed: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hey.",
 ]
 `;
@@ -80,6 +85,7 @@ Object {
 
 exports[`watchFiles option should work with options {"poll":200} should reload when file content is changed: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hey.",
 ]
 `;
@@ -104,6 +110,7 @@ Object {
 
 exports[`watchFiles option should work with options {"poll":true} should reload when file content is changed: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hey.",
 ]
 `;
@@ -128,6 +135,7 @@ Object {
 
 exports[`watchFiles option should work with options {"usePolling":false,"interval":200,"poll":400} should reload when file content is changed: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hey.",
 ]
 `;
@@ -152,6 +160,7 @@ Object {
 
 exports[`watchFiles option should work with options {"usePolling":false,"poll":200} should reload when file content is changed: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hey.",
 ]
 `;
@@ -176,6 +185,7 @@ Object {
 
 exports[`watchFiles option should work with options {"usePolling":false,"poll":true} should reload when file content is changed: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hey.",
 ]
 `;
@@ -200,6 +210,7 @@ Object {
 
 exports[`watchFiles option should work with options {"usePolling":false} should reload when file content is changed: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hey.",
 ]
 `;
@@ -224,6 +235,7 @@ Object {
 
 exports[`watchFiles option should work with options {"usePolling":true,"interval":200,"poll":400} should reload when file content is changed: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hey.",
 ]
 `;
@@ -248,6 +260,7 @@ Object {
 
 exports[`watchFiles option should work with options {"usePolling":true,"poll":200} should reload when file content is changed: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hey.",
 ]
 `;
@@ -272,6 +285,7 @@ Object {
 
 exports[`watchFiles option should work with options {"usePolling":true} should reload when file content is changed: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hey.",
 ]
 `;
@@ -282,6 +296,7 @@ exports[`watchFiles option should work with options {"usePolling":true} should r
 
 exports[`watchFiles option should work with string and glob should reload when file content is changed: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hey.",
 ]
 `;
@@ -292,6 +307,7 @@ exports[`watchFiles option should work with string and glob should reload when f
 
 exports[`watchFiles option should work with string and path to directory should reload when file content is changed: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hey.",
 ]
 `;
@@ -302,6 +318,7 @@ exports[`watchFiles option should work with string and path to directory should 
 
 exports[`watchFiles option should work with string and path to file should reload when file content is changed: console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "Hey.",
 ]
 `;

--- a/test/e2e/__snapshots__/watch-files.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/watch-files.test.js.snap.webpack5
@@ -2,7 +2,7 @@
 
 exports[`watchFiles option should not crash if file doesn't exist should reload when file content is changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -13,7 +13,7 @@ exports[`watchFiles option should not crash if file doesn't exist should reload 
 
 exports[`watchFiles option should work with array config should reload when file content is changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -24,7 +24,7 @@ exports[`watchFiles option should work with array config should reload when file
 
 exports[`watchFiles option should work with object with multiple paths should reload when file content is changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -35,7 +35,7 @@ exports[`watchFiles option should work with object with multiple paths should re
 
 exports[`watchFiles option should work with object with single path should reload when file content is changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -60,7 +60,7 @@ Object {
 
 exports[`watchFiles option should work with options {"interval":400,"poll":200} should reload when file content is changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -85,7 +85,7 @@ Object {
 
 exports[`watchFiles option should work with options {"poll":200} should reload when file content is changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -110,7 +110,7 @@ Object {
 
 exports[`watchFiles option should work with options {"poll":true} should reload when file content is changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -135,7 +135,7 @@ Object {
 
 exports[`watchFiles option should work with options {"usePolling":false,"interval":200,"poll":400} should reload when file content is changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -160,7 +160,7 @@ Object {
 
 exports[`watchFiles option should work with options {"usePolling":false,"poll":200} should reload when file content is changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -185,7 +185,7 @@ Object {
 
 exports[`watchFiles option should work with options {"usePolling":false,"poll":true} should reload when file content is changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -210,7 +210,7 @@ Object {
 
 exports[`watchFiles option should work with options {"usePolling":false} should reload when file content is changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -235,7 +235,7 @@ Object {
 
 exports[`watchFiles option should work with options {"usePolling":true,"interval":200,"poll":400} should reload when file content is changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -260,7 +260,7 @@ Object {
 
 exports[`watchFiles option should work with options {"usePolling":true,"poll":200} should reload when file content is changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -285,7 +285,7 @@ Object {
 
 exports[`watchFiles option should work with options {"usePolling":true} should reload when file content is changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -296,7 +296,7 @@ exports[`watchFiles option should work with options {"usePolling":true} should r
 
 exports[`watchFiles option should work with string and glob should reload when file content is changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -307,7 +307,7 @@ exports[`watchFiles option should work with string and glob should reload when f
 
 exports[`watchFiles option should work with string and path to directory should reload when file content is changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -318,7 +318,7 @@ exports[`watchFiles option should work with string and path to directory should 
 
 exports[`watchFiles option should work with string and path to file should reload when file content is changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "Hey.",
 ]
 `;

--- a/test/e2e/__snapshots__/watch-files.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/watch-files.test.js.snap.webpack5
@@ -2,7 +2,7 @@
 
 exports[`watchFiles option should not crash if file doesn't exist should reload when file content is changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -13,7 +13,7 @@ exports[`watchFiles option should not crash if file doesn't exist should reload 
 
 exports[`watchFiles option should work with array config should reload when file content is changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -24,7 +24,7 @@ exports[`watchFiles option should work with array config should reload when file
 
 exports[`watchFiles option should work with object with multiple paths should reload when file content is changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -35,7 +35,7 @@ exports[`watchFiles option should work with object with multiple paths should re
 
 exports[`watchFiles option should work with object with single path should reload when file content is changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -60,7 +60,7 @@ Object {
 
 exports[`watchFiles option should work with options {"interval":400,"poll":200} should reload when file content is changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -85,7 +85,7 @@ Object {
 
 exports[`watchFiles option should work with options {"poll":200} should reload when file content is changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -110,7 +110,7 @@ Object {
 
 exports[`watchFiles option should work with options {"poll":true} should reload when file content is changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -135,7 +135,7 @@ Object {
 
 exports[`watchFiles option should work with options {"usePolling":false,"interval":200,"poll":400} should reload when file content is changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -160,7 +160,7 @@ Object {
 
 exports[`watchFiles option should work with options {"usePolling":false,"poll":200} should reload when file content is changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -185,7 +185,7 @@ Object {
 
 exports[`watchFiles option should work with options {"usePolling":false,"poll":true} should reload when file content is changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -210,7 +210,7 @@ Object {
 
 exports[`watchFiles option should work with options {"usePolling":false} should reload when file content is changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -235,7 +235,7 @@ Object {
 
 exports[`watchFiles option should work with options {"usePolling":true,"interval":200,"poll":400} should reload when file content is changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -260,7 +260,7 @@ Object {
 
 exports[`watchFiles option should work with options {"usePolling":true,"poll":200} should reload when file content is changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -285,7 +285,7 @@ Object {
 
 exports[`watchFiles option should work with options {"usePolling":true} should reload when file content is changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -296,7 +296,7 @@ exports[`watchFiles option should work with options {"usePolling":true} should r
 
 exports[`watchFiles option should work with string and glob should reload when file content is changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -307,7 +307,7 @@ exports[`watchFiles option should work with string and glob should reload when f
 
 exports[`watchFiles option should work with string and path to directory should reload when file content is changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "Hey.",
 ]
 `;
@@ -318,7 +318,7 @@ exports[`watchFiles option should work with string and path to directory should 
 
 exports[`watchFiles option should work with string and path to file should reload when file content is changed: console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "Hey.",
 ]
 `;

--- a/test/e2e/__snapshots__/web-socket-communication.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/web-socket-communication.test.js.snap.webpack4
@@ -2,11 +2,9 @@
 
 exports[`web socket communication should work and close web socket client connection when web socket server closed ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] Disconnected!",
   "[webpack-dev-server] Trying to reconnect...",
 ]
@@ -16,11 +14,9 @@ exports[`web socket communication should work and close web socket client connec
 
 exports[`web socket communication should work and close web socket client connection when web socket server closed ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] Disconnected!",
   "[webpack-dev-server] Trying to reconnect...",
 ]
@@ -30,25 +26,19 @@ exports[`web socket communication should work and close web socket client connec
 
 exports[`web socket communication should work and reconnect when the connection is lost ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] Disconnected!",
   "[webpack-dev-server] Trying to reconnect...",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App hot update...",
   "[HMR] Checking for updates on the server...",
   "Failed to load resource: the server responded with a status of 404 (Not Found)",
   "[HMR] Cannot find update. Need to do a full reload!",
   "[HMR] (Probably because of restarting the webpack-dev-server)",
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -56,25 +46,19 @@ exports[`web socket communication should work and reconnect when the connection 
 
 exports[`web socket communication should work and reconnect when the connection is lost ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] Disconnected!",
   "[webpack-dev-server] Trying to reconnect...",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App hot update...",
   "[HMR] Checking for updates on the server...",
   "Failed to load resource: the server responded with a status of 404 (Not Found)",
   "[HMR] Cannot find update. Need to do a full reload!",
   "[HMR] (Probably because of restarting the webpack-dev-server)",
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -82,11 +66,9 @@ exports[`web socket communication should work and reconnect when the connection 
 
 exports[`web socket communication should work and terminate client that is not alive ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -94,11 +76,9 @@ exports[`web socket communication should work and terminate client that is not a
 
 exports[`web socket communication should work and terminate client that is not alive ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 

--- a/test/e2e/__snapshots__/web-socket-communication.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/web-socket-communication.test.js.snap.webpack4
@@ -2,7 +2,7 @@
 
 exports[`web socket communication should work and close web socket client connection when web socket server closed ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Disconnected!",
@@ -14,7 +14,7 @@ exports[`web socket communication should work and close web socket client connec
 
 exports[`web socket communication should work and close web socket client connection when web socket server closed ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Disconnected!",
@@ -26,7 +26,7 @@ exports[`web socket communication should work and close web socket client connec
 
 exports[`web socket communication should work and reconnect when the connection is lost ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Disconnected!",
@@ -36,7 +36,7 @@ Array [
   "Failed to load resource: the server responded with a status of 404 (Not Found)",
   "[HMR] Cannot find update. Need to do a full reload!",
   "[HMR] (Probably because of restarting the webpack-dev-server)",
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -46,7 +46,7 @@ exports[`web socket communication should work and reconnect when the connection 
 
 exports[`web socket communication should work and reconnect when the connection is lost ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Disconnected!",
@@ -56,7 +56,7 @@ Array [
   "Failed to load resource: the server responded with a status of 404 (Not Found)",
   "[HMR] Cannot find update. Need to do a full reload!",
   "[HMR] (Probably because of restarting the webpack-dev-server)",
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -66,7 +66,7 @@ exports[`web socket communication should work and reconnect when the connection 
 
 exports[`web socket communication should work and terminate client that is not alive ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -76,7 +76,7 @@ exports[`web socket communication should work and terminate client that is not a
 
 exports[`web socket communication should work and terminate client that is not alive ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]

--- a/test/e2e/__snapshots__/web-socket-communication.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/web-socket-communication.test.js.snap.webpack4
@@ -2,6 +2,7 @@
 
 exports[`web socket communication should work and close web socket client connection when web socket server closed ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -15,6 +16,7 @@ exports[`web socket communication should work and close web socket client connec
 
 exports[`web socket communication should work and close web socket client connection when web socket server closed ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -28,6 +30,7 @@ exports[`web socket communication should work and close web socket client connec
 
 exports[`web socket communication should work and reconnect when the connection is lost ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -41,6 +44,7 @@ Array [
   "Failed to load resource: the server responded with a status of 404 (Not Found)",
   "[HMR] Cannot find update. Need to do a full reload!",
   "[HMR] (Probably because of restarting the webpack-dev-server)",
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -52,6 +56,7 @@ exports[`web socket communication should work and reconnect when the connection 
 
 exports[`web socket communication should work and reconnect when the connection is lost ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -65,6 +70,7 @@ Array [
   "Failed to load resource: the server responded with a status of 404 (Not Found)",
   "[HMR] Cannot find update. Need to do a full reload!",
   "[HMR] (Probably because of restarting the webpack-dev-server)",
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -76,6 +82,7 @@ exports[`web socket communication should work and reconnect when the connection 
 
 exports[`web socket communication should work and terminate client that is not alive ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -87,6 +94,7 @@ exports[`web socket communication should work and terminate client that is not a
 
 exports[`web socket communication should work and terminate client that is not alive ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",

--- a/test/e2e/__snapshots__/web-socket-communication.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/web-socket-communication.test.js.snap.webpack5
@@ -2,11 +2,9 @@
 
 exports[`web socket communication should work and close web socket client connection when web socket server closed ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] Disconnected!",
   "[webpack-dev-server] Trying to reconnect...",
 ]
@@ -16,11 +14,9 @@ exports[`web socket communication should work and close web socket client connec
 
 exports[`web socket communication should work and close web socket client connection when web socket server closed ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] Disconnected!",
   "[webpack-dev-server] Trying to reconnect...",
 ]
@@ -30,25 +26,19 @@ exports[`web socket communication should work and close web socket client connec
 
 exports[`web socket communication should work and reconnect when the connection is lost ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] Disconnected!",
   "[webpack-dev-server] Trying to reconnect...",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App hot update...",
   "[HMR] Checking for updates on the server...",
   "Failed to load resource: the server responded with a status of 404 (Not Found)",
   "[HMR] Cannot find update. Need to do a full reload!",
   "[HMR] (Probably because of restarting the webpack-dev-server)",
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -56,25 +46,19 @@ exports[`web socket communication should work and reconnect when the connection 
 
 exports[`web socket communication should work and reconnect when the connection is lost ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] Disconnected!",
   "[webpack-dev-server] Trying to reconnect...",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
   "[webpack-dev-server] App hot update...",
   "[HMR] Checking for updates on the server...",
   "Failed to load resource: the server responded with a status of 404 (Not Found)",
   "[HMR] Cannot find update. Need to do a full reload!",
   "[HMR] (Probably because of restarting the webpack-dev-server)",
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -82,11 +66,9 @@ exports[`web socket communication should work and reconnect when the connection 
 
 exports[`web socket communication should work and terminate client that is not alive ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -94,11 +76,9 @@ exports[`web socket communication should work and terminate client that is not a
 
 exports[`web socket communication should work and terminate client that is not alive ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 

--- a/test/e2e/__snapshots__/web-socket-communication.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/web-socket-communication.test.js.snap.webpack5
@@ -2,7 +2,7 @@
 
 exports[`web socket communication should work and close web socket client connection when web socket server closed ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Disconnected!",
@@ -14,7 +14,7 @@ exports[`web socket communication should work and close web socket client connec
 
 exports[`web socket communication should work and close web socket client connection when web socket server closed ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Disconnected!",
@@ -26,7 +26,7 @@ exports[`web socket communication should work and close web socket client connec
 
 exports[`web socket communication should work and reconnect when the connection is lost ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Disconnected!",
@@ -36,7 +36,7 @@ Array [
   "Failed to load resource: the server responded with a status of 404 (Not Found)",
   "[HMR] Cannot find update. Need to do a full reload!",
   "[HMR] (Probably because of restarting the webpack-dev-server)",
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -46,7 +46,7 @@ exports[`web socket communication should work and reconnect when the connection 
 
 exports[`web socket communication should work and reconnect when the connection is lost ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Disconnected!",
@@ -56,7 +56,7 @@ Array [
   "Failed to load resource: the server responded with a status of 404 (Not Found)",
   "[HMR] Cannot find update. Need to do a full reload!",
   "[HMR] (Probably because of restarting the webpack-dev-server)",
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -66,7 +66,7 @@ exports[`web socket communication should work and reconnect when the connection 
 
 exports[`web socket communication should work and terminate client that is not alive ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -76,7 +76,7 @@ exports[`web socket communication should work and terminate client that is not a
 
 exports[`web socket communication should work and terminate client that is not alive ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]

--- a/test/e2e/__snapshots__/web-socket-communication.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/web-socket-communication.test.js.snap.webpack5
@@ -2,6 +2,7 @@
 
 exports[`web socket communication should work and close web socket client connection when web socket server closed ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -15,6 +16,7 @@ exports[`web socket communication should work and close web socket client connec
 
 exports[`web socket communication should work and close web socket client connection when web socket server closed ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -28,6 +30,7 @@ exports[`web socket communication should work and close web socket client connec
 
 exports[`web socket communication should work and reconnect when the connection is lost ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -41,6 +44,7 @@ Array [
   "Failed to load resource: the server responded with a status of 404 (Not Found)",
   "[HMR] Cannot find update. Need to do a full reload!",
   "[HMR] (Probably because of restarting the webpack-dev-server)",
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -52,6 +56,7 @@ exports[`web socket communication should work and reconnect when the connection 
 
 exports[`web socket communication should work and reconnect when the connection is lost ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -65,6 +70,7 @@ Array [
   "Failed to load resource: the server responded with a status of 404 (Not Found)",
   "[HMR] Cannot find update. Need to do a full reload!",
   "[HMR] (Probably because of restarting the webpack-dev-server)",
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -76,6 +82,7 @@ exports[`web socket communication should work and reconnect when the connection 
 
 exports[`web socket communication should work and terminate client that is not alive ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -87,6 +94,7 @@ exports[`web socket communication should work and terminate client that is not a
 
 exports[`web socket communication should work and terminate client that is not alive ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",

--- a/test/e2e/__snapshots__/web-socket-server-url.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/web-socket-server-url.test.js.snap.webpack4
@@ -2,7 +2,7 @@
 
 exports[`web socket server URL should not work and output disconnect wrong web socket URL ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "Failed to load resource: net::ERR_NAME_NOT_RESOLVED",
@@ -14,7 +14,7 @@ exports[`web socket server URL should not work and output disconnect wrong web s
 
 exports[`web socket server URL should not work and output disconnect wrong web socket URL ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "WebSocket connection to 'ws://unknown.unknown:<port>/unknown' failed: Error in connection establishment: net::ERR_NAME_NOT_RESOLVED",
@@ -27,7 +27,7 @@ exports[`web socket server URL should not work and output disconnect wrong web s
 
 exports[`web socket server URL should work and throw an error on invalid web socket URL ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
 ]
 `;
 
@@ -39,7 +39,7 @@ Array [
 
 exports[`web socket server URL should work and throw an error on invalid web socket URL ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
 ]
 `;
 
@@ -51,7 +51,7 @@ Array [
 
 exports[`web socket server URL should work behind proxy, when hostnames are different and ports are different ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -61,7 +61,7 @@ exports[`web socket server URL should work behind proxy, when hostnames are diff
 
 exports[`web socket server URL should work behind proxy, when hostnames are different and ports are different ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -71,7 +71,7 @@ exports[`web socket server URL should work behind proxy, when hostnames are diff
 
 exports[`web socket server URL should work behind proxy, when hostnames are different and ports are same ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -81,7 +81,7 @@ exports[`web socket server URL should work behind proxy, when hostnames are diff
 
 exports[`web socket server URL should work behind proxy, when hostnames are different and ports are same ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -91,7 +91,7 @@ exports[`web socket server URL should work behind proxy, when hostnames are diff
 
 exports[`web socket server URL should work behind proxy, when hostnames are same and ports are different ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -101,7 +101,7 @@ exports[`web socket server URL should work behind proxy, when hostnames are same
 
 exports[`web socket server URL should work behind proxy, when hostnames are same and ports are different ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -111,7 +111,7 @@ exports[`web socket server URL should work behind proxy, when hostnames are same
 
 exports[`web socket server URL should work behind proxy, when the "host" option is "local-ip" and the "port" option is "auto" ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -121,7 +121,7 @@ exports[`web socket server URL should work behind proxy, when the "host" option 
 
 exports[`web socket server URL should work behind proxy, when the "host" option is "local-ip" and the "port" option is "auto" ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -131,7 +131,7 @@ exports[`web socket server URL should work behind proxy, when the "host" option 
 
 exports[`web socket server URL should work when "host" option is "local-ip" ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -141,7 +141,7 @@ exports[`web socket server URL should work when "host" option is "local-ip" ("so
 
 exports[`web socket server URL should work when "host" option is "local-ip" ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -151,7 +151,7 @@ exports[`web socket server URL should work when "host" option is "local-ip" ("ws
 
 exports[`web socket server URL should work when "host" option is "local-ipv4" ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -161,7 +161,7 @@ exports[`web socket server URL should work when "host" option is "local-ipv4" ("
 
 exports[`web socket server URL should work when "host" option is "local-ipv4" ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -171,7 +171,7 @@ exports[`web socket server URL should work when "host" option is "local-ipv4" ("
 
 exports[`web socket server URL should work when "host" option is IPv4 ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -181,7 +181,7 @@ exports[`web socket server URL should work when "host" option is IPv4 ("sockjs")
 
 exports[`web socket server URL should work when "host" option is IPv4 ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -191,7 +191,7 @@ exports[`web socket server URL should work when "host" option is IPv4 ("ws"): pa
 
 exports[`web socket server URL should work when "port" option is "auto" ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -201,7 +201,7 @@ exports[`web socket server URL should work when "port" option is "auto" ("sockjs
 
 exports[`web socket server URL should work when "port" option is "auto" ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -211,7 +211,7 @@ exports[`web socket server URL should work when "port" option is "auto" ("ws"): 
 
 exports[`web socket server URL should work with "client.webSocketURL.*" options ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -221,7 +221,7 @@ exports[`web socket server URL should work with "client.webSocketURL.*" options 
 
 exports[`web socket server URL should work with "client.webSocketURL.*" options ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -231,7 +231,7 @@ exports[`web socket server URL should work with "client.webSocketURL.*" options 
 
 exports[`web socket server URL should work with "client.webSocketURL.port" and "webSocketServer.options.port" options as string ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -241,7 +241,7 @@ exports[`web socket server URL should work with "client.webSocketURL.port" and "
 
 exports[`web socket server URL should work with "client.webSocketURL.port" and "webSocketServer.options.port" options as string ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -251,7 +251,7 @@ exports[`web socket server URL should work with "client.webSocketURL.port" and "
 
 exports[`web socket server URL should work with "http2" option ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -261,7 +261,7 @@ exports[`web socket server URL should work with "http2" option ("sockjs"): page 
 
 exports[`web socket server URL should work with "http2" option ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -271,7 +271,7 @@ exports[`web socket server URL should work with "http2" option ("ws"): page erro
 
 exports[`web socket server URL should work with "https" option ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -281,7 +281,7 @@ exports[`web socket server URL should work with "https" option ("sockjs"): page 
 
 exports[`web socket server URL should work with "https" option ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -291,7 +291,7 @@ exports[`web socket server URL should work with "https" option ("ws"): page erro
 
 exports[`web socket server URL should work with "server: 'https'" option ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -301,7 +301,7 @@ exports[`web socket server URL should work with "server: 'https'" option ("sockj
 
 exports[`web socket server URL should work with "server: 'https'" option ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -311,7 +311,7 @@ exports[`web socket server URL should work with "server: 'https'" option ("ws"):
 
 exports[`web socket server URL should work with "server: 'spdy'" option ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -321,7 +321,7 @@ exports[`web socket server URL should work with "server: 'spdy'" option ("sockjs
 
 exports[`web socket server URL should work with "server: 'spdy'" option ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -331,7 +331,7 @@ exports[`web socket server URL should work with "server: 'spdy'" option ("ws"): 
 
 exports[`web socket server URL should work with default "/ws" value of the "client.webSocketURL.pathname" option ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -341,7 +341,7 @@ exports[`web socket server URL should work with default "/ws" value of the "clie
 
 exports[`web socket server URL should work with default "/ws" value of the "client.webSocketURL.pathname" option ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -351,7 +351,7 @@ exports[`web socket server URL should work with default "/ws" value of the "clie
 
 exports[`web socket server URL should work with the "client.webSocketURL" option as "string" ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -361,7 +361,7 @@ exports[`web socket server URL should work with the "client.webSocketURL" option
 
 exports[`web socket server URL should work with the "client.webSocketURL" option as "string" ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -371,7 +371,7 @@ exports[`web socket server URL should work with the "client.webSocketURL" option
 
 exports[`web socket server URL should work with the "client.webSocketURL.host" option ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -381,7 +381,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.host" o
 
 exports[`web socket server URL should work with the "client.webSocketURL.host" option ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -391,7 +391,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.host" o
 
 exports[`web socket server URL should work with the "client.webSocketURL.host" option using "0.0.0.0" value ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -401,7 +401,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.host" o
 
 exports[`web socket server URL should work with the "client.webSocketURL.host" option using "0.0.0.0" value ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -411,7 +411,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.host" o
 
 exports[`web socket server URL should work with the "client.webSocketURL.password" option ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -421,7 +421,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.passwor
 
 exports[`web socket server URL should work with the "client.webSocketURL.password" option ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -431,7 +431,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.passwor
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -441,7 +441,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -451,7 +451,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option and the custom web socket server "path" ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -461,7 +461,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option and the custom web socket server "path" ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -471,7 +471,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option and the custom web socket server "path" ending with slash ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -481,7 +481,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option and the custom web socket server "path" ending with slash ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -491,7 +491,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option and the custom web socket server "path" ending without slash ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -501,7 +501,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option and the custom web socket server "path" ending without slash ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -511,7 +511,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option and the custom web socket server "path" using empty value ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -521,7 +521,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option and the custom web socket server "path" using empty value ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -531,7 +531,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option and the custom web socket server "prefix" for compatibility with "sockjs" ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -541,7 +541,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option and the custom web socket server "prefix" for compatibility with "sockjs" ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -551,7 +551,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.port" option ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -561,7 +561,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.port" o
 
 exports[`web socket server URL should work with the "client.webSocketURL.port" option ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -571,7 +571,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.port" o
 
 exports[`web socket server URL should work with the "client.webSocketURL.port" option as string ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -581,7 +581,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.port" o
 
 exports[`web socket server URL should work with the "client.webSocketURL.port" option as string ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -591,7 +591,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.port" o
 
 exports[`web socket server URL should work with the "client.webSocketURL.port" option using "0" value ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -601,7 +601,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.port" o
 
 exports[`web socket server URL should work with the "client.webSocketURL.port" option using "0" value ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -611,7 +611,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.port" o
 
 exports[`web socket server URL should work with the "client.webSocketURL.protocol" option ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -621,7 +621,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.protoco
 
 exports[`web socket server URL should work with the "client.webSocketURL.protocol" option ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -631,7 +631,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.protoco
 
 exports[`web socket server URL should work with the "client.webSocketURL.protocol" option using "auto:" value ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -641,7 +641,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.protoco
 
 exports[`web socket server URL should work with the "client.webSocketURL.protocol" option using "auto:" value ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -651,7 +651,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.protoco
 
 exports[`web socket server URL should work with the "client.webSocketURL.protocol" option using "http:" value and covert to "ws:" ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -661,7 +661,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.protoco
 
 exports[`web socket server URL should work with the "client.webSocketURL.protocol" option using "http:" value and covert to "ws:" ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -671,7 +671,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.protoco
 
 exports[`web socket server URL should work with the "client.webSocketURL.username" and "client.webSocketURL.password" option ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -681,7 +681,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.usernam
 
 exports[`web socket server URL should work with the "client.webSocketURL.username" and "client.webSocketURL.password" option ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -691,7 +691,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.usernam
 
 exports[`web socket server URL should work with the "client.webSocketURL.username" option ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -701,7 +701,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.usernam
 
 exports[`web socket server URL should work with the "client.webSocketURL.username" option ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -711,7 +711,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.usernam
 
 exports[`web socket server URL should work with the custom web socket server "path" ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -721,7 +721,7 @@ exports[`web socket server URL should work with the custom web socket server "pa
 
 exports[`web socket server URL should work with the custom web socket server "path" ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -731,7 +731,7 @@ exports[`web socket server URL should work with the custom web socket server "pa
 
 exports[`web socket server URL should work with the custom web socket server "path" using empty value ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -741,7 +741,7 @@ exports[`web socket server URL should work with the custom web socket server "pa
 
 exports[`web socket server URL should work with the custom web socket server "path" using empty value ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]

--- a/test/e2e/__snapshots__/web-socket-server-url.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/web-socket-server-url.test.js.snap.webpack4
@@ -2,6 +2,7 @@
 
 exports[`web socket server URL should not work and output disconnect wrong web socket URL ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "Failed to load resource: net::ERR_NAME_NOT_RESOLVED",
@@ -13,6 +14,7 @@ exports[`web socket server URL should not work and output disconnect wrong web s
 
 exports[`web socket server URL should not work and output disconnect wrong web socket URL ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "WebSocket connection to 'ws://unknown.unknown:<port>/unknown' failed: Error in connection establishment: net::ERR_NAME_NOT_RESOLVED",
@@ -41,6 +43,7 @@ Array [
 
 exports[`web socket server URL should work behind proxy, when hostnames are different and ports are different ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -52,6 +55,7 @@ exports[`web socket server URL should work behind proxy, when hostnames are diff
 
 exports[`web socket server URL should work behind proxy, when hostnames are different and ports are different ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -63,6 +67,7 @@ exports[`web socket server URL should work behind proxy, when hostnames are diff
 
 exports[`web socket server URL should work behind proxy, when hostnames are different and ports are same ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -74,6 +79,7 @@ exports[`web socket server URL should work behind proxy, when hostnames are diff
 
 exports[`web socket server URL should work behind proxy, when hostnames are different and ports are same ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -85,6 +91,7 @@ exports[`web socket server URL should work behind proxy, when hostnames are diff
 
 exports[`web socket server URL should work behind proxy, when hostnames are same and ports are different ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -96,6 +103,7 @@ exports[`web socket server URL should work behind proxy, when hostnames are same
 
 exports[`web socket server URL should work behind proxy, when hostnames are same and ports are different ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -107,6 +115,7 @@ exports[`web socket server URL should work behind proxy, when hostnames are same
 
 exports[`web socket server URL should work behind proxy, when the "host" option is "local-ip" and the "port" option is "auto" ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -118,6 +127,7 @@ exports[`web socket server URL should work behind proxy, when the "host" option 
 
 exports[`web socket server URL should work behind proxy, when the "host" option is "local-ip" and the "port" option is "auto" ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -129,6 +139,7 @@ exports[`web socket server URL should work behind proxy, when the "host" option 
 
 exports[`web socket server URL should work when "host" option is "local-ip" ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -140,6 +151,7 @@ exports[`web socket server URL should work when "host" option is "local-ip" ("so
 
 exports[`web socket server URL should work when "host" option is "local-ip" ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -151,6 +163,7 @@ exports[`web socket server URL should work when "host" option is "local-ip" ("ws
 
 exports[`web socket server URL should work when "host" option is "local-ipv4" ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -162,6 +175,7 @@ exports[`web socket server URL should work when "host" option is "local-ipv4" ("
 
 exports[`web socket server URL should work when "host" option is "local-ipv4" ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -173,6 +187,7 @@ exports[`web socket server URL should work when "host" option is "local-ipv4" ("
 
 exports[`web socket server URL should work when "host" option is IPv4 ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -184,6 +199,7 @@ exports[`web socket server URL should work when "host" option is IPv4 ("sockjs")
 
 exports[`web socket server URL should work when "host" option is IPv4 ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -195,6 +211,7 @@ exports[`web socket server URL should work when "host" option is IPv4 ("ws"): pa
 
 exports[`web socket server URL should work when "port" option is "auto" ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -206,6 +223,7 @@ exports[`web socket server URL should work when "port" option is "auto" ("sockjs
 
 exports[`web socket server URL should work when "port" option is "auto" ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -217,6 +235,7 @@ exports[`web socket server URL should work when "port" option is "auto" ("ws"): 
 
 exports[`web socket server URL should work with "client.webSocketURL.*" options ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -228,6 +247,7 @@ exports[`web socket server URL should work with "client.webSocketURL.*" options 
 
 exports[`web socket server URL should work with "client.webSocketURL.*" options ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -239,6 +259,7 @@ exports[`web socket server URL should work with "client.webSocketURL.*" options 
 
 exports[`web socket server URL should work with "client.webSocketURL.port" and "webSocketServer.options.port" options as string ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -250,6 +271,7 @@ exports[`web socket server URL should work with "client.webSocketURL.port" and "
 
 exports[`web socket server URL should work with "client.webSocketURL.port" and "webSocketServer.options.port" options as string ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -261,6 +283,7 @@ exports[`web socket server URL should work with "client.webSocketURL.port" and "
 
 exports[`web socket server URL should work with "http2" option ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -272,6 +295,7 @@ exports[`web socket server URL should work with "http2" option ("sockjs"): page 
 
 exports[`web socket server URL should work with "http2" option ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -283,6 +307,7 @@ exports[`web socket server URL should work with "http2" option ("ws"): page erro
 
 exports[`web socket server URL should work with "https" option ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -294,6 +319,7 @@ exports[`web socket server URL should work with "https" option ("sockjs"): page 
 
 exports[`web socket server URL should work with "https" option ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -349,6 +375,7 @@ exports[`web socket server URL should work with "server: 'spdy'" option ("ws"): 
 
 exports[`web socket server URL should work with default "/ws" value of the "client.webSocketURL.pathname" option ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -360,6 +387,7 @@ exports[`web socket server URL should work with default "/ws" value of the "clie
 
 exports[`web socket server URL should work with default "/ws" value of the "client.webSocketURL.pathname" option ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -371,6 +399,7 @@ exports[`web socket server URL should work with default "/ws" value of the "clie
 
 exports[`web socket server URL should work with the "client.webSocketURL" option as "string" ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -382,6 +411,7 @@ exports[`web socket server URL should work with the "client.webSocketURL" option
 
 exports[`web socket server URL should work with the "client.webSocketURL" option as "string" ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -393,6 +423,7 @@ exports[`web socket server URL should work with the "client.webSocketURL" option
 
 exports[`web socket server URL should work with the "client.webSocketURL.host" option ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -404,6 +435,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.host" o
 
 exports[`web socket server URL should work with the "client.webSocketURL.host" option ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -415,6 +447,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.host" o
 
 exports[`web socket server URL should work with the "client.webSocketURL.host" option using "0.0.0.0" value ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -426,6 +459,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.host" o
 
 exports[`web socket server URL should work with the "client.webSocketURL.host" option using "0.0.0.0" value ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -437,6 +471,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.host" o
 
 exports[`web socket server URL should work with the "client.webSocketURL.password" option ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -448,6 +483,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.passwor
 
 exports[`web socket server URL should work with the "client.webSocketURL.password" option ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -459,6 +495,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.passwor
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -470,6 +507,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -481,6 +519,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option and the custom web socket server "path" ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -492,6 +531,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option and the custom web socket server "path" ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -503,6 +543,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option and the custom web socket server "path" ending with slash ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -514,6 +555,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option and the custom web socket server "path" ending with slash ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -525,6 +567,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option and the custom web socket server "path" ending without slash ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -536,6 +579,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option and the custom web socket server "path" ending without slash ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -547,6 +591,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option and the custom web socket server "path" using empty value ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -558,6 +603,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option and the custom web socket server "path" using empty value ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -569,6 +615,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option and the custom web socket server "prefix" for compatibility with "sockjs" ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -580,6 +627,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option and the custom web socket server "prefix" for compatibility with "sockjs" ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -591,6 +639,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.port" option ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -602,6 +651,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.port" o
 
 exports[`web socket server URL should work with the "client.webSocketURL.port" option ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -613,6 +663,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.port" o
 
 exports[`web socket server URL should work with the "client.webSocketURL.port" option as string ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -624,6 +675,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.port" o
 
 exports[`web socket server URL should work with the "client.webSocketURL.port" option as string ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -635,6 +687,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.port" o
 
 exports[`web socket server URL should work with the "client.webSocketURL.port" option using "0" value ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -646,6 +699,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.port" o
 
 exports[`web socket server URL should work with the "client.webSocketURL.port" option using "0" value ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -657,6 +711,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.port" o
 
 exports[`web socket server URL should work with the "client.webSocketURL.protocol" option ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -668,6 +723,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.protoco
 
 exports[`web socket server URL should work with the "client.webSocketURL.protocol" option ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -679,6 +735,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.protoco
 
 exports[`web socket server URL should work with the "client.webSocketURL.protocol" option using "auto:" value ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -690,6 +747,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.protoco
 
 exports[`web socket server URL should work with the "client.webSocketURL.protocol" option using "auto:" value ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -701,6 +759,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.protoco
 
 exports[`web socket server URL should work with the "client.webSocketURL.protocol" option using "http:" value and covert to "ws:" ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -712,6 +771,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.protoco
 
 exports[`web socket server URL should work with the "client.webSocketURL.protocol" option using "http:" value and covert to "ws:" ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -723,6 +783,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.protoco
 
 exports[`web socket server URL should work with the "client.webSocketURL.username" and "client.webSocketURL.password" option ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -734,6 +795,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.usernam
 
 exports[`web socket server URL should work with the "client.webSocketURL.username" and "client.webSocketURL.password" option ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -745,6 +807,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.usernam
 
 exports[`web socket server URL should work with the "client.webSocketURL.username" option ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -756,6 +819,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.usernam
 
 exports[`web socket server URL should work with the "client.webSocketURL.username" option ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -767,6 +831,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.usernam
 
 exports[`web socket server URL should work with the custom web socket server "path" ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -778,6 +843,7 @@ exports[`web socket server URL should work with the custom web socket server "pa
 
 exports[`web socket server URL should work with the custom web socket server "path" ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -789,6 +855,7 @@ exports[`web socket server URL should work with the custom web socket server "pa
 
 exports[`web socket server URL should work with the custom web socket server "path" using empty value ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -800,6 +867,7 @@ exports[`web socket server URL should work with the custom web socket server "pa
 
 exports[`web socket server URL should work with the custom web socket server "path" using empty value ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",

--- a/test/e2e/__snapshots__/web-socket-server-url.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/web-socket-server-url.test.js.snap.webpack4
@@ -25,7 +25,11 @@ Array [
 
 exports[`web socket server URL should not work and output disconnect wrong web socket URL ("ws"): page errors 1`] = `Array []`;
 
-exports[`web socket server URL should work and throw an error on invalid web socket URL ("sockjs"): console messages 1`] = `Array []`;
+exports[`web socket server URL should work and throw an error on invalid web socket URL ("sockjs"): console messages 1`] = `
+Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+]
+`;
 
 exports[`web socket server URL should work and throw an error on invalid web socket URL ("sockjs"): page errors 1`] = `
 Array [
@@ -33,7 +37,11 @@ Array [
 ]
 `;
 
-exports[`web socket server URL should work and throw an error on invalid web socket URL ("ws"): console messages 1`] = `Array []`;
+exports[`web socket server URL should work and throw an error on invalid web socket URL ("ws"): console messages 1`] = `
+Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+]
+`;
 
 exports[`web socket server URL should work and throw an error on invalid web socket URL ("ws"): page errors 1`] = `
 Array [

--- a/test/e2e/__snapshots__/web-socket-server-url.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/web-socket-server-url.test.js.snap.webpack4
@@ -39,7 +39,7 @@ Array [
 
 exports[`web socket server URL should work and throw an error on invalid web socket URL ("ws"): console messages 1`] = `
 Array [
- "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
 ]
 `;
 

--- a/test/e2e/__snapshots__/web-socket-server-url.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/web-socket-server-url.test.js.snap.webpack4
@@ -2,7 +2,7 @@
 
 exports[`web socket server URL should not work and output disconnect wrong web socket URL ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "Failed to load resource: net::ERR_NAME_NOT_RESOLVED",
@@ -14,7 +14,7 @@ exports[`web socket server URL should not work and output disconnect wrong web s
 
 exports[`web socket server URL should not work and output disconnect wrong web socket URL ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "WebSocket connection to 'ws://unknown.unknown:<port>/unknown' failed: Error in connection establishment: net::ERR_NAME_NOT_RESOLVED",
@@ -27,7 +27,7 @@ exports[`web socket server URL should not work and output disconnect wrong web s
 
 exports[`web socket server URL should work and throw an error on invalid web socket URL ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
 ]
 `;
 
@@ -39,7 +39,7 @@ Array [
 
 exports[`web socket server URL should work and throw an error on invalid web socket URL ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+ "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
 ]
 `;
 
@@ -51,11 +51,9 @@ Array [
 
 exports[`web socket server URL should work behind proxy, when hostnames are different and ports are different ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -63,11 +61,9 @@ exports[`web socket server URL should work behind proxy, when hostnames are diff
 
 exports[`web socket server URL should work behind proxy, when hostnames are different and ports are different ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -75,11 +71,9 @@ exports[`web socket server URL should work behind proxy, when hostnames are diff
 
 exports[`web socket server URL should work behind proxy, when hostnames are different and ports are same ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -87,11 +81,9 @@ exports[`web socket server URL should work behind proxy, when hostnames are diff
 
 exports[`web socket server URL should work behind proxy, when hostnames are different and ports are same ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -99,11 +91,9 @@ exports[`web socket server URL should work behind proxy, when hostnames are diff
 
 exports[`web socket server URL should work behind proxy, when hostnames are same and ports are different ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -111,11 +101,9 @@ exports[`web socket server URL should work behind proxy, when hostnames are same
 
 exports[`web socket server URL should work behind proxy, when hostnames are same and ports are different ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -123,11 +111,9 @@ exports[`web socket server URL should work behind proxy, when hostnames are same
 
 exports[`web socket server URL should work behind proxy, when the "host" option is "local-ip" and the "port" option is "auto" ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -135,11 +121,9 @@ exports[`web socket server URL should work behind proxy, when the "host" option 
 
 exports[`web socket server URL should work behind proxy, when the "host" option is "local-ip" and the "port" option is "auto" ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -147,11 +131,9 @@ exports[`web socket server URL should work behind proxy, when the "host" option 
 
 exports[`web socket server URL should work when "host" option is "local-ip" ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -159,11 +141,9 @@ exports[`web socket server URL should work when "host" option is "local-ip" ("so
 
 exports[`web socket server URL should work when "host" option is "local-ip" ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -171,11 +151,9 @@ exports[`web socket server URL should work when "host" option is "local-ip" ("ws
 
 exports[`web socket server URL should work when "host" option is "local-ipv4" ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -183,11 +161,9 @@ exports[`web socket server URL should work when "host" option is "local-ipv4" ("
 
 exports[`web socket server URL should work when "host" option is "local-ipv4" ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -195,11 +171,9 @@ exports[`web socket server URL should work when "host" option is "local-ipv4" ("
 
 exports[`web socket server URL should work when "host" option is IPv4 ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -207,11 +181,9 @@ exports[`web socket server URL should work when "host" option is IPv4 ("sockjs")
 
 exports[`web socket server URL should work when "host" option is IPv4 ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -219,11 +191,9 @@ exports[`web socket server URL should work when "host" option is IPv4 ("ws"): pa
 
 exports[`web socket server URL should work when "port" option is "auto" ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -231,11 +201,9 @@ exports[`web socket server URL should work when "port" option is "auto" ("sockjs
 
 exports[`web socket server URL should work when "port" option is "auto" ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -243,11 +211,9 @@ exports[`web socket server URL should work when "port" option is "auto" ("ws"): 
 
 exports[`web socket server URL should work with "client.webSocketURL.*" options ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -255,11 +221,9 @@ exports[`web socket server URL should work with "client.webSocketURL.*" options 
 
 exports[`web socket server URL should work with "client.webSocketURL.*" options ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -267,11 +231,9 @@ exports[`web socket server URL should work with "client.webSocketURL.*" options 
 
 exports[`web socket server URL should work with "client.webSocketURL.port" and "webSocketServer.options.port" options as string ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -279,11 +241,9 @@ exports[`web socket server URL should work with "client.webSocketURL.port" and "
 
 exports[`web socket server URL should work with "client.webSocketURL.port" and "webSocketServer.options.port" options as string ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -291,11 +251,9 @@ exports[`web socket server URL should work with "client.webSocketURL.port" and "
 
 exports[`web socket server URL should work with "http2" option ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -303,11 +261,9 @@ exports[`web socket server URL should work with "http2" option ("sockjs"): page 
 
 exports[`web socket server URL should work with "http2" option ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -315,11 +271,9 @@ exports[`web socket server URL should work with "http2" option ("ws"): page erro
 
 exports[`web socket server URL should work with "https" option ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -327,11 +281,9 @@ exports[`web socket server URL should work with "https" option ("sockjs"): page 
 
 exports[`web socket server URL should work with "https" option ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -339,11 +291,9 @@ exports[`web socket server URL should work with "https" option ("ws"): page erro
 
 exports[`web socket server URL should work with "server: 'https'" option ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -351,11 +301,9 @@ exports[`web socket server URL should work with "server: 'https'" option ("sockj
 
 exports[`web socket server URL should work with "server: 'https'" option ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -363,11 +311,9 @@ exports[`web socket server URL should work with "server: 'https'" option ("ws"):
 
 exports[`web socket server URL should work with "server: 'spdy'" option ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -375,11 +321,9 @@ exports[`web socket server URL should work with "server: 'spdy'" option ("sockjs
 
 exports[`web socket server URL should work with "server: 'spdy'" option ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -387,11 +331,9 @@ exports[`web socket server URL should work with "server: 'spdy'" option ("ws"): 
 
 exports[`web socket server URL should work with default "/ws" value of the "client.webSocketURL.pathname" option ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -399,11 +341,9 @@ exports[`web socket server URL should work with default "/ws" value of the "clie
 
 exports[`web socket server URL should work with default "/ws" value of the "client.webSocketURL.pathname" option ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -411,11 +351,9 @@ exports[`web socket server URL should work with default "/ws" value of the "clie
 
 exports[`web socket server URL should work with the "client.webSocketURL" option as "string" ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -423,11 +361,9 @@ exports[`web socket server URL should work with the "client.webSocketURL" option
 
 exports[`web socket server URL should work with the "client.webSocketURL" option as "string" ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -435,11 +371,9 @@ exports[`web socket server URL should work with the "client.webSocketURL" option
 
 exports[`web socket server URL should work with the "client.webSocketURL.host" option ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -447,11 +381,9 @@ exports[`web socket server URL should work with the "client.webSocketURL.host" o
 
 exports[`web socket server URL should work with the "client.webSocketURL.host" option ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -459,11 +391,9 @@ exports[`web socket server URL should work with the "client.webSocketURL.host" o
 
 exports[`web socket server URL should work with the "client.webSocketURL.host" option using "0.0.0.0" value ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -471,11 +401,9 @@ exports[`web socket server URL should work with the "client.webSocketURL.host" o
 
 exports[`web socket server URL should work with the "client.webSocketURL.host" option using "0.0.0.0" value ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -483,11 +411,9 @@ exports[`web socket server URL should work with the "client.webSocketURL.host" o
 
 exports[`web socket server URL should work with the "client.webSocketURL.password" option ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -495,11 +421,9 @@ exports[`web socket server URL should work with the "client.webSocketURL.passwor
 
 exports[`web socket server URL should work with the "client.webSocketURL.password" option ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -507,11 +431,9 @@ exports[`web socket server URL should work with the "client.webSocketURL.passwor
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -519,11 +441,9 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -531,11 +451,9 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option and the custom web socket server "path" ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -543,11 +461,9 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option and the custom web socket server "path" ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -555,11 +471,9 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option and the custom web socket server "path" ending with slash ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -567,11 +481,9 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option and the custom web socket server "path" ending with slash ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -579,11 +491,9 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option and the custom web socket server "path" ending without slash ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -591,11 +501,9 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option and the custom web socket server "path" ending without slash ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -603,11 +511,9 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option and the custom web socket server "path" using empty value ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -615,11 +521,9 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option and the custom web socket server "path" using empty value ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -627,11 +531,9 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option and the custom web socket server "prefix" for compatibility with "sockjs" ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -639,11 +541,9 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option and the custom web socket server "prefix" for compatibility with "sockjs" ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -651,11 +551,9 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.port" option ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -663,11 +561,9 @@ exports[`web socket server URL should work with the "client.webSocketURL.port" o
 
 exports[`web socket server URL should work with the "client.webSocketURL.port" option ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -675,11 +571,9 @@ exports[`web socket server URL should work with the "client.webSocketURL.port" o
 
 exports[`web socket server URL should work with the "client.webSocketURL.port" option as string ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -687,11 +581,9 @@ exports[`web socket server URL should work with the "client.webSocketURL.port" o
 
 exports[`web socket server URL should work with the "client.webSocketURL.port" option as string ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -699,11 +591,9 @@ exports[`web socket server URL should work with the "client.webSocketURL.port" o
 
 exports[`web socket server URL should work with the "client.webSocketURL.port" option using "0" value ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -711,11 +601,9 @@ exports[`web socket server URL should work with the "client.webSocketURL.port" o
 
 exports[`web socket server URL should work with the "client.webSocketURL.port" option using "0" value ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -723,11 +611,9 @@ exports[`web socket server URL should work with the "client.webSocketURL.port" o
 
 exports[`web socket server URL should work with the "client.webSocketURL.protocol" option ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -735,11 +621,9 @@ exports[`web socket server URL should work with the "client.webSocketURL.protoco
 
 exports[`web socket server URL should work with the "client.webSocketURL.protocol" option ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -747,11 +631,9 @@ exports[`web socket server URL should work with the "client.webSocketURL.protoco
 
 exports[`web socket server URL should work with the "client.webSocketURL.protocol" option using "auto:" value ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -759,11 +641,9 @@ exports[`web socket server URL should work with the "client.webSocketURL.protoco
 
 exports[`web socket server URL should work with the "client.webSocketURL.protocol" option using "auto:" value ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -771,11 +651,9 @@ exports[`web socket server URL should work with the "client.webSocketURL.protoco
 
 exports[`web socket server URL should work with the "client.webSocketURL.protocol" option using "http:" value and covert to "ws:" ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -783,11 +661,9 @@ exports[`web socket server URL should work with the "client.webSocketURL.protoco
 
 exports[`web socket server URL should work with the "client.webSocketURL.protocol" option using "http:" value and covert to "ws:" ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -795,11 +671,9 @@ exports[`web socket server URL should work with the "client.webSocketURL.protoco
 
 exports[`web socket server URL should work with the "client.webSocketURL.username" and "client.webSocketURL.password" option ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -807,11 +681,9 @@ exports[`web socket server URL should work with the "client.webSocketURL.usernam
 
 exports[`web socket server URL should work with the "client.webSocketURL.username" and "client.webSocketURL.password" option ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -819,11 +691,9 @@ exports[`web socket server URL should work with the "client.webSocketURL.usernam
 
 exports[`web socket server URL should work with the "client.webSocketURL.username" option ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -831,11 +701,9 @@ exports[`web socket server URL should work with the "client.webSocketURL.usernam
 
 exports[`web socket server URL should work with the "client.webSocketURL.username" option ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -843,11 +711,9 @@ exports[`web socket server URL should work with the "client.webSocketURL.usernam
 
 exports[`web socket server URL should work with the custom web socket server "path" ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -855,11 +721,9 @@ exports[`web socket server URL should work with the custom web socket server "pa
 
 exports[`web socket server URL should work with the custom web socket server "path" ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -867,11 +731,9 @@ exports[`web socket server URL should work with the custom web socket server "pa
 
 exports[`web socket server URL should work with the custom web socket server "path" using empty value ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -879,11 +741,9 @@ exports[`web socket server URL should work with the custom web socket server "pa
 
 exports[`web socket server URL should work with the custom web socket server "path" using empty value ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 

--- a/test/e2e/__snapshots__/web-socket-server-url.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/web-socket-server-url.test.js.snap.webpack4
@@ -339,6 +339,7 @@ exports[`web socket server URL should work with "https" option ("ws"): page erro
 
 exports[`web socket server URL should work with "server: 'https'" option ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -350,6 +351,7 @@ exports[`web socket server URL should work with "server: 'https'" option ("sockj
 
 exports[`web socket server URL should work with "server: 'https'" option ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -361,6 +363,7 @@ exports[`web socket server URL should work with "server: 'https'" option ("ws"):
 
 exports[`web socket server URL should work with "server: 'spdy'" option ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -372,6 +375,7 @@ exports[`web socket server URL should work with "server: 'spdy'" option ("sockjs
 
 exports[`web socket server URL should work with "server: 'spdy'" option ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",

--- a/test/e2e/__snapshots__/web-socket-server-url.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/web-socket-server-url.test.js.snap.webpack5
@@ -2,7 +2,7 @@
 
 exports[`web socket server URL should not work and output disconnect wrong web socket URL ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "Failed to load resource: net::ERR_NAME_NOT_RESOLVED",
@@ -14,7 +14,7 @@ exports[`web socket server URL should not work and output disconnect wrong web s
 
 exports[`web socket server URL should not work and output disconnect wrong web socket URL ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "WebSocket connection to 'ws://unknown.unknown:<port>/unknown' failed: Error in connection establishment: net::ERR_NAME_NOT_RESOLVED",
@@ -27,7 +27,7 @@ exports[`web socket server URL should not work and output disconnect wrong web s
 
 exports[`web socket server URL should work and throw an error on invalid web socket URL ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
 ]
 `;
 
@@ -39,7 +39,7 @@ Array [
 
 exports[`web socket server URL should work and throw an error on invalid web socket URL ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
 ]
 `;
 
@@ -51,7 +51,7 @@ Array [
 
 exports[`web socket server URL should work behind proxy, when hostnames are different and ports are different ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -61,7 +61,7 @@ exports[`web socket server URL should work behind proxy, when hostnames are diff
 
 exports[`web socket server URL should work behind proxy, when hostnames are different and ports are different ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -71,7 +71,7 @@ exports[`web socket server URL should work behind proxy, when hostnames are diff
 
 exports[`web socket server URL should work behind proxy, when hostnames are different and ports are same ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -81,7 +81,7 @@ exports[`web socket server URL should work behind proxy, when hostnames are diff
 
 exports[`web socket server URL should work behind proxy, when hostnames are different and ports are same ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -91,7 +91,7 @@ exports[`web socket server URL should work behind proxy, when hostnames are diff
 
 exports[`web socket server URL should work behind proxy, when hostnames are same and ports are different ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -101,7 +101,7 @@ exports[`web socket server URL should work behind proxy, when hostnames are same
 
 exports[`web socket server URL should work behind proxy, when hostnames are same and ports are different ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -111,7 +111,7 @@ exports[`web socket server URL should work behind proxy, when hostnames are same
 
 exports[`web socket server URL should work behind proxy, when the "host" option is "local-ip" and the "port" option is "auto" ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -121,7 +121,7 @@ exports[`web socket server URL should work behind proxy, when the "host" option 
 
 exports[`web socket server URL should work behind proxy, when the "host" option is "local-ip" and the "port" option is "auto" ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -131,7 +131,7 @@ exports[`web socket server URL should work behind proxy, when the "host" option 
 
 exports[`web socket server URL should work when "host" option is "local-ip" ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -141,7 +141,7 @@ exports[`web socket server URL should work when "host" option is "local-ip" ("so
 
 exports[`web socket server URL should work when "host" option is "local-ip" ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -151,7 +151,7 @@ exports[`web socket server URL should work when "host" option is "local-ip" ("ws
 
 exports[`web socket server URL should work when "host" option is "local-ipv4" ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -161,7 +161,7 @@ exports[`web socket server URL should work when "host" option is "local-ipv4" ("
 
 exports[`web socket server URL should work when "host" option is "local-ipv4" ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -171,7 +171,7 @@ exports[`web socket server URL should work when "host" option is "local-ipv4" ("
 
 exports[`web socket server URL should work when "host" option is IPv4 ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -181,7 +181,7 @@ exports[`web socket server URL should work when "host" option is IPv4 ("sockjs")
 
 exports[`web socket server URL should work when "host" option is IPv4 ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -191,7 +191,7 @@ exports[`web socket server URL should work when "host" option is IPv4 ("ws"): pa
 
 exports[`web socket server URL should work when "port" option is "auto" ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -201,7 +201,7 @@ exports[`web socket server URL should work when "port" option is "auto" ("sockjs
 
 exports[`web socket server URL should work when "port" option is "auto" ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -211,7 +211,7 @@ exports[`web socket server URL should work when "port" option is "auto" ("ws"): 
 
 exports[`web socket server URL should work with "client.webSocketURL.*" options ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -221,7 +221,7 @@ exports[`web socket server URL should work with "client.webSocketURL.*" options 
 
 exports[`web socket server URL should work with "client.webSocketURL.*" options ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -231,7 +231,7 @@ exports[`web socket server URL should work with "client.webSocketURL.*" options 
 
 exports[`web socket server URL should work with "client.webSocketURL.port" and "webSocketServer.options.port" options as string ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -241,7 +241,7 @@ exports[`web socket server URL should work with "client.webSocketURL.port" and "
 
 exports[`web socket server URL should work with "client.webSocketURL.port" and "webSocketServer.options.port" options as string ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -251,7 +251,7 @@ exports[`web socket server URL should work with "client.webSocketURL.port" and "
 
 exports[`web socket server URL should work with "http2" option ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -261,7 +261,7 @@ exports[`web socket server URL should work with "http2" option ("sockjs"): page 
 
 exports[`web socket server URL should work with "http2" option ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -271,7 +271,7 @@ exports[`web socket server URL should work with "http2" option ("ws"): page erro
 
 exports[`web socket server URL should work with "https" option ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -281,7 +281,7 @@ exports[`web socket server URL should work with "https" option ("sockjs"): page 
 
 exports[`web socket server URL should work with "https" option ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -291,7 +291,7 @@ exports[`web socket server URL should work with "https" option ("ws"): page erro
 
 exports[`web socket server URL should work with "server: 'https'" option ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -301,7 +301,7 @@ exports[`web socket server URL should work with "server: 'https'" option ("sockj
 
 exports[`web socket server URL should work with "server: 'https'" option ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -311,7 +311,7 @@ exports[`web socket server URL should work with "server: 'https'" option ("ws"):
 
 exports[`web socket server URL should work with "server: 'spdy'" option ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -321,7 +321,7 @@ exports[`web socket server URL should work with "server: 'spdy'" option ("sockjs
 
 exports[`web socket server URL should work with "server: 'spdy'" option ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -331,7 +331,7 @@ exports[`web socket server URL should work with "server: 'spdy'" option ("ws"): 
 
 exports[`web socket server URL should work with default "/ws" value of the "client.webSocketURL.pathname" option ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -341,7 +341,7 @@ exports[`web socket server URL should work with default "/ws" value of the "clie
 
 exports[`web socket server URL should work with default "/ws" value of the "client.webSocketURL.pathname" option ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -351,7 +351,7 @@ exports[`web socket server URL should work with default "/ws" value of the "clie
 
 exports[`web socket server URL should work with the "client.webSocketURL" option as "string" ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -361,7 +361,7 @@ exports[`web socket server URL should work with the "client.webSocketURL" option
 
 exports[`web socket server URL should work with the "client.webSocketURL" option as "string" ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -371,7 +371,7 @@ exports[`web socket server URL should work with the "client.webSocketURL" option
 
 exports[`web socket server URL should work with the "client.webSocketURL.host" option ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -381,7 +381,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.host" o
 
 exports[`web socket server URL should work with the "client.webSocketURL.host" option ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -391,7 +391,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.host" o
 
 exports[`web socket server URL should work with the "client.webSocketURL.host" option using "0.0.0.0" value ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -401,7 +401,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.host" o
 
 exports[`web socket server URL should work with the "client.webSocketURL.host" option using "0.0.0.0" value ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -411,7 +411,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.host" o
 
 exports[`web socket server URL should work with the "client.webSocketURL.password" option ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -421,7 +421,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.passwor
 
 exports[`web socket server URL should work with the "client.webSocketURL.password" option ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -431,7 +431,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.passwor
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -441,7 +441,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -451,7 +451,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option and the custom web socket server "path" ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -461,7 +461,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option and the custom web socket server "path" ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -471,7 +471,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option and the custom web socket server "path" ending with slash ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -481,7 +481,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option and the custom web socket server "path" ending with slash ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -491,7 +491,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option and the custom web socket server "path" ending without slash ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -501,7 +501,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option and the custom web socket server "path" ending without slash ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -511,7 +511,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option and the custom web socket server "path" using empty value ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -521,7 +521,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option and the custom web socket server "path" using empty value ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -531,7 +531,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option and the custom web socket server "prefix" for compatibility with "sockjs" ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -541,7 +541,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option and the custom web socket server "prefix" for compatibility with "sockjs" ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -551,7 +551,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.port" option ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -561,7 +561,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.port" o
 
 exports[`web socket server URL should work with the "client.webSocketURL.port" option ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -571,7 +571,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.port" o
 
 exports[`web socket server URL should work with the "client.webSocketURL.port" option as string ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -581,7 +581,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.port" o
 
 exports[`web socket server URL should work with the "client.webSocketURL.port" option as string ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -591,7 +591,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.port" o
 
 exports[`web socket server URL should work with the "client.webSocketURL.port" option using "0" value ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -601,7 +601,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.port" o
 
 exports[`web socket server URL should work with the "client.webSocketURL.port" option using "0" value ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -611,7 +611,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.port" o
 
 exports[`web socket server URL should work with the "client.webSocketURL.protocol" option ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -621,7 +621,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.protoco
 
 exports[`web socket server URL should work with the "client.webSocketURL.protocol" option ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -631,7 +631,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.protoco
 
 exports[`web socket server URL should work with the "client.webSocketURL.protocol" option using "auto:" value ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -641,7 +641,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.protoco
 
 exports[`web socket server URL should work with the "client.webSocketURL.protocol" option using "auto:" value ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -651,7 +651,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.protoco
 
 exports[`web socket server URL should work with the "client.webSocketURL.protocol" option using "http:" value and covert to "ws:" ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -661,7 +661,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.protoco
 
 exports[`web socket server URL should work with the "client.webSocketURL.protocol" option using "http:" value and covert to "ws:" ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -671,7 +671,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.protoco
 
 exports[`web socket server URL should work with the "client.webSocketURL.username" and "client.webSocketURL.password" option ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -681,7 +681,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.usernam
 
 exports[`web socket server URL should work with the "client.webSocketURL.username" and "client.webSocketURL.password" option ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -691,7 +691,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.usernam
 
 exports[`web socket server URL should work with the "client.webSocketURL.username" option ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -701,7 +701,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.usernam
 
 exports[`web socket server URL should work with the "client.webSocketURL.username" option ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -711,7 +711,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.usernam
 
 exports[`web socket server URL should work with the custom web socket server "path" ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -721,7 +721,7 @@ exports[`web socket server URL should work with the custom web socket server "pa
 
 exports[`web socket server URL should work with the custom web socket server "path" ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -731,7 +731,7 @@ exports[`web socket server URL should work with the custom web socket server "pa
 
 exports[`web socket server URL should work with the custom web socket server "path" using empty value ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]
@@ -741,7 +741,7 @@ exports[`web socket server URL should work with the custom web socket server "pa
 
 exports[`web socket server URL should work with the custom web socket server "path" using empty value ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
 ]

--- a/test/e2e/__snapshots__/web-socket-server-url.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/web-socket-server-url.test.js.snap.webpack5
@@ -2,6 +2,7 @@
 
 exports[`web socket server URL should not work and output disconnect wrong web socket URL ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "Failed to load resource: net::ERR_NAME_NOT_RESOLVED",
@@ -13,6 +14,7 @@ exports[`web socket server URL should not work and output disconnect wrong web s
 
 exports[`web socket server URL should not work and output disconnect wrong web socket URL ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "WebSocket connection to 'ws://unknown.unknown:<port>/unknown' failed: Error in connection establishment: net::ERR_NAME_NOT_RESOLVED",
@@ -41,6 +43,7 @@ Array [
 
 exports[`web socket server URL should work behind proxy, when hostnames are different and ports are different ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -52,6 +55,7 @@ exports[`web socket server URL should work behind proxy, when hostnames are diff
 
 exports[`web socket server URL should work behind proxy, when hostnames are different and ports are different ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -63,6 +67,7 @@ exports[`web socket server URL should work behind proxy, when hostnames are diff
 
 exports[`web socket server URL should work behind proxy, when hostnames are different and ports are same ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -74,6 +79,7 @@ exports[`web socket server URL should work behind proxy, when hostnames are diff
 
 exports[`web socket server URL should work behind proxy, when hostnames are different and ports are same ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -85,6 +91,7 @@ exports[`web socket server URL should work behind proxy, when hostnames are diff
 
 exports[`web socket server URL should work behind proxy, when hostnames are same and ports are different ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -96,6 +103,7 @@ exports[`web socket server URL should work behind proxy, when hostnames are same
 
 exports[`web socket server URL should work behind proxy, when hostnames are same and ports are different ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -107,6 +115,7 @@ exports[`web socket server URL should work behind proxy, when hostnames are same
 
 exports[`web socket server URL should work behind proxy, when the "host" option is "local-ip" and the "port" option is "auto" ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -118,6 +127,7 @@ exports[`web socket server URL should work behind proxy, when the "host" option 
 
 exports[`web socket server URL should work behind proxy, when the "host" option is "local-ip" and the "port" option is "auto" ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -129,6 +139,7 @@ exports[`web socket server URL should work behind proxy, when the "host" option 
 
 exports[`web socket server URL should work when "host" option is "local-ip" ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -140,6 +151,7 @@ exports[`web socket server URL should work when "host" option is "local-ip" ("so
 
 exports[`web socket server URL should work when "host" option is "local-ip" ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -151,6 +163,7 @@ exports[`web socket server URL should work when "host" option is "local-ip" ("ws
 
 exports[`web socket server URL should work when "host" option is "local-ipv4" ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -162,6 +175,7 @@ exports[`web socket server URL should work when "host" option is "local-ipv4" ("
 
 exports[`web socket server URL should work when "host" option is "local-ipv4" ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -173,6 +187,7 @@ exports[`web socket server URL should work when "host" option is "local-ipv4" ("
 
 exports[`web socket server URL should work when "host" option is IPv4 ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -184,6 +199,7 @@ exports[`web socket server URL should work when "host" option is IPv4 ("sockjs")
 
 exports[`web socket server URL should work when "host" option is IPv4 ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -195,6 +211,7 @@ exports[`web socket server URL should work when "host" option is IPv4 ("ws"): pa
 
 exports[`web socket server URL should work when "port" option is "auto" ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -206,6 +223,7 @@ exports[`web socket server URL should work when "port" option is "auto" ("sockjs
 
 exports[`web socket server URL should work when "port" option is "auto" ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -217,6 +235,7 @@ exports[`web socket server URL should work when "port" option is "auto" ("ws"): 
 
 exports[`web socket server URL should work with "client.webSocketURL.*" options ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -228,6 +247,7 @@ exports[`web socket server URL should work with "client.webSocketURL.*" options 
 
 exports[`web socket server URL should work with "client.webSocketURL.*" options ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -239,6 +259,7 @@ exports[`web socket server URL should work with "client.webSocketURL.*" options 
 
 exports[`web socket server URL should work with "client.webSocketURL.port" and "webSocketServer.options.port" options as string ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -250,6 +271,7 @@ exports[`web socket server URL should work with "client.webSocketURL.port" and "
 
 exports[`web socket server URL should work with "client.webSocketURL.port" and "webSocketServer.options.port" options as string ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -261,6 +283,7 @@ exports[`web socket server URL should work with "client.webSocketURL.port" and "
 
 exports[`web socket server URL should work with "http2" option ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -272,6 +295,7 @@ exports[`web socket server URL should work with "http2" option ("sockjs"): page 
 
 exports[`web socket server URL should work with "http2" option ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -283,6 +307,7 @@ exports[`web socket server URL should work with "http2" option ("ws"): page erro
 
 exports[`web socket server URL should work with "https" option ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -294,6 +319,7 @@ exports[`web socket server URL should work with "https" option ("sockjs"): page 
 
 exports[`web socket server URL should work with "https" option ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -349,6 +375,7 @@ exports[`web socket server URL should work with "server: 'spdy'" option ("ws"): 
 
 exports[`web socket server URL should work with default "/ws" value of the "client.webSocketURL.pathname" option ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -360,6 +387,7 @@ exports[`web socket server URL should work with default "/ws" value of the "clie
 
 exports[`web socket server URL should work with default "/ws" value of the "client.webSocketURL.pathname" option ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -371,6 +399,7 @@ exports[`web socket server URL should work with default "/ws" value of the "clie
 
 exports[`web socket server URL should work with the "client.webSocketURL" option as "string" ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -382,6 +411,7 @@ exports[`web socket server URL should work with the "client.webSocketURL" option
 
 exports[`web socket server URL should work with the "client.webSocketURL" option as "string" ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -393,6 +423,7 @@ exports[`web socket server URL should work with the "client.webSocketURL" option
 
 exports[`web socket server URL should work with the "client.webSocketURL.host" option ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -404,6 +435,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.host" o
 
 exports[`web socket server URL should work with the "client.webSocketURL.host" option ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -415,6 +447,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.host" o
 
 exports[`web socket server URL should work with the "client.webSocketURL.host" option using "0.0.0.0" value ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -426,6 +459,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.host" o
 
 exports[`web socket server URL should work with the "client.webSocketURL.host" option using "0.0.0.0" value ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -437,6 +471,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.host" o
 
 exports[`web socket server URL should work with the "client.webSocketURL.password" option ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -448,6 +483,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.passwor
 
 exports[`web socket server URL should work with the "client.webSocketURL.password" option ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -459,6 +495,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.passwor
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -470,6 +507,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -481,6 +519,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option and the custom web socket server "path" ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -492,6 +531,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option and the custom web socket server "path" ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -503,6 +543,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option and the custom web socket server "path" ending with slash ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -514,6 +555,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option and the custom web socket server "path" ending with slash ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -525,6 +567,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option and the custom web socket server "path" ending without slash ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -536,6 +579,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option and the custom web socket server "path" ending without slash ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -547,6 +591,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option and the custom web socket server "path" using empty value ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -558,6 +603,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option and the custom web socket server "path" using empty value ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -569,6 +615,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option and the custom web socket server "prefix" for compatibility with "sockjs" ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -580,6 +627,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option and the custom web socket server "prefix" for compatibility with "sockjs" ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -591,6 +639,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.port" option ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -602,6 +651,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.port" o
 
 exports[`web socket server URL should work with the "client.webSocketURL.port" option ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -613,6 +663,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.port" o
 
 exports[`web socket server URL should work with the "client.webSocketURL.port" option as string ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -624,6 +675,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.port" o
 
 exports[`web socket server URL should work with the "client.webSocketURL.port" option as string ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -635,6 +687,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.port" o
 
 exports[`web socket server URL should work with the "client.webSocketURL.port" option using "0" value ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -646,6 +699,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.port" o
 
 exports[`web socket server URL should work with the "client.webSocketURL.port" option using "0" value ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -657,6 +711,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.port" o
 
 exports[`web socket server URL should work with the "client.webSocketURL.protocol" option ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -668,6 +723,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.protoco
 
 exports[`web socket server URL should work with the "client.webSocketURL.protocol" option ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -679,6 +735,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.protoco
 
 exports[`web socket server URL should work with the "client.webSocketURL.protocol" option using "auto:" value ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -690,6 +747,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.protoco
 
 exports[`web socket server URL should work with the "client.webSocketURL.protocol" option using "auto:" value ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -701,6 +759,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.protoco
 
 exports[`web socket server URL should work with the "client.webSocketURL.protocol" option using "http:" value and covert to "ws:" ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -712,6 +771,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.protoco
 
 exports[`web socket server URL should work with the "client.webSocketURL.protocol" option using "http:" value and covert to "ws:" ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -723,6 +783,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.protoco
 
 exports[`web socket server URL should work with the "client.webSocketURL.username" and "client.webSocketURL.password" option ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -734,6 +795,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.usernam
 
 exports[`web socket server URL should work with the "client.webSocketURL.username" and "client.webSocketURL.password" option ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -745,6 +807,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.usernam
 
 exports[`web socket server URL should work with the "client.webSocketURL.username" option ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -756,6 +819,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.usernam
 
 exports[`web socket server URL should work with the "client.webSocketURL.username" option ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -767,6 +831,7 @@ exports[`web socket server URL should work with the "client.webSocketURL.usernam
 
 exports[`web socket server URL should work with the custom web socket server "path" ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -778,6 +843,7 @@ exports[`web socket server URL should work with the custom web socket server "pa
 
 exports[`web socket server URL should work with the custom web socket server "path" ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -789,6 +855,7 @@ exports[`web socket server URL should work with the custom web socket server "pa
 
 exports[`web socket server URL should work with the custom web socket server "path" using empty value ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -800,6 +867,7 @@ exports[`web socket server URL should work with the custom web socket server "pa
 
 exports[`web socket server URL should work with the custom web socket server "path" using empty value ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",

--- a/test/e2e/__snapshots__/web-socket-server-url.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/web-socket-server-url.test.js.snap.webpack5
@@ -25,7 +25,11 @@ Array [
 
 exports[`web socket server URL should not work and output disconnect wrong web socket URL ("ws"): page errors 1`] = `Array []`;
 
-exports[`web socket server URL should work and throw an error on invalid web socket URL ("sockjs"): console messages 1`] = `Array []`;
+exports[`web socket server URL should work and throw an error on invalid web socket URL ("sockjs"): console messages 1`] = `
+Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+]
+`;
 
 exports[`web socket server URL should work and throw an error on invalid web socket URL ("sockjs"): page errors 1`] = `
 Array [
@@ -33,7 +37,11 @@ Array [
 ]
 `;
 
-exports[`web socket server URL should work and throw an error on invalid web socket URL ("ws"): console messages 1`] = `Array []`;
+exports[`web socket server URL should work and throw an error on invalid web socket URL ("ws"): console messages 1`] = `
+Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+]
+`;
 
 exports[`web socket server URL should work and throw an error on invalid web socket URL ("ws"): page errors 1`] = `
 Array [

--- a/test/e2e/__snapshots__/web-socket-server-url.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/web-socket-server-url.test.js.snap.webpack5
@@ -39,7 +39,7 @@ Array [
 
 exports[`web socket server URL should work and throw an error on invalid web socket URL ("ws"): console messages 1`] = `
 Array [
- "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
 ]
 `;
 

--- a/test/e2e/__snapshots__/web-socket-server-url.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/web-socket-server-url.test.js.snap.webpack5
@@ -2,7 +2,7 @@
 
 exports[`web socket server URL should not work and output disconnect wrong web socket URL ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "Failed to load resource: net::ERR_NAME_NOT_RESOLVED",
@@ -14,7 +14,7 @@ exports[`web socket server URL should not work and output disconnect wrong web s
 
 exports[`web socket server URL should not work and output disconnect wrong web socket URL ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "WebSocket connection to 'ws://unknown.unknown:<port>/unknown' failed: Error in connection establishment: net::ERR_NAME_NOT_RESOLVED",
@@ -27,7 +27,7 @@ exports[`web socket server URL should not work and output disconnect wrong web s
 
 exports[`web socket server URL should work and throw an error on invalid web socket URL ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
 ]
 `;
 
@@ -39,7 +39,7 @@ Array [
 
 exports[`web socket server URL should work and throw an error on invalid web socket URL ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+ "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
 ]
 `;
 
@@ -51,11 +51,9 @@ Array [
 
 exports[`web socket server URL should work behind proxy, when hostnames are different and ports are different ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -63,11 +61,9 @@ exports[`web socket server URL should work behind proxy, when hostnames are diff
 
 exports[`web socket server URL should work behind proxy, when hostnames are different and ports are different ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -75,11 +71,9 @@ exports[`web socket server URL should work behind proxy, when hostnames are diff
 
 exports[`web socket server URL should work behind proxy, when hostnames are different and ports are same ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -87,11 +81,9 @@ exports[`web socket server URL should work behind proxy, when hostnames are diff
 
 exports[`web socket server URL should work behind proxy, when hostnames are different and ports are same ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -99,11 +91,9 @@ exports[`web socket server URL should work behind proxy, when hostnames are diff
 
 exports[`web socket server URL should work behind proxy, when hostnames are same and ports are different ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -111,11 +101,9 @@ exports[`web socket server URL should work behind proxy, when hostnames are same
 
 exports[`web socket server URL should work behind proxy, when hostnames are same and ports are different ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -123,11 +111,9 @@ exports[`web socket server URL should work behind proxy, when hostnames are same
 
 exports[`web socket server URL should work behind proxy, when the "host" option is "local-ip" and the "port" option is "auto" ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -135,11 +121,9 @@ exports[`web socket server URL should work behind proxy, when the "host" option 
 
 exports[`web socket server URL should work behind proxy, when the "host" option is "local-ip" and the "port" option is "auto" ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -147,11 +131,9 @@ exports[`web socket server URL should work behind proxy, when the "host" option 
 
 exports[`web socket server URL should work when "host" option is "local-ip" ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -159,11 +141,9 @@ exports[`web socket server URL should work when "host" option is "local-ip" ("so
 
 exports[`web socket server URL should work when "host" option is "local-ip" ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -171,11 +151,9 @@ exports[`web socket server URL should work when "host" option is "local-ip" ("ws
 
 exports[`web socket server URL should work when "host" option is "local-ipv4" ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -183,11 +161,9 @@ exports[`web socket server URL should work when "host" option is "local-ipv4" ("
 
 exports[`web socket server URL should work when "host" option is "local-ipv4" ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -195,11 +171,9 @@ exports[`web socket server URL should work when "host" option is "local-ipv4" ("
 
 exports[`web socket server URL should work when "host" option is IPv4 ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -207,11 +181,9 @@ exports[`web socket server URL should work when "host" option is IPv4 ("sockjs")
 
 exports[`web socket server URL should work when "host" option is IPv4 ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -219,11 +191,9 @@ exports[`web socket server URL should work when "host" option is IPv4 ("ws"): pa
 
 exports[`web socket server URL should work when "port" option is "auto" ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -231,11 +201,9 @@ exports[`web socket server URL should work when "port" option is "auto" ("sockjs
 
 exports[`web socket server URL should work when "port" option is "auto" ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -243,11 +211,9 @@ exports[`web socket server URL should work when "port" option is "auto" ("ws"): 
 
 exports[`web socket server URL should work with "client.webSocketURL.*" options ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -255,11 +221,9 @@ exports[`web socket server URL should work with "client.webSocketURL.*" options 
 
 exports[`web socket server URL should work with "client.webSocketURL.*" options ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -267,11 +231,9 @@ exports[`web socket server URL should work with "client.webSocketURL.*" options 
 
 exports[`web socket server URL should work with "client.webSocketURL.port" and "webSocketServer.options.port" options as string ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -279,11 +241,9 @@ exports[`web socket server URL should work with "client.webSocketURL.port" and "
 
 exports[`web socket server URL should work with "client.webSocketURL.port" and "webSocketServer.options.port" options as string ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -291,11 +251,9 @@ exports[`web socket server URL should work with "client.webSocketURL.port" and "
 
 exports[`web socket server URL should work with "http2" option ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -303,11 +261,9 @@ exports[`web socket server URL should work with "http2" option ("sockjs"): page 
 
 exports[`web socket server URL should work with "http2" option ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -315,11 +271,9 @@ exports[`web socket server URL should work with "http2" option ("ws"): page erro
 
 exports[`web socket server URL should work with "https" option ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -327,11 +281,9 @@ exports[`web socket server URL should work with "https" option ("sockjs"): page 
 
 exports[`web socket server URL should work with "https" option ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -339,11 +291,9 @@ exports[`web socket server URL should work with "https" option ("ws"): page erro
 
 exports[`web socket server URL should work with "server: 'https'" option ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -351,11 +301,9 @@ exports[`web socket server URL should work with "server: 'https'" option ("sockj
 
 exports[`web socket server URL should work with "server: 'https'" option ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -363,11 +311,9 @@ exports[`web socket server URL should work with "server: 'https'" option ("ws"):
 
 exports[`web socket server URL should work with "server: 'spdy'" option ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -375,11 +321,9 @@ exports[`web socket server URL should work with "server: 'spdy'" option ("sockjs
 
 exports[`web socket server URL should work with "server: 'spdy'" option ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -387,11 +331,9 @@ exports[`web socket server URL should work with "server: 'spdy'" option ("ws"): 
 
 exports[`web socket server URL should work with default "/ws" value of the "client.webSocketURL.pathname" option ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -399,11 +341,9 @@ exports[`web socket server URL should work with default "/ws" value of the "clie
 
 exports[`web socket server URL should work with default "/ws" value of the "client.webSocketURL.pathname" option ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -411,11 +351,9 @@ exports[`web socket server URL should work with default "/ws" value of the "clie
 
 exports[`web socket server URL should work with the "client.webSocketURL" option as "string" ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -423,11 +361,9 @@ exports[`web socket server URL should work with the "client.webSocketURL" option
 
 exports[`web socket server URL should work with the "client.webSocketURL" option as "string" ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -435,11 +371,9 @@ exports[`web socket server URL should work with the "client.webSocketURL" option
 
 exports[`web socket server URL should work with the "client.webSocketURL.host" option ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -447,11 +381,9 @@ exports[`web socket server URL should work with the "client.webSocketURL.host" o
 
 exports[`web socket server URL should work with the "client.webSocketURL.host" option ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -459,11 +391,9 @@ exports[`web socket server URL should work with the "client.webSocketURL.host" o
 
 exports[`web socket server URL should work with the "client.webSocketURL.host" option using "0.0.0.0" value ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -471,11 +401,9 @@ exports[`web socket server URL should work with the "client.webSocketURL.host" o
 
 exports[`web socket server URL should work with the "client.webSocketURL.host" option using "0.0.0.0" value ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -483,11 +411,9 @@ exports[`web socket server URL should work with the "client.webSocketURL.host" o
 
 exports[`web socket server URL should work with the "client.webSocketURL.password" option ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -495,11 +421,9 @@ exports[`web socket server URL should work with the "client.webSocketURL.passwor
 
 exports[`web socket server URL should work with the "client.webSocketURL.password" option ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -507,11 +431,9 @@ exports[`web socket server URL should work with the "client.webSocketURL.passwor
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -519,11 +441,9 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -531,11 +451,9 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option and the custom web socket server "path" ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -543,11 +461,9 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option and the custom web socket server "path" ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -555,11 +471,9 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option and the custom web socket server "path" ending with slash ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -567,11 +481,9 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option and the custom web socket server "path" ending with slash ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -579,11 +491,9 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option and the custom web socket server "path" ending without slash ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -591,11 +501,9 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option and the custom web socket server "path" ending without slash ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -603,11 +511,9 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option and the custom web socket server "path" using empty value ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -615,11 +521,9 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option and the custom web socket server "path" using empty value ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -627,11 +531,9 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option and the custom web socket server "prefix" for compatibility with "sockjs" ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -639,11 +541,9 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.pathname" option and the custom web socket server "prefix" for compatibility with "sockjs" ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -651,11 +551,9 @@ exports[`web socket server URL should work with the "client.webSocketURL.pathnam
 
 exports[`web socket server URL should work with the "client.webSocketURL.port" option ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -663,11 +561,9 @@ exports[`web socket server URL should work with the "client.webSocketURL.port" o
 
 exports[`web socket server URL should work with the "client.webSocketURL.port" option ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -675,11 +571,9 @@ exports[`web socket server URL should work with the "client.webSocketURL.port" o
 
 exports[`web socket server URL should work with the "client.webSocketURL.port" option as string ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -687,11 +581,9 @@ exports[`web socket server URL should work with the "client.webSocketURL.port" o
 
 exports[`web socket server URL should work with the "client.webSocketURL.port" option as string ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -699,11 +591,9 @@ exports[`web socket server URL should work with the "client.webSocketURL.port" o
 
 exports[`web socket server URL should work with the "client.webSocketURL.port" option using "0" value ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -711,11 +601,9 @@ exports[`web socket server URL should work with the "client.webSocketURL.port" o
 
 exports[`web socket server URL should work with the "client.webSocketURL.port" option using "0" value ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -723,11 +611,9 @@ exports[`web socket server URL should work with the "client.webSocketURL.port" o
 
 exports[`web socket server URL should work with the "client.webSocketURL.protocol" option ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -735,11 +621,9 @@ exports[`web socket server URL should work with the "client.webSocketURL.protoco
 
 exports[`web socket server URL should work with the "client.webSocketURL.protocol" option ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -747,11 +631,9 @@ exports[`web socket server URL should work with the "client.webSocketURL.protoco
 
 exports[`web socket server URL should work with the "client.webSocketURL.protocol" option using "auto:" value ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -759,11 +641,9 @@ exports[`web socket server URL should work with the "client.webSocketURL.protoco
 
 exports[`web socket server URL should work with the "client.webSocketURL.protocol" option using "auto:" value ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -771,11 +651,9 @@ exports[`web socket server URL should work with the "client.webSocketURL.protoco
 
 exports[`web socket server URL should work with the "client.webSocketURL.protocol" option using "http:" value and covert to "ws:" ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -783,11 +661,9 @@ exports[`web socket server URL should work with the "client.webSocketURL.protoco
 
 exports[`web socket server URL should work with the "client.webSocketURL.protocol" option using "http:" value and covert to "ws:" ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -795,11 +671,9 @@ exports[`web socket server URL should work with the "client.webSocketURL.protoco
 
 exports[`web socket server URL should work with the "client.webSocketURL.username" and "client.webSocketURL.password" option ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -807,11 +681,9 @@ exports[`web socket server URL should work with the "client.webSocketURL.usernam
 
 exports[`web socket server URL should work with the "client.webSocketURL.username" and "client.webSocketURL.password" option ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -819,11 +691,9 @@ exports[`web socket server URL should work with the "client.webSocketURL.usernam
 
 exports[`web socket server URL should work with the "client.webSocketURL.username" option ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -831,11 +701,9 @@ exports[`web socket server URL should work with the "client.webSocketURL.usernam
 
 exports[`web socket server URL should work with the "client.webSocketURL.username" option ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -843,11 +711,9 @@ exports[`web socket server URL should work with the "client.webSocketURL.usernam
 
 exports[`web socket server URL should work with the custom web socket server "path" ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -855,11 +721,9 @@ exports[`web socket server URL should work with the custom web socket server "pa
 
 exports[`web socket server URL should work with the custom web socket server "path" ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -867,11 +731,9 @@ exports[`web socket server URL should work with the custom web socket server "pa
 
 exports[`web socket server URL should work with the custom web socket server "path" using empty value ("sockjs"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 
@@ -879,11 +741,9 @@ exports[`web socket server URL should work with the custom web socket server "pa
 
 exports[`web socket server URL should work with the custom web socket server "path" using empty value ("ws"): console messages 1`] = `
 Array [
-  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
-  "[webpack-dev-server] Hot Module Replacement enabled.",
-  "[webpack-dev-server] Live Reloading enabled.",
 ]
 `;
 

--- a/test/e2e/__snapshots__/web-socket-server-url.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/web-socket-server-url.test.js.snap.webpack5
@@ -339,6 +339,7 @@ exports[`web socket server URL should work with "https" option ("ws"): page erro
 
 exports[`web socket server URL should work with "server: 'https'" option ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -350,6 +351,7 @@ exports[`web socket server URL should work with "server: 'https'" option ("sockj
 
 exports[`web socket server URL should work with "server: 'https'" option ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -361,6 +363,7 @@ exports[`web socket server URL should work with "server: 'https'" option ("ws"):
 
 exports[`web socket server URL should work with "server: 'spdy'" option ("sockjs"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",
@@ -372,6 +375,7 @@ exports[`web socket server URL should work with "server: 'spdy'" option ("sockjs
 
 exports[`web socket server URL should work with "server: 'spdy'" option ("ws"): console messages 1`] = `
 Array [
+  "[webpack-dev-server] Overlay is enabled for both errors and warnings.",
   "[HMR] Waiting for update signal from WDS...",
   "Hey.",
   "[webpack-dev-server] Hot Module Replacement enabled.",

--- a/test/e2e/api.test.js
+++ b/test/e2e/api.test.js
@@ -9,7 +9,7 @@ const runBrowser = require("../helpers/run-browser");
 const port = require("../ports-map").api;
 
 describe("API", () => {
-  describe("WEBPACK_SERVE environment variable", () => {
+  describe.skip("WEBPACK_SERVE environment variable", () => {
     const OLD_ENV = process.env;
     let server;
     let page;
@@ -542,7 +542,7 @@ describe("API", () => {
     });
   });
 
-  describe("Server.getFreePort", () => {
+  describe.skip("Server.getFreePort", () => {
     let dummyServers = [];
     let devServerPort;
 

--- a/test/e2e/api.test.js
+++ b/test/e2e/api.test.js
@@ -9,7 +9,7 @@ const runBrowser = require("../helpers/run-browser");
 const port = require("../ports-map").api;
 
 describe("API", () => {
-  describe.skip("WEBPACK_SERVE environment variable", () => {
+  describe("WEBPACK_SERVE environment variable", () => {
     const OLD_ENV = process.env;
     let server;
     let page;
@@ -542,7 +542,7 @@ describe("API", () => {
     });
   });
 
-  describe.skip("Server.getFreePort", () => {
+  describe("Server.getFreePort", () => {
     let dummyServers = [];
     let devServerPort;
 

--- a/test/e2e/entry.test.js
+++ b/test/e2e/entry.test.js
@@ -14,9 +14,7 @@ const HOT_ENABLED_MESSAGE =
 const waitForConsoleLogFinished = async (consoleLogs) => {
   await new Promise((resolve) => {
     const interval = setInterval(() => {
-      if (
-        consoleLogs.includes(HOT_ENABLED_MESSAGE)
-      ) {
+      if (consoleLogs.includes(HOT_ENABLED_MESSAGE)) {
         clearInterval(interval);
 
         resolve();

--- a/test/e2e/entry.test.js
+++ b/test/e2e/entry.test.js
@@ -9,16 +9,13 @@ const port = require("../ports-map").entry;
 const isWebpack5 = require("../helpers/isWebpack5");
 
 const HOT_ENABLED_MESSAGE =
-  "[webpack-dev-server] Hot Module Replacement enabled.";
-const LIVE_RELOAD_ENABLED_MESSAGE =
-  "[webpack-dev-server] Hot Module Replacement enabled.";
+  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.";
 
 const waitForConsoleLogFinished = async (consoleLogs) => {
   await new Promise((resolve) => {
     const interval = setInterval(() => {
       if (
-        consoleLogs.includes(HOT_ENABLED_MESSAGE) &&
-        consoleLogs.includes(LIVE_RELOAD_ENABLED_MESSAGE)
+        consoleLogs.includes(HOT_ENABLED_MESSAGE)
       ) {
         clearInterval(interval);
 

--- a/test/e2e/entry.test.js
+++ b/test/e2e/entry.test.js
@@ -9,7 +9,7 @@ const port = require("../ports-map").entry;
 const isWebpack5 = require("../helpers/isWebpack5");
 
 const HOT_ENABLED_MESSAGE =
-  "[webpack-dev-server] server started with Hot Module Replacement, Live Reloading, Overlay enabled.";
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.";
 
 const waitForConsoleLogFinished = async (consoleLogs) => {
   await new Promise((resolve) => {

--- a/types/lib/Server.d.ts
+++ b/types/lib/Server.d.ts
@@ -865,6 +865,12 @@ declare class Server {
           description: string;
           negatedDescription: string;
           path: string;
+          /**
+           * prependEntry Method for webpack 4
+           * @param {any} originalEntry
+           * @param {any} newAdditionalEntries
+           * @returns {any}
+           */
         }[];
         description: string;
         simpleType: string;
@@ -905,21 +911,21 @@ declare class Server {
       "magic-html": {
         configs: {
           type: string;
-          /** @type {string} */ multiple: boolean;
+          multiple: boolean;
           description: string;
           negatedDescription: string;
           path: string;
         }[];
         description: string;
         simpleType: string;
-        multiple: boolean /** @type {MultiCompiler} */;
+        multiple: boolean;
       };
       open: {
         configs: (
           | {
               type: string;
               multiple: boolean;
-              description: string;
+              /** @type {MultiCompiler} */ description: string;
               path: string;
             }
           | {
@@ -938,7 +944,7 @@ declare class Server {
         configs: {
           type: string;
           multiple: boolean;
-          /** @type {MultiCompiler} */ description: string;
+          description: string;
           path: string;
         }[];
         description: string;
@@ -955,6 +961,10 @@ declare class Server {
         description: string;
         simpleType: string;
         multiple: boolean;
+        /**
+         * @param {WatchOptions & { aggregateTimeout?: number, ignored?: WatchOptions["ignored"], poll?: number | boolean }} watchOptions
+         * @returns {WatchOptions}
+         */
       };
       "open-app-name-reset": {
         configs: {
@@ -1185,7 +1195,7 @@ declare class Server {
         }[];
         description: string;
         multiple: boolean;
-        simpleType: string;
+        simpleType: string /** @type {ServerOptions} */;
       };
       static: {
         configs: (
@@ -1198,7 +1208,7 @@ declare class Server {
           | {
               type: string;
               multiple: boolean;
-              description: string;
+              /** @type {ServerOptions} */ description: string;
               negatedDescription: string;
               path: string;
             }
@@ -1210,10 +1220,14 @@ declare class Server {
       "static-directory": {
         configs: {
           type: string;
-          multiple: boolean;
+          /** @type {any} */ multiple: boolean;
           description: string;
           path: string;
         }[];
+        /**
+         * @param {string | Buffer | undefined} item
+         * @returns {string | Buffer | undefined}
+         */
         description: string;
         simpleType: string;
         multiple: boolean;
@@ -1226,7 +1240,7 @@ declare class Server {
           path: string;
         }[];
         description: string;
-        simpleType: string;
+        /** @type {any} */ simpleType: string;
         multiple: boolean;
       };
       "static-public-path-reset": {
@@ -1323,7 +1337,7 @@ declare class Server {
         )[];
         description: string;
         simpleType: string;
-        /** @type {ServerOptions} */ multiple: boolean;
+        multiple: boolean;
       };
       "web-socket-server-type": {
         configs: (
@@ -1338,12 +1352,12 @@ declare class Server {
               description: string;
               multiple: boolean;
               path: string;
-              type: string;
+              type: string /** @type {ServerOptions & { cacert?: ServerOptions["ca"] }} */;
             }
         )[];
         description: string;
-        /** @type {ServerOptions} */ simpleType: string;
-        multiple: boolean;
+        simpleType: string;
+        multiple: boolean /** @type {ServerOptions} */;
       };
     };
     readonly processArguments: (
@@ -2408,7 +2422,6 @@ declare class Server {
         };
       };
       OpenString: {
-        /** @type {Object<string,string>} */
         type: string;
         minLength: number;
       };
@@ -2437,7 +2450,6 @@ declare class Server {
             }
         )[];
         description: string;
-        /** @type {any} */
         link: string;
       };
       Proxy: {
@@ -2475,7 +2487,6 @@ declare class Server {
       ServerType: {
         enum: string[];
       };
-      /** @type {MultiCompiler} */
       ServerEnum: {
         enum: string[];
         cli: {
@@ -2491,7 +2502,6 @@ declare class Server {
       };
       ServerObject: {
         type: string;
-        /** @type {MultiCompiler} */
         properties: {
           type: {
             anyOf: {
@@ -2903,7 +2913,7 @@ declare class Server {
           $ref: string;
         }[];
         description: string;
-        link: string /** @type {ServerOptions} */;
+        link: string;
       };
       WebSocketServerType: {
         enum: string[];
@@ -2912,10 +2922,10 @@ declare class Server {
         anyOf: (
           | {
               enum: boolean[];
-              cli: {
+              /** @type {ServerOptions} */ cli: {
                 negatedDescription: string;
               };
-              $ref?: undefined;
+              /** @type {ServerOptions} */ $ref?: undefined;
             }
           | {
               $ref: string;
@@ -2983,7 +2993,7 @@ declare class Server {
         $ref: string;
       };
       http2: {
-        $ref: string /** @type {ServerOptions} */;
+        $ref: string;
       };
       https: {
         $ref: string;

--- a/types/lib/Server.d.ts
+++ b/types/lib/Server.d.ts
@@ -863,7 +863,7 @@ declare class Server {
           type: string;
           multiple: boolean;
           description: string;
-          /** @type {Object<string,string>} */ negatedDescription: string;
+          negatedDescription: string;
           path: string;
         }[];
         description: string;
@@ -875,13 +875,12 @@ declare class Server {
           | {
               type: string;
               multiple: boolean;
-              /** @type {any} */
               description: string;
               path: string;
             }
           | {
               type: string;
-              /** @type {any} */ values: boolean[];
+              values: boolean[];
               multiple: boolean;
               description: string;
               path: string;
@@ -906,14 +905,14 @@ declare class Server {
       "magic-html": {
         configs: {
           type: string;
-          multiple: boolean;
+          /** @type {string} */ multiple: boolean;
           description: string;
           negatedDescription: string;
           path: string;
         }[];
         description: string;
         simpleType: string;
-        multiple: boolean;
+        multiple: boolean /** @type {MultiCompiler} */;
       };
       open: {
         configs: (
@@ -931,7 +930,7 @@ declare class Server {
               path: string;
             }
         )[];
-        /** @type {Compiler} */ description: string;
+        description: string;
         simpleType: string;
         multiple: boolean;
       };
@@ -939,7 +938,7 @@ declare class Server {
         configs: {
           type: string;
           multiple: boolean;
-          description: string;
+          /** @type {MultiCompiler} */ description: string;
           path: string;
         }[];
         description: string;
@@ -987,7 +986,7 @@ declare class Server {
           path: string;
         }[];
         description: string;
-        /** @type {NormalizedStatic} */ simpleType: string;
+        simpleType: string;
         multiple: boolean;
       };
       "open-target-reset": {
@@ -1162,9 +1161,8 @@ declare class Server {
         }[];
         description: string;
         multiple: boolean;
-        simpleType: string /** @type {ServerOptions} */;
+        simpleType: string;
       };
-      /** @type {ServerOptions} */
       "server-options-request-cert": {
         configs: {
           description: string;
@@ -1200,10 +1198,6 @@ declare class Server {
           | {
               type: string;
               multiple: boolean;
-              /**
-               * @param {string | Buffer | undefined} item
-               * @returns {string | Buffer | undefined}
-               */
               description: string;
               negatedDescription: string;
               path: string;
@@ -1220,7 +1214,7 @@ declare class Server {
           description: string;
           path: string;
         }[];
-        /** @type {any} */ description: string;
+        description: string;
         simpleType: string;
         multiple: boolean;
       };
@@ -1327,11 +1321,9 @@ declare class Server {
               type: string;
             }
         )[];
-        /** @type {ServerOptions & { cacert?: ServerOptions["ca"] }} */
         description: string;
-        /** @type {ServerOptions} */
         simpleType: string;
-        multiple: boolean;
+        /** @type {ServerOptions} */ multiple: boolean;
       };
       "web-socket-server-type": {
         configs: (
@@ -1350,7 +1342,7 @@ declare class Server {
             }
         )[];
         description: string;
-        simpleType: string;
+        /** @type {ServerOptions} */ simpleType: string;
         multiple: boolean;
       };
     };
@@ -2374,12 +2366,6 @@ declare class Server {
                       anyOf: (
                         | {
                             type: string;
-                            /**
-                             * prependEntry Method for webpack 4
-                             * @param {any} originalEntry
-                             * @param {any} newAdditionalEntries
-                             * @returns {any}
-                             */
                             items: {
                               type: string;
                               minLength: number;
@@ -2421,8 +2407,8 @@ declare class Server {
           };
         };
       };
-      /** @type {any} */
       OpenString: {
+        /** @type {Object<string,string>} */
         type: string;
         minLength: number;
       };
@@ -2451,6 +2437,7 @@ declare class Server {
             }
         )[];
         description: string;
+        /** @type {any} */
         link: string;
       };
       Proxy: {
@@ -2480,7 +2467,7 @@ declare class Server {
       };
       Server: {
         anyOf: {
-          $ref: string /** @type {MultiCompiler} */;
+          $ref: string;
         }[];
         link: string;
         description: string;
@@ -2488,6 +2475,7 @@ declare class Server {
       ServerType: {
         enum: string[];
       };
+      /** @type {MultiCompiler} */
       ServerEnum: {
         enum: string[];
         cli: {
@@ -2503,6 +2491,7 @@ declare class Server {
       };
       ServerObject: {
         type: string;
+        /** @type {MultiCompiler} */
         properties: {
           type: {
             anyOf: {
@@ -2631,7 +2620,6 @@ declare class Server {
                     anyOf: (
                       | {
                           type: string;
-                          /** @type {NormalizedStatic} */
                           instanceof?: undefined;
                         }
                       | {
@@ -2915,7 +2903,7 @@ declare class Server {
           $ref: string;
         }[];
         description: string;
-        link: string;
+        link: string /** @type {ServerOptions} */;
       };
       WebSocketServerType: {
         enum: string[];
@@ -2936,7 +2924,7 @@ declare class Server {
             }
         )[];
         cli: {
-          description: string /** @type {any} */;
+          description: string;
         };
       };
       WebSocketServerFunction: {
@@ -2995,7 +2983,7 @@ declare class Server {
         $ref: string;
       };
       http2: {
-        $ref: string;
+        $ref: string /** @type {ServerOptions} */;
       };
       https: {
         $ref: string;


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [ ] This is a **bugfix**
- [x] This is a **feature**
- [ ] This is a **code refactor**
- [x] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?
Yes
<!-- Please note that we won't approve your changes if you don't add tests. -->

### Motivation / Use-Case

Fix https://github.com/webpack/webpack-dev-server/pull/4157
Fix https://github.com/webpack/webpack-dev-server/issues/4156
allow to configure `progress` and `overlay` options via resource URL.

<!--
  What existing problem does the pull request solve?

  Please explain the motivation or use-case for making this change.
  If this Pull Request addresses an issue, please link to the issue.
-->

### Breaking Changes
None
<!--
  If this PR introduces a breaking change, please describe the impact and a
  potential migration path for existing applications.
-->

### Additional Info
NO