### PR TITLE
fix: use correct port for https reverse proxy

### DIFF
--- a/client-src/utils/createSocketURL.js
+++ b/client-src/utils/createSocketURL.js
@@ -74,6 +74,7 @@ function format(objURL) {
  */
 function createSocketURL(parsedURL) {
   let { hostname } = parsedURL;
+  let socketURLPort = parsedURL.port;
 
   // Node.js module parses it as `::`
   // `new URL(urlString, [baseURLString])` parses it as '[::]'
@@ -89,6 +90,9 @@ function createSocketURL(parsedURL) {
     self.location.protocol.indexOf("http") === 0
   ) {
     hostname = self.location.hostname;
+    // If we are using the location.hostname for the hostname, we should use the port from
+    // the location as well
+    socketURLPort = self.location.port;
   }
 
   let socketURLProtocol = parsedURL.protocol || self.location.protocol;
@@ -134,8 +138,6 @@ function createSocketURL(parsedURL) {
     self.location.hostname ||
     "localhost"
   ).replace(/^\[(.*)\]$/, "$1");
-
-  let socketURLPort = parsedURL.port;
 
   if (!socketURLPort || socketURLPort === "0") {
     socketURLPort = self.location.port;

--- a/test/client/utils/createSocketURL.test.js
+++ b/test/client/utils/createSocketURL.test.js
@@ -100,6 +100,16 @@ describe("'createSocketURL' function ", () => {
     [null, "file:///home/user/project/index.html", "ws://localhost/ws"],
     [null, "chrome-extension://localhost/", "ws://localhost/ws"],
     [null, "file://localhost/", "ws://localhost/ws"],
+    [
+      "?protocol=ws:&hostname=0.0.0.0&port=3000&pathname=/ws&logging=none&reconnect=10",
+      "https://app.test.com",
+      "wss://app.test.com/ws",
+    ],
+    [
+      "?protocol=ws:&hostname=0.0.0.0&port=3000&pathname=/ws&logging=none&reconnect=10",
+      "https://app.test.com:7777",
+      "wss://app.test.com:7777/ws",
+    ],
   ];
 
   samples.forEach(([__resourceQuery, location, expected]) => {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [x] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?
New test cases have been added
<!-- Please note that we won't approve your changes if you don't add tests. -->

### Motivation / Use-Case
This solves https://github.com/webpack/webpack-dev-server/issues/4292 where the port of the webpack dev server is used instead of the port from the `location` in https situations.
<!--
  What existing problem does the pull request solve?

  Please explain the motivation or use-case for making this change.
  If this Pull Request addresses an issue, please link to the issue.
-->

### Breaking Changes
no breaking changes
<!--
  If this PR introduces a breaking change, please describe the impact and a
  potential migration path for existing applications.
-->

### Additional Info
