### PR TITLE
Add a note about TypeScript usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ fast in-memory access to the webpack assets.
   - [With the CLI](#with-the-cli)
   - [With NPM Scripts](#with-npm-scripts)
   - [With the API](#with-the-api)
+  - [With TypeScript](#with-typescript)
   - [The Result](#the-result)
 - [Browser Support](#browser-support)
 - [Support](#support)
@@ -248,6 +249,30 @@ execute the file or command.
 While it's recommended to run webpack-dev-server via the CLI, you may also choose to start a server via the API.
 
 See the related [API documentation for `webpack-dev-server`](https://webpack.js.org/api/webpack-dev-server/).
+
+### With TypeScript
+
+If you use TypeScript in the webpack config, you'll need to properly type `devServer` property in order to avoid TS errors (e.g. `'devServer' does not exist in type 'Configuration'`). For that use either:
+
+```ts
+/// <reference path="node_modules/webpack-dev-server/types/lib/Server.d.ts"/>
+import type { Configuration } from "webpack";
+
+// Your logic
+```
+
+Or you can import the type from `webpack-dev-server`, i.e.
+
+```ts
+import type { Configuration as DevServerConfiguration } from "webpack-dev-server";
+import type { Configuration } from "webpack";
+
+const devServer: DevServerConfiguration = {};
+const config: Configuration = { devServer };
+
+// module.exports
+export default config;
+```
 
 ### The Result
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [ ] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [x] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

<!-- Please note that we won't approve your changes if you don't add tests. -->

### Motivation / Use-Case

<!--
  What existing problem does the pull request solve?

  Please explain the motivation or use-case for making this change.
  If this Pull Request addresses an issue, please link to the issue.
-->

This explains how to fix a pretty common issue with the `devServer` types definition when webpack config is written in TypeScript (`'devServer' does not exist in type 'Configuration'`).

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  potential migration path for existing applications.
-->

### Additional Info
