### PR TITLE
feat: export initialized socket client

### DIFF
--- a/client-src/socket.js
+++ b/client-src/socket.js
@@ -18,6 +18,8 @@ let retries = 0;
 let maxRetries = 10;
 
 // Initialized client is exported so external consumers can utilize the same instance
+// It is mutable to enforce singleton
+// eslint-disable-next-line no-mutable-exports
 export let client = null;
 
 /**

--- a/client-src/socket.js
+++ b/client-src/socket.js
@@ -19,7 +19,7 @@ let maxRetries = 10;
 
 // Initialized client is exported so external consumers can utilize the same instance
 // It is mutable to enforce singleton
-// eslint-disable-next-line no-mutable-exports
+// eslint-disable-next-line import/no-mutable-exports
 export let client = null;
 
 /**

--- a/client-src/socket.js
+++ b/client-src/socket.js
@@ -16,7 +16,9 @@ const Client =
 
 let retries = 0;
 let maxRetries = 10;
-let client = null;
+
+// Initialized client is exported so external consumers can utilize the same instance
+export let client = null;
 
 /**
  * @param {string} url

--- a/test/client/socket-helper.test.js
+++ b/test/client/socket-helper.test.js
@@ -5,7 +5,7 @@
 "use strict";
 
 describe("socket", () => {
-  afterEach(() => {
+  beforeEach(() => {
     jest.resetAllMocks();
     jest.resetModules();
   });
@@ -76,5 +76,20 @@ describe("socket", () => {
     expect(mockClientInstance.onClose.mock.calls).toMatchSnapshot();
     expect(mockClientInstance.onMessage.mock.calls).toMatchSnapshot();
     expect(mockHandler.mock.calls).toMatchSnapshot();
+  });
+
+  it("should export initialized client", () => {
+    const socket = require("../../client/socket").default;
+
+    const nonInitializedInstance = require("../../client/socket").client;
+    expect(nonInitializedInstance).toBe(null);
+
+    socket("my.url", {});
+
+    const initializedInstance = require("../../client/socket").client;
+    expect(initializedInstance).not.toBe(null);
+    expect(typeof initializedInstance.onClose).toBe("function");
+    expect(typeof initializedInstance.onMessage).toBe("function");
+    expect(typeof initializedInstance.onOpen).toBe("function");
   });
 });


### PR DESCRIPTION
- [ ] This is a **bugfix**
- [x] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

~No new tests are added as I believe this is a simple change and no additional functionality is added, it just exposes a bit more of the private parts.~

Added a simple test for `null` value before init, and a "valid" client instance after init.

### Motivation / Use-Case

Fixes #4261
Fixes #4324

### Additional Info

I chose the simplest way to expose the initialized client, so consumers can just import the file and use it - but I'm also ok with setting it to some globals (on `globalThis`/`window`) if you think that's better (I'm unsure if mutable exports are implemented properly when compiled?).
