### PR TITLE
chore: embed strip-ansi dependency

### DIFF
--- a/client-src/index.js
+++ b/client-src/index.js
@@ -1,7 +1,7 @@
 /* global __resourceQuery, __webpack_hash__ */
 /// <reference types="webpack/module" />
 import webpackHotLog from "webpack/hot/log.js";
-import stripAnsi from "./modules/strip-ansi/index.js";
+import stripAnsi from "./utils/stripAnsi.js";
 import parseURL from "./utils/parseURL.js";
 import socket from "./socket.js";
 import { formatProblem, show, hide } from "./overlay.js";

--- a/client-src/modules/strip-ansi/index.js
+++ b/client-src/modules/strip-ansi/index.js
@@ -1,3 +1,0 @@
-import stripAnsi from "strip-ansi";
-
-export default stripAnsi;

--- a/client-src/utils/stripAnsi.js
+++ b/client-src/utils/stripAnsi.js
@@ -1,0 +1,26 @@
+const ansiRegex = new RegExp(
+  [
+    "[\\u001B\\u009B][[\\]()#;?]*(?:(?:(?:(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]+)*|[a-zA-Z\\d]+(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]*)*)?\\u0007)",
+    "(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PR-TZcf-nq-uy=><~]))",
+  ].join("|"),
+  "g"
+);
+
+/**
+ *
+ * Strip [ANSI escape codes](https://en.wikipedia.org/wiki/ANSI_escape_code) from a string.
+ * Adapted from code originally released by Sindre Sorhus
+ * Licensed the MIT License
+ *
+ * @param {string} string
+ * @return {string}
+ */
+function stripAnsi(string) {
+  if (typeof string !== "string") {
+    throw new TypeError(`Expected a \`string\`, got \`${typeof string}\``);
+  }
+
+  return string.replace(ansiRegex, "");
+}
+
+export default stripAnsi;

--- a/client-src/webpack.config.js
+++ b/client-src/webpack.config.js
@@ -79,13 +79,6 @@ module.exports = [
     ],
   }),
   merge(baseForModules, {
-    entry: path.join(__dirname, "modules/strip-ansi/index.js"),
-    output: {
-      // @ts-ignore
-      filename: "strip-ansi/index.js",
-    },
-  }),
-  merge(baseForModules, {
     entry: path.join(__dirname, "modules/sockjs-client/index.js"),
     output: {
       filename: "sockjs-client/index.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,6 @@
         "serve-index": "^1.9.1",
         "sockjs": "^0.3.21",
         "spdy": "^4.0.2",
-        "strip-ansi": "^7.0.0",
         "webpack-dev-middleware": "^5.3.1",
         "ws": "^8.4.2"
       },
@@ -14190,6 +14189,7 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
       "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
+      "dev": true,
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -14214,6 +14214,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
       "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -26479,6 +26480,7 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
       "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
+      "dev": true,
       "requires": {
         "ansi-regex": "^6.0.1"
       },
@@ -26486,7 +26488,8 @@
         "ansi-regex": {
           "version": "6.0.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-          "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA=="
+          "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "serve-index": "^1.9.1",
     "sockjs": "^0.3.21",
     "spdy": "^4.0.2",
-    "strip-ansi": "^7.0.0",
     "webpack-dev-middleware": "^5.3.1",
     "ws": "^8.4.2"
   },

--- a/test/client/index.test.js
+++ b/test/client/index.test.js
@@ -27,7 +27,6 @@ describe("index", () => {
       },
       setLogLevel: jest.fn(),
     });
-    jest.setMock("strip-ansi", require("strip-ansi-v6"));
 
     log = require("../../client-src/utils/log");
 

--- a/test/e2e/__snapshots__/multi-compiler.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/multi-compiler.test.js.snap.webpack5
@@ -55,13 +55,13 @@ Array [
   "[HMR] Cannot apply update. Need to do a full reload!",
   "[HMR] Error: Aborted because ./browser.js is not accepted
 Update propagation: ./browser.js
-    at applyHandler (http://127.0.0.1:8103/browser.js:1017:31)
-    at http://127.0.0.1:8103/browser.js:717:21
+    at applyHandler (http://127.0.0.1:8103/browser.js:1018:31)
+    at http://127.0.0.1:8103/browser.js:718:21
     at Array.map (<anonymous>)
-    at internalApply (http://127.0.0.1:8103/browser.js:716:54)
-    at http://127.0.0.1:8103/browser.js:690:26
-    at waitForBlockingPromises (http://127.0.0.1:8103/browser.js:643:55)
-    at http://127.0.0.1:8103/browser.js:688:24",
+    at internalApply (http://127.0.0.1:8103/browser.js:717:54)
+    at http://127.0.0.1:8103/browser.js:691:26
+    at waitForBlockingPromises (http://127.0.0.1:8103/browser.js:644:55)
+    at http://127.0.0.1:8103/browser.js:689:24",
   "[HMR] Waiting for update signal from WDS...",
   "Hello from the browser",
   "[webpack-dev-server] Hot Module Replacement enabled.",


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [ ] This is a **bugfix**
- [ ] This is a **feature**
- [x] This is a **code refactor**
- [x] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?
No new feature or bugs.
<!-- Please note that we won't approve your changes if you don't add tests. -->

### Motivation / Use-Case 
Simplify the build and tests and reduce dependencies.
Copying the `strip-ansi` source (which is one RegEx and one function testing a string against that) 
1. gets rid of `strip-ansi@7` and `ansi-regex` in production
2. gets rid of the the webpack config to precompile the `ansi-regex` package
3. removes the need to mock `strip-ansi` in the tests
<!--
  What existing problem does the pull request solve?

  Please explain the motivation or use-case for making this change.
  If this Pull Request addresses an issue, please link to the issue.
-->

### Breaking Changes
No breaking changes.
<!--
  If this PR introduces a breaking change, please describe the impact and a
  potential migration path for existing applications.
-->

### Additional Info
The [original strip-ansi  source](https://github.com/chalk/strip-ansi/blob/main/index.js)