### PR TITLE
chore: replace deprecated String.prototype.substr()

### DIFF
--- a/client-src/utils/createSocketURL.js
+++ b/client-src/utils/createSocketURL.js
@@ -5,7 +5,7 @@
 function format(objURL) {
   let protocol = objURL.protocol || "";
 
-  if (protocol && protocol.substr(-1) !== ":") {
+  if (protocol && !protocol.endsWith(":")) {
     protocol += ":";
   }
 

--- a/client-src/utils/parseURL.js
+++ b/client-src/utils/parseURL.js
@@ -9,7 +9,7 @@ function parseURL(resourceQuery) {
   let options = {};
 
   if (typeof resourceQuery === "string" && resourceQuery !== "") {
-    const searchParams = resourceQuery.substr(1).split("&");
+    const searchParams = resourceQuery.slice(1).split("&");
 
     for (let i = 0; i < searchParams.length; i++) {
       const pair = searchParams[i].split("=");

--- a/test/e2e/range-header.test.js
+++ b/test/e2e/range-header.test.js
@@ -42,7 +42,7 @@ describe("'Range' header", () => {
     );
     expect(responseRange.headers["content-length"]).toBe("500");
     expect(responseRange.headers["content-range"]).toMatch(/^bytes 0-499\//);
-    expect(responseRange.text).toBe(responseContent.substr(0, 500));
+    expect(responseRange.text).toBe(responseContent.slice(0, 500));
     expect(responseRange.text.length).toBe(500);
   });
 


### PR DESCRIPTION
This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.

### Breaking Changes

None

### Additional Info
