### PR TITLE
feat: allow to set  the `sockjs_url` option (only `sockjs`)

### DIFF
--- a/lib/servers/SockJSServer.js
+++ b/lib/servers/SockJSServer.js
@@ -41,9 +41,16 @@ module.exports = class SockJSServer extends BaseServer {
   constructor(server) {
     super(server);
 
+    const sockjsUrl =
+      /** @type {NonNullable<WebSocketServerConfiguration["options"]>} */
+      (
+        /** @type {WebSocketServerConfiguration} */
+        (this.server.options.webSocketServer).options
+      ).sockjsUrl ?? "/__webpack_dev_server__/sockjs.bundle.js";
+
     this.implementation = sockjs.createServer({
       // Use provided up-to-date sockjs-client
-      sockjs_url: "/__webpack_dev_server__/sockjs.bundle.js",
+      sockjs_url: sockjsUrl,
       // Default logger is very annoy. Limit useless logs.
       /**
        * @param {string} severity

--- a/lib/servers/SockJSServer.js
+++ b/lib/servers/SockJSServer.js
@@ -41,16 +41,28 @@ module.exports = class SockJSServer extends BaseServer {
   constructor(server) {
     super(server);
 
-    const sockjsUrl =
+    const webSocketServerOptions =
       /** @type {NonNullable<WebSocketServerConfiguration["options"]>} */
       (
         /** @type {WebSocketServerConfiguration} */
         (this.server.options.webSocketServer).options
-      ).sockjsUrl ?? "/__webpack_dev_server__/sockjs.bundle.js";
+      );
+
+    /**
+     * @param {NonNullable<WebSocketServerConfiguration["options"]>} options
+     * @returns {string}
+     */
+    const getSockjsUrl = (options) => {
+      if (typeof options.sockjsUrl !== "undefined") {
+        return options.sockjsUrl;
+      }
+
+      return "/__webpack_dev_server__/sockjs.bundle.js";
+    };
 
     this.implementation = sockjs.createServer({
       // Use provided up-to-date sockjs-client
-      sockjs_url: sockjsUrl,
+      sockjs_url: getSockjsUrl(webSocketServerOptions),
       // Default logger is very annoy. Limit useless logs.
       /**
        * @param {string} severity
@@ -80,15 +92,8 @@ module.exports = class SockJSServer extends BaseServer {
     };
 
     const options = {
-      .../** @type {WebSocketServerConfiguration} */
-      (this.server.options.webSocketServer).options,
-      prefix: getPrefix(
-        /** @type {NonNullable<WebSocketServerConfiguration["options"]>} */
-        (
-          /** @type {WebSocketServerConfiguration} */
-          (this.server.options.webSocketServer).options
-        )
-      ),
+      ...webSocketServerOptions,
+      prefix: getPrefix(webSocketServerOptions),
     };
 
     this.implementation.installHandlers(


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [ ] This is a **bugfix**
- [x] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

To test it we should disable websocket supporting in headless chrome (but it is impossible), as an alternative solution we can allow to set all options for sockjs server, but sockjs is old and only for old IE and Opera, I don't think many developers support it now and we should spend time on it, really, so I tested it manually and all works fine, in the next major release we will remove sockjs

### Motivation / Use-Case

fixes https://github.com/webpack/webpack-dev-server/issues/4348

### Breaking Changes

No

### Additional Info

Should we document it?