### PR TITLE
feat: open editor when clicking error on overlay

### DIFF
--- a/client-src/overlay.js
+++ b/client-src/overlay.js
@@ -184,7 +184,7 @@ function formatProblem(type, item) {
 // Compilation with errors (e.g. syntax error or missing modules).
 /**
  * @param {string} type
- * @param {Array<string  | { file?: string, moduleName?: string, loc?: string, message?: string }>} messages
+ * @param {Array<string  | { moduleIdentifier?: string, moduleName?: string, loc?: string, message?: string }>} messages
  * @param {string | null} trustedTypesPolicyName
  */
 function show(type, messages, trustedTypesPolicyName) {
@@ -202,6 +202,16 @@ function show(type, messages, trustedTypesPolicyName) {
 
       typeElement.innerText = header;
       applyStyle(typeElement, msgTypeStyle);
+
+      if (message.moduleIdentifier) {
+        applyStyle(typeElement, { cursor: "pointer" });
+        typeElement.dataset.canOpen = true;
+        typeElement.addEventListener("click", () => {
+          fetch(
+            `/webpack-dev-server/open-editor?fileName=${message.moduleIdentifier}`
+          );
+        });
+      }
 
       // Make it look similar to our terminal.
       const text = ansiHTML(encode(body));

--- a/examples/client/overlay/app.js
+++ b/examples/client/overlay/app.js
@@ -2,5 +2,9 @@
 
 const target = document.querySelector("#target");
 
+// eslint-disable-next-line import/no-unresolved, import/extensions
+const invalid = require("./invalid.js");
+
+console.log(invalid);
 target.classList.add("pass");
 target.innerHTML = "Success!";

--- a/examples/client/overlay/webpack.config.js
+++ b/examples/client/overlay/webpack.config.js
@@ -7,7 +7,7 @@ const { setup } = require("../../util");
 module.exports = setup({
   context: __dirname,
   // create error for overlay
-  entry: "./invalid.js",
+  entry: "./app.js",
   devServer: {
     client: {
       overlay: true,

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -2034,6 +2034,19 @@ class Server {
     );
 
     /** @type {import("express").Application} */
+    (app).get("/webpack-dev-server/open-editor", (req, res) => {
+      const fileName = req.query.fileName;
+
+      if (typeof fileName === "string") {
+        // @ts-ignore
+        const launchEditor = require("launch-editor");
+        launchEditor(fileName);
+      }
+
+      res.end();
+    });
+
+    /** @type {import("express").Application} */
     (app).get(
       "/webpack-dev-server",
       /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "html-entities": "^2.3.2",
         "http-proxy-middleware": "^2.0.3",
         "ipaddr.js": "^2.0.1",
+        "launch-editor": "^2.6.0",
         "open": "^8.0.9",
         "p-retry": "^4.5.0",
         "rimraf": "^3.0.2",
@@ -94,6 +95,7 @@
         "tcp-port-used": "^1.0.2",
         "typescript": "^4.7.2",
         "url-loader": "^4.1.1",
+        "wait-for-expect": "^3.0.2",
         "webpack": "^5.71.0",
         "webpack-cli": "^4.7.2",
         "webpack-merge": "^5.8.0"
@@ -11041,6 +11043,15 @@
         "node": ">= 8"
       }
     },
+    "node_modules/launch-editor": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.6.0.tgz",
+      "integrity": "sha512-JpDCcQnyAAzZZaZ7vEiSqL690w7dAEyLao+KC96zBplnYbJS7TYNjvM3M7y3dGz+v7aIsJk3hllWuc0kWAjyRQ==",
+      "dependencies": {
+        "picocolors": "^1.0.0",
+        "shell-quote": "^1.7.3"
+      }
+    },
     "node_modules/less": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/less/-/less-4.1.3.tgz",
@@ -13831,8 +13842,7 @@
     "node_modules/shell-quote": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz",
-      "integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==",
-      "dev": true
+      "integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw=="
     },
     "node_modules/side-channel": {
       "version": "1.0.4",
@@ -15274,6 +15284,12 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/wait-for-expect": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/wait-for-expect/-/wait-for-expect-3.0.2.tgz",
+      "integrity": "sha512-cfS1+DZxuav1aBYbaO/kE06EOS8yRw7qOFoD3XtjTkYvCvh3zUvNST8DXK/nPaeqIzIv3P3kL3lRJn8iwOiSag==",
+      "dev": true
     },
     "node_modules/walker": {
       "version": "1.0.8",
@@ -24061,6 +24077,15 @@
       "integrity": "sha512-pJiBpiXMbt7dkzXe8Ghj/u4FfXOOa98fPW+bihOJ4SjnoijweJrNThJfd3ifXpXhREjpoF2mZVH1GfS9LV3kHQ==",
       "dev": true
     },
+    "launch-editor": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.6.0.tgz",
+      "integrity": "sha512-JpDCcQnyAAzZZaZ7vEiSqL690w7dAEyLao+KC96zBplnYbJS7TYNjvM3M7y3dGz+v7aIsJk3hllWuc0kWAjyRQ==",
+      "requires": {
+        "picocolors": "^1.0.0",
+        "shell-quote": "^1.7.3"
+      }
+    },
     "less": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/less/-/less-4.1.3.tgz",
@@ -26141,8 +26166,7 @@
     "shell-quote": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz",
-      "integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==",
-      "dev": true
+      "integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw=="
     },
     "side-channel": {
       "version": "1.0.4",
@@ -27204,6 +27228,12 @@
       "requires": {
         "xml-name-validator": "^4.0.0"
       }
+    },
+    "wait-for-expect": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/wait-for-expect/-/wait-for-expect-3.0.2.tgz",
+      "integrity": "sha512-cfS1+DZxuav1aBYbaO/kE06EOS8yRw7qOFoD3XtjTkYvCvh3zUvNST8DXK/nPaeqIzIv3P3kL3lRJn8iwOiSag==",
+      "dev": true
     },
     "walker": {
       "version": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "html-entities": "^2.3.2",
     "http-proxy-middleware": "^2.0.3",
     "ipaddr.js": "^2.0.1",
+    "launch-editor": "^2.6.0",
     "open": "^8.0.9",
     "p-retry": "^4.5.0",
     "rimraf": "^3.0.2",
@@ -126,6 +127,7 @@
     "tcp-port-used": "^1.0.2",
     "typescript": "^4.7.2",
     "url-loader": "^4.1.1",
+    "wait-for-expect": "^3.0.2",
     "webpack": "^5.71.0",
     "webpack-cli": "^4.7.2",
     "webpack-merge": "^5.8.0"

--- a/test/e2e/__snapshots__/overlay.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/overlay.test.js.snap.webpack5
@@ -90,11 +90,13 @@ exports[`overlay should not show initially, then show on an error and allow to c
       \\"
     >
       <div
+        data-can-open=\\"true\\"
         style=\\"
           color: rgb(232, 59, 70);
           font-size: 1.2em;
           margin-bottom: 1rem;
           font-family: sans-serif;
+          cursor: pointer;
         \\"
       >
         ERROR in ./foo.js 1:1
@@ -212,11 +214,13 @@ exports[`overlay should not show initially, then show on an error, then hide on 
       \\"
     >
       <div
+        data-can-open=\\"true\\"
         style=\\"
           color: rgb(232, 59, 70);
           font-size: 1.2em;
           margin-bottom: 1rem;
           font-family: sans-serif;
+          cursor: pointer;
         \\"
       >
         ERROR in ./foo.js 1:1
@@ -334,11 +338,13 @@ exports[`overlay should not show initially, then show on an error, then show oth
       \\"
     >
       <div
+        data-can-open=\\"true\\"
         style=\\"
           color: rgb(232, 59, 70);
           font-size: 1.2em;
           margin-bottom: 1rem;
           font-family: sans-serif;
+          cursor: pointer;
         \\"
       >
         ERROR in ./foo.js 1:1
@@ -419,11 +425,13 @@ exports[`overlay should not show initially, then show on an error, then show oth
       \\"
     >
       <div
+        data-can-open=\\"true\\"
         style=\\"
           color: rgb(232, 59, 70);
           font-size: 1.2em;
           margin-bottom: 1rem;
           font-family: sans-serif;
+          cursor: pointer;
         \\"
       >
         ERROR in ./foo.js 1:1

--- a/test/helpers/run-browser.js
+++ b/test/helpers/run-browser.js
@@ -3,6 +3,16 @@
 const puppeteer = require("puppeteer");
 const { puppeteerArgs } = require("./puppeteer-constants");
 
+/**
+ * @typedef {Object} RunBrowserResult
+ * @property {import('puppeteer').Page} page
+ * @property {import('puppeteer').Browser} browser
+ */
+
+/**
+ * @param {Parameters<import('puppeteer').Page['emulate']>[0]} config
+ * @returns {Promise<RunBrowserResult>}
+ */
 function runBrowser(config) {
   const options = {
     viewport: {
@@ -14,7 +24,13 @@ function runBrowser(config) {
   };
 
   return new Promise((resolve, reject) => {
+    /**
+     * @type {import('puppeteer').Page}
+     */
     let page;
+    /**
+     * @type {import('puppeteer').Browser}
+     */
     let browser;
 
     puppeteer


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [ ] This is a **bugfix**
- [x] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

<!-- Please note that we won't approve your changes if you don't add tests. -->

### Motivation / Use-Case

This PR make webpack-dev-server open editor when user clicks on the error message on overlay.

Part of #3689.

<!--
  What existing problem does the pull request solve?

  Please explain the motivation or use-case for making this change.
  If this Pull Request addresses an issue, please link to the issue.
-->

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  potential migration path for existing applications.
-->

### Additional Info

- New endpoint `"/webpack-dev-server/open-editor"` is added on the dev server which the client would calls using `fetch`.
- Right now I assume `moduleIdentifier` from the `stats.errors` is the file name, but I not sure if that assumption is correct.
- Use [`launch-editor`](https://github.com/yyx990803/launch-editor) to open editor (it is based on `react-dev-utils` of Create React App, and is being used by Vite as well).
- For webpack 4 the logic does not work because there is no `moduleIdentifier`, but I assume that is not a dealbreaker.