### PR TITLE
refactor!: remove the `content-changed` method from onSocketMessage

### DIFF
--- a/client-src/index.js
+++ b/client-src/index.js
@@ -205,19 +205,6 @@ const onSocketMessage = {
 
     reloadApp(options, status);
   },
-  // TODO: remove in v5 in favor of 'static-changed'
-  /**
-   * @param {string} file
-   */
-  "content-changed": function contentChanged(file) {
-    log.info(
-      `${
-        file ? `"${file}"` : "Content"
-      } from static directory was changed. Reloading...`
-    );
-
-    self.location.reload();
-  },
   /**
    * @param {string} file
    */

--- a/test/client/__snapshots__/index.test.js.snap.webpack5
+++ b/test/client/__snapshots__/index.test.js.snap.webpack5
@@ -56,10 +56,6 @@ BODY: warning",
 ]
 `;
 
-exports[`index should run onSocketMessage['content-changed'] 1`] = `"Content from static directory was changed. Reloading..."`;
-
-exports[`index should run onSocketMessage['content-changed'](file) 1`] = `"\\"/public/assets/index.html\\" from static directory was changed. Reloading..."`;
-
 exports[`index should run onSocketMessage['static-changed'] 1`] = `"Content from static directory was changed. Reloading..."`;
 
 exports[`index should run onSocketMessage['static-changed'](file) 1`] = `"\\"/static/assets/index.html\\" from static directory was changed. Reloading..."`;
@@ -73,7 +69,6 @@ Array [
   "mock-url",
   Object {
     "close": [Function],
-    "content-changed": [Function],
     "error": [Function],
     "errors": [Function],
     "hash": [Function],

--- a/test/client/index.test.js
+++ b/test/client/index.test.js
@@ -154,20 +154,6 @@ describe("index", () => {
     expect(res).toEqual(undefined);
   });
 
-  test("should run onSocketMessage['content-changed']", () => {
-    onSocketMessage["content-changed"]();
-
-    expect(log.log.info.mock.calls[0][0]).toMatchSnapshot();
-    expect(self.location.reload).toBeCalled();
-  });
-
-  test("should run onSocketMessage['content-changed'](file)", () => {
-    onSocketMessage["content-changed"]("/public/assets/index.html");
-
-    expect(log.log.info.mock.calls[0][0]).toMatchSnapshot();
-    expect(self.location.reload).toBeCalled();
-  });
-
   test("should run onSocketMessage['static-changed']", () => {
     onSocketMessage["static-changed"]();
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [ ] This is a **bugfix**
- [ ] This is a **feature**
- [x] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

No.
<!-- Please note that we won't approve your changes if you don't add tests. -->

### Motivation / Use-Case

Remove the deprecated `content-changed` method.

<!--
  What existing problem does the pull request solve?

  Please explain the motivation or use-case for making this change.
  If this Pull Request addresses an issue, please link to the issue.
-->

### Breaking Changes

BREAKING CHANGE: the `content-changed` method was removed in favor of the `static-changed` method.

<!--
  If this PR introduces a breaking change, please describe the impact and a
  potential migration path for existing applications.
-->

### Additional Info
No