### PR TITLE
refactor!: remove the `--web-socket-server` cli option

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -2382,7 +2382,6 @@ class Server {
    * @private
    * @returns {void}
    */
-  // TODO: remove `--web-socket-server` in favor of `--web-socket-server-type`
   createWebSocketServer() {
     /** @type {WebSocketServerImplementation | undefined | null} */
     this.webSocketServer = new /** @type {any} */ (this.getServerTransport())(

--- a/lib/options.json
+++ b/lib/options.json
@@ -897,12 +897,12 @@
           }
         },
         {
-          "$ref": "#/definitions/WebSocketServerType"
+          "enum": ["sockjs", "ws"],
+          "cli": {
+            "exclude": true
+          }
         }
-      ],
-      "cli": {
-        "description": "Deprecated: please use '--web-socket-server-type' option."
-      }
+      ]
     },
     "WebSocketServerFunction": {
       "instanceof": "Function"
@@ -935,7 +935,10 @@
     },
     "WebSocketServerString": {
       "type": "string",
-      "minLength": 1
+      "minLength": 1,
+      "cli": {
+        "exclude": true
+      }
     }
   },
   "additionalProperties": false,

--- a/test/cli/__snapshots__/basic.test.js.snap.webpack5
+++ b/test/cli/__snapshots__/basic.test.js.snap.webpack5
@@ -127,7 +127,6 @@ Options:
   --static-public-path-reset                          Clear all items provided in 'static.publicPath' configuration. The static files will be available in the browser under this public path.
   --watch-files <value...>                            Allows to configure list of globs/directories/files to watch for file changes.
   --watch-files-reset                                 Clear all items provided in 'watchFiles' configuration. Allows to configure list of globs/directories/files to watch for file changes.
-  --web-socket-server <value>                         Deprecated: please use '--web-socket-server-type' option. Allows to set web socket server and options (by default 'ws').
   --no-web-socket-server                              Disallows to set web socket server and options.
   --web-socket-server-type <value>                    Allows to set web socket server and options (by default 'ws').
 

--- a/test/cli/webSocketServer-option.test.js
+++ b/test/cli/webSocketServer-option.test.js
@@ -4,28 +4,6 @@ const { testBin } = require("../helpers/test-bin");
 const port = require("../ports-map")["cli-web-socket-server"];
 
 describe('"webSocketServer" CLI option', () => {
-  it('should work using "--web-socket-server sockjs"', async () => {
-    const { exitCode } = await testBin([
-      "--port",
-      port,
-      "--web-socket-server",
-      "sockjs",
-    ]);
-
-    expect(exitCode).toEqual(0);
-  });
-
-  it('should work using "--web-socket-server ws"', async () => {
-    const { exitCode } = await testBin([
-      "--port",
-      port,
-      "--web-socket-server",
-      "ws",
-    ]);
-
-    expect(exitCode).toEqual(0);
-  });
-
   it('should work using "--web-socket-server-type ws"', async () => {
     const { exitCode } = await testBin([
       "--port",
@@ -43,6 +21,16 @@ describe('"webSocketServer" CLI option', () => {
       port,
       "--web-socket-server-type",
       "sockjs",
+    ]);
+
+    expect(exitCode).toEqual(0);
+  });
+
+  it('should work using "--no-web-socket-server"', async () => {
+    const { exitCode } = await testBin([
+      "--port",
+      port,
+      "--no-web-socket-server",
     ]);
 
     expect(exitCode).toEqual(0);

--- a/types/lib/Server.d.ts
+++ b/types/lib/Server.d.ts
@@ -1291,18 +1291,17 @@ declare class Server {
               enum: boolean[];
               cli: {
                 negatedDescription: string;
+                exclude?: undefined;
               };
-              $ref?: undefined;
             }
           | {
-              $ref: string;
-              enum?: undefined;
-              cli?: undefined /** @typedef {import("express").Request} Request */;
+              enum: string[];
+              cli: {
+                exclude: boolean;
+                negatedDescription?: undefined;
+              };
             }
         )[];
-        cli: {
-          description: string;
-        };
       };
       WebSocketServerFunction: {
         instanceof: string;
@@ -1328,6 +1327,9 @@ declare class Server {
       WebSocketServerString: {
         type: string;
         minLength: number;
+        cli: {
+          exclude: boolean;
+        };
       };
     };
     additionalProperties: boolean;


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [ ] This is a **bugfix**
- [ ] This is a **feature**
- [x] This is a **code refactor**
- [x] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

Added test case for `--no-web-socket-server`.

<!-- Please note that we won't approve your changes if you don't add tests. -->

### Motivation / Use-Case

Remove the deprecated `--web-socket-server` option.
<!--
  What existing problem does the pull request solve?

  Please explain the motivation or use-case for making this change.
  If this Pull Request addresses an issue, please link to the issue.
-->

### Breaking Changes

BREAKING CHANGE: the `--web-socket-server <value>` cli option was removed in favor of the `--web-socket-server-type <value>` cli option
<!--
  If this PR introduces a breaking change, please describe the impact and a
  potential migration path for existing applications.
-->

### Additional Info
NO