### PR TITLE
fix: add client.overlay.runtimeErrors options

### DIFF
--- a/bin/cli-flags.js
+++ b/bin/cli-flags.js
@@ -153,6 +153,23 @@ module.exports = {
     simpleType: "boolean",
     multiple: false,
   },
+  "client-overlay-runtime-errors": {
+    configs: [
+      {
+        type: "boolean",
+        multiple: false,
+        description:
+          "Enables a full-screen overlay in the browser when there are uncaught runtime errors.",
+        negatedDescription:
+          "Disables the full-screen overlay in the browser when there are uncaught runtime errors.",
+        path: "client.overlay.runtimeErrors",
+      },
+    ],
+    description:
+      "Enables a full-screen overlay in the browser when there are uncaught runtime errors.",
+    simpleType: "boolean",
+    multiple: false,
+  },
   "client-progress": {
     configs: [
       {

--- a/client-src/index.js
+++ b/client-src/index.js
@@ -116,23 +116,17 @@ self.addEventListener("beforeunload", () => {
   status.isUnloading = true;
 });
 
-const overlay = options.overlay
-  ? createOverlay(
-      typeof options.overlay === "object"
-        ? {
-            trustedTypesPolicyName: options.overlay.trustedTypesPolicyName,
-            catchRuntimeError: options.overlay.runtimeErrors,
-          }
-        : {
-            trustedTypesPolicyName: false,
-            catchRuntimeError: options.overlay,
-          }
-    )
-  : {
-      send() {
-        // noop
-      },
-    };
+const overlay = createOverlay(
+  typeof options.overlay === "object"
+    ? {
+        trustedTypesPolicyName: options.overlay.trustedTypesPolicyName,
+        catchRuntimeError: options.overlay.runtimeErrors,
+      }
+    : {
+        trustedTypesPolicyName: false,
+        catchRuntimeError: options.overlay,
+      }
+);
 
 const onSocketMessage = {
   hot() {

--- a/client-src/index.js
+++ b/client-src/index.js
@@ -116,17 +116,20 @@ self.addEventListener("beforeunload", () => {
   status.isUnloading = true;
 });
 
-const overlay = createOverlay(
-  typeof options.overlay === "object"
-    ? {
-        trustedTypesPolicyName: options.overlay.trustedTypesPolicyName,
-        catchRuntimeError: options.overlay.runtimeErrors,
-      }
-    : {
-        trustedTypesPolicyName: false,
-        catchRuntimeError: options.overlay,
-      }
-);
+const overlay =
+  typeof window !== "undefined"
+    ? createOverlay(
+        typeof options.overlay === "object"
+          ? {
+              trustedTypesPolicyName: options.overlay.trustedTypesPolicyName,
+              catchRuntimeError: options.overlay.runtimeErrors,
+            }
+          : {
+              trustedTypesPolicyName: false,
+              catchRuntimeError: options.overlay,
+            }
+      )
+    : { send: () => {} };
 
 const onSocketMessage = {
   hot() {

--- a/client-src/index.js
+++ b/client-src/index.js
@@ -46,6 +46,8 @@ const options = {
 };
 const parsedResourceQuery = parseURL(__resourceQuery);
 
+console.log(parsedResourceQuery);
+
 const enabledFeatures = {
   "Hot Module Replacement": false,
   "Live Reloading": false,

--- a/client-src/index.js
+++ b/client-src/index.js
@@ -46,8 +46,6 @@ const options = {
 };
 const parsedResourceQuery = parseURL(__resourceQuery);
 
-console.log(parsedResourceQuery);
-
 const enabledFeatures = {
   "Hot Module Replacement": false,
   "Live Reloading": false,

--- a/client-src/index.js
+++ b/client-src/index.js
@@ -115,13 +115,18 @@ self.addEventListener("beforeunload", () => {
   status.isUnloading = true;
 });
 
-const trustedTypesPolicyName =
-  typeof options.overlay === "object" && options.overlay.trustedTypesPolicyName;
-
 const overlay = options.overlay
-  ? createOverlay({
-      trustedTypesPolicyName,
-    })
+  ? createOverlay(
+      typeof options.overlay === "object"
+        ? {
+            trustedTypesPolicyName: options.overlay.trustedTypesPolicyName,
+            catchRuntimeError: options.overlay.errors,
+          }
+        : {
+            trustedTypesPolicyName: false,
+            catchRuntimeError: options.overlay,
+          }
+    )
   : {
       send() {
         // noop

--- a/client-src/index.js
+++ b/client-src/index.js
@@ -118,9 +118,15 @@ self.addEventListener("beforeunload", () => {
 const trustedTypesPolicyName =
   typeof options.overlay === "object" && options.overlay.trustedTypesPolicyName;
 
-const overlay = createOverlay({
-  trustedTypesPolicyName,
-});
+const overlay = options.overlay
+  ? createOverlay({
+      trustedTypesPolicyName,
+    })
+  : {
+      send() {
+        // noop
+      },
+    };
 
 const onSocketMessage = {
   hot() {

--- a/client-src/index.js
+++ b/client-src/index.js
@@ -15,7 +15,7 @@ import createSocketURL from "./utils/createSocketURL.js";
  * @property {boolean} hot
  * @property {boolean} liveReload
  * @property {boolean} progress
- * @property {boolean | { warnings?: boolean, errors?: boolean, trustedTypesPolicyName?: string }} overlay
+ * @property {boolean | { warnings?: boolean, errors?: boolean, runtimeErrors?: boolean, trustedTypesPolicyName?: string }} overlay
  * @property {string} [logging]
  * @property {number} [reconnect]
  */
@@ -80,6 +80,7 @@ if (parsedResourceQuery.overlay) {
     options.overlay = {
       errors: true,
       warnings: true,
+      runtimeErrors: true,
       ...options.overlay,
     };
   }
@@ -120,7 +121,7 @@ const overlay = options.overlay
       typeof options.overlay === "object"
         ? {
             trustedTypesPolicyName: options.overlay.trustedTypesPolicyName,
-            catchRuntimeError: options.overlay.errors,
+            catchRuntimeError: options.overlay.runtimeErrors,
           }
         : {
             trustedTypesPolicyName: false,

--- a/client-src/overlay.js
+++ b/client-src/overlay.js
@@ -272,7 +272,7 @@ const createOverlay = (options) => {
     hideOverlay: hide,
   });
 
-  if (options.catchRuntimeError) {
+  if (options.catchRuntimeError && typeof window !== "undefined") {
     listenToRuntimeError((errorEvent) => {
       // error property may be empty in older browser like IE
       const { error, message } = errorEvent;

--- a/client-src/overlay.js
+++ b/client-src/overlay.js
@@ -272,15 +272,18 @@ const createOverlay = (options) => {
     hideOverlay: hide,
   });
 
-  if (options.catchRuntimeError && typeof window !== "undefined") {
+  if (options.catchRuntimeError) {
     listenToRuntimeError((errorEvent) => {
       // error property may be empty in older browser like IE
       const { error, message } = errorEvent;
+
       if (!error && !message) {
         return;
       }
+
       const errorObject =
         error instanceof Error ? error : new Error(error || message);
+
       overlayService.send({
         type: "RUNTIME_ERROR",
         messages: [

--- a/client-src/overlay.js
+++ b/client-src/overlay.js
@@ -78,6 +78,7 @@ function formatProblem(type, item) {
 /**
  * @typedef {Object} CreateOverlayOptions
  * @property {string | null} trustedTypesPolicyName
+ * @property {boolean} [catchRuntimeError]
  */
 
 /**
@@ -271,24 +272,26 @@ const createOverlay = (options) => {
     hideOverlay: hide,
   });
 
-  listenToRuntimeError((errorEvent) => {
-    // error property may be empty in older browser like IE
-    const { error, message } = errorEvent;
-    if (!error && !message) {
-      return;
-    }
-    const errorObject =
-      error instanceof Error ? error : new Error(error || message);
-    overlayService.send({
-      type: "RUNTIME_ERROR",
-      messages: [
-        {
-          message: errorObject.message,
-          stack: parseErrorToStacks(errorObject),
-        },
-      ],
+  if (options.catchRuntimeError) {
+    listenToRuntimeError((errorEvent) => {
+      // error property may be empty in older browser like IE
+      const { error, message } = errorEvent;
+      if (!error && !message) {
+        return;
+      }
+      const errorObject =
+        error instanceof Error ? error : new Error(error || message);
+      overlayService.send({
+        type: "RUNTIME_ERROR",
+        messages: [
+          {
+            message: errorObject.message,
+            stack: parseErrorToStacks(errorObject),
+          },
+        ],
+      });
     });
-  });
+  }
 
   return overlayService;
 };

--- a/examples/client/overlay/webpack.config.js
+++ b/examples/client/overlay/webpack.config.js
@@ -10,7 +10,9 @@ module.exports = setup({
   entry: "./app.js",
   devServer: {
     client: {
-      overlay: true,
+      overlay: {
+        runtimeErrors: false,
+      },
     },
   },
   // uncomment to test for IE

--- a/examples/client/overlay/webpack.config.js
+++ b/examples/client/overlay/webpack.config.js
@@ -10,9 +10,7 @@ module.exports = setup({
   entry: "./app.js",
   devServer: {
     client: {
-      overlay: {
-        runtimeErrors: false,
-      },
+      overlay: true,
     },
   },
   // uncomment to test for IE

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -159,7 +159,7 @@ const schema = require("./options.json");
 /**
  * @typedef {Object} ClientConfiguration
  * @property {"log" | "info" | "warn" | "error" | "none" | "verbose"} [logging]
- * @property {boolean  | { warnings?: boolean, errors?: boolean }} [overlay]
+ * @property {boolean  | { warnings?: boolean, errors?: boolean, runtimeErrors?: boolean }} [overlay]
  * @property {boolean} [progress]
  * @property {boolean | number} [reconnect]
  * @property {"ws" | "sockjs" | string} [webSocketTransport]

--- a/lib/options.json
+++ b/lib/options.json
@@ -111,6 +111,13 @@
                 "negatedDescription": "Disables the full-screen overlay in the browser when there are compiler warnings."
               }
             },
+            "runtimeErrors": {
+              "description": "Enables a full-screen overlay in the browser when there are uncaught runtime errors.",
+              "type": "boolean",
+              "cli": {
+                "negatedDescription": "Disables the full-screen overlay in the browser when there are uncaught runtime errors."
+              }
+            },
             "trustedTypesPolicyName": {
               "description": "The name of a Trusted Types policy for the overlay. Defaults to 'webpack-dev-server#overlay'.",
               "type": "string"

--- a/test/__snapshots__/validate-options.test.js.snap.webpack4
+++ b/test/__snapshots__/validate-options.test.js.snap.webpack4
@@ -90,19 +90,19 @@ exports[`options validate should throw an error on the "client" option with '{"o
    -> Read more at https://webpack.js.org/configuration/dev-server/#devserverclient
    Details:
     * options.client.overlay should be one of these:
-      boolean | object { errors?, warnings?, trustedTypesPolicyName? }
+      boolean | object { errors?, warnings?, runtimeErrors?, trustedTypesPolicyName? }
       Details:
        * options.client.overlay should be a boolean.
          -> Enables a full-screen overlay in the browser when there are compiler errors or warnings.
          -> Read more at https://webpack.js.org/configuration/dev-server/#overlay
        * options.client.overlay should be an object:
-         object { errors?, warnings?, trustedTypesPolicyName? }"
+         object { errors?, warnings?, runtimeErrors?, trustedTypesPolicyName? }"
 `;
 
 exports[`options validate should throw an error on the "client" option with '{"overlay":{"arbitrary":""}}' value 1`] = `
 "ValidationError: Invalid options object. Dev Server has been initialized using an options object that does not match the API schema.
  - options.client.overlay has an unknown property 'arbitrary'. These properties are valid:
-   object { errors?, warnings?, trustedTypesPolicyName? }"
+   object { errors?, warnings?, runtimeErrors?, trustedTypesPolicyName? }"
 `;
 
 exports[`options validate should throw an error on the "client" option with '{"overlay":{"errors":""}}' value 1`] = `

--- a/test/__snapshots__/validate-options.test.js.snap.webpack5
+++ b/test/__snapshots__/validate-options.test.js.snap.webpack5
@@ -90,19 +90,19 @@ exports[`options validate should throw an error on the "client" option with '{"o
    -> Read more at https://webpack.js.org/configuration/dev-server/#devserverclient
    Details:
     * options.client.overlay should be one of these:
-      boolean | object { errors?, warnings?, trustedTypesPolicyName? }
+      boolean | object { errors?, warnings?, runtimeErrors?, trustedTypesPolicyName? }
       Details:
        * options.client.overlay should be a boolean.
          -> Enables a full-screen overlay in the browser when there are compiler errors or warnings.
          -> Read more at https://webpack.js.org/configuration/dev-server/#overlay
        * options.client.overlay should be an object:
-         object { errors?, warnings?, trustedTypesPolicyName? }"
+         object { errors?, warnings?, runtimeErrors?, trustedTypesPolicyName? }"
 `;
 
 exports[`options validate should throw an error on the "client" option with '{"overlay":{"arbitrary":""}}' value 1`] = `
 "ValidationError: Invalid options object. Dev Server has been initialized using an options object that does not match the API schema.
  - options.client.overlay has an unknown property 'arbitrary'. These properties are valid:
-   object { errors?, warnings?, trustedTypesPolicyName? }"
+   object { errors?, warnings?, runtimeErrors?, trustedTypesPolicyName? }"
 `;
 
 exports[`options validate should throw an error on the "client" option with '{"overlay":{"errors":""}}' value 1`] = `

--- a/test/cli/__snapshots__/basic.test.js.snap.webpack4
+++ b/test/cli/__snapshots__/basic.test.js.snap.webpack4
@@ -67,6 +67,8 @@ Options:
   --client-overlay-trusted-types-policy-name <value>  The name of a Trusted Types policy for the overlay. Defaults to 'webpack-dev-server#overlay'.
   --client-overlay-warnings                           Enables a full-screen overlay in the browser when there are compiler warnings.
   --no-client-overlay-warnings                        Disables the full-screen overlay in the browser when there are compiler warnings.
+  --client-overlay-runtime-errors                     Enables a full-screen overlay in the browser when there are uncaught runtime errors.
+  --no-client-overlay-runtime-errors                  Disables the full-screen overlay in the browser when there are uncaught runtime errors.
   --client-progress                                   Prints compilation progress in percentage in the browser.
   --no-client-progress                                Does not print compilation progress in percentage in the browser.
   --client-reconnect [value]                          Tells dev-server the number of times it should try to reconnect the client.

--- a/test/cli/__snapshots__/basic.test.js.snap.webpack5
+++ b/test/cli/__snapshots__/basic.test.js.snap.webpack5
@@ -67,6 +67,8 @@ Options:
   --no-client-overlay-errors                          Disables the full-screen overlay in the browser when there are compiler errors.
   --client-overlay-warnings                           Enables a full-screen overlay in the browser when there are compiler warnings.
   --no-client-overlay-warnings                        Disables the full-screen overlay in the browser when there are compiler warnings.
+  --client-overlay-runtime-errors                     Enables a full-screen overlay in the browser when there are uncaught runtime errors.
+  --no-client-overlay-runtime-errors                  Disables the full-screen overlay in the browser when there are uncaught runtime errors.
   --client-overlay-trusted-types-policy-name <value>  The name of a Trusted Types policy for the overlay. Defaults to 'webpack-dev-server#overlay'.
   --client-progress                                   Prints compilation progress in percentage in the browser.
   --no-client-progress                                Does not print compilation progress in percentage in the browser.

--- a/types/bin/cli-flags.d.ts
+++ b/types/bin/cli-flags.d.ts
@@ -114,6 +114,18 @@ declare const _exports: {
     simpleType: string;
     multiple: boolean;
   };
+  "client-overlay-runtime-errors": {
+    configs: {
+      type: string;
+      multiple: boolean;
+      description: string;
+      negatedDescription: string;
+      path: string;
+    }[];
+    description: string;
+    simpleType: string;
+    multiple: boolean;
+  };
   "client-progress": {
     configs: {
       type: string;

--- a/types/lib/Server.d.ts
+++ b/types/lib/Server.d.ts
@@ -1644,6 +1644,13 @@ declare class Server {
                     negatedDescription: string;
                   };
                 };
+                runtimeErrors: {
+                  description: string;
+                  type: string;
+                  cli: {
+                    negatedDescription: string;
+                  };
+                };
                 trustedTypesPolicyName: {
                   description: string;
                   type: string;
@@ -1668,15 +1675,7 @@ declare class Server {
         link: string;
         anyOf: (
           | {
-              /**
-               * @typedef {{ path?: HttpProxyMiddlewareOptionsFilter | undefined, context?: HttpProxyMiddlewareOptionsFilter | undefined } & { bypass?: ByPass } & HttpProxyMiddlewareOptions } ProxyConfigArrayItem
-               */
-              /**
-               * @typedef {(ProxyConfigArrayItem | ((req?: Request | undefined, res?: Response | undefined, next?: NextFunction | undefined) => ProxyConfigArrayItem))[]} ProxyConfigArray
-               */
-              /**
-               * @typedef {{ [url: string]: string | ProxyConfigArrayItem }} ProxyConfigMap
-               */
+              type: string;
               /**
                * @typedef {Object} OpenApp
                * @property {string} [name]
@@ -1746,7 +1745,6 @@ declare class Server {
                * @property {(devServer: Server) => void} [onListening]
                * @property {(middlewares: Middleware[], devServer: Server) => Middleware[]} [setupMiddlewares]
                */
-              type: string;
               cli: {
                 negatedDescription: string;
               };
@@ -1763,75 +1761,6 @@ declare class Server {
         anyOf: {
           $ref: string;
         }[];
-        /**
-         * @typedef {Object} OpenApp
-         * @property {string} [name]
-         * @property {string[]} [arguments]
-         */
-        /**
-         * @typedef {Object} Open
-         * @property {string | string[] | OpenApp} [app]
-         * @property {string | string[]} [target]
-         */
-        /**
-         * @typedef {Object} NormalizedOpen
-         * @property {string} target
-         * @property {import("open").Options} options
-         */
-        /**
-         * @typedef {Object} WebSocketURL
-         * @property {string} [hostname]
-         * @property {string} [password]
-         * @property {string} [pathname]
-         * @property {number | string} [port]
-         * @property {string} [protocol]
-         * @property {string} [username]
-         */
-        /**
-         * @typedef {Object} ClientConfiguration
-         * @property {"log" | "info" | "warn" | "error" | "none" | "verbose"} [logging]
-         * @property {boolean  | { warnings?: boolean, errors?: boolean, runtimeErrors?: boolean }} [overlay]
-         * @property {boolean} [progress]
-         * @property {boolean | number} [reconnect]
-         * @property {"ws" | "sockjs" | string} [webSocketTransport]
-         * @property {string | WebSocketURL} [webSocketURL]
-         */
-        /**
-         * @typedef {Array<{ key: string; value: string }> | Record<string, string | string[]>} Headers
-         */
-        /**
-         * @typedef {{ name?: string, path?: string, middleware: ExpressRequestHandler | ExpressErrorRequestHandler } | ExpressRequestHandler | ExpressErrorRequestHandler} Middleware
-         */
-        /**
-         * @typedef {Object} Configuration
-         * @property {boolean | string} [ipc]
-         * @property {Host} [host]
-         * @property {Port} [port]
-         * @property {boolean | "only"} [hot]
-         * @property {boolean} [liveReload]
-         * @property {DevMiddlewareOptions<Request, Response>} [devMiddleware]
-         * @property {boolean} [compress]
-         * @property {boolean} [magicHtml]
-         * @property {"auto" | "all" | string | string[]} [allowedHosts]
-         * @property {boolean | ConnectHistoryApiFallbackOptions} [historyApiFallback]
-         * @property {boolean} [setupExitSignals]
-         * @property {boolean | Record<string, never> | BonjourOptions} [bonjour]
-         * @property {string | string[] | WatchFiles | Array<string | WatchFiles>} [watchFiles]
-         * @property {boolean | string | Static | Array<string | Static>} [static]
-         * @property {boolean | ServerOptions} [https]
-         * @property {boolean} [http2]
-         * @property {"http" | "https" | "spdy" | string | ServerConfiguration} [server]
-         * @property {boolean | "sockjs" | "ws" | string | WebSocketServerConfiguration} [webSocketServer]
-         * @property {ProxyConfigMap | ProxyConfigArrayItem | ProxyConfigArray} [proxy]
-         * @property {boolean | string | Open | Array<string | Open>} [open]
-         * @property {boolean} [setupExitSignals]
-         * @property {boolean | ClientConfiguration} [client]
-         * @property {Headers | ((req: Request, res: Response, context: DevMiddlewareContext<Request, Response>) => Headers)} [headers]
-         * @property {(devServer: Server) => void} [onAfterSetupMiddleware]
-         * @property {(devServer: Server) => void} [onBeforeSetupMiddleware]
-         * @property {(devServer: Server) => void} [onListening]
-         * @property {(middlewares: Middleware[], devServer: Server) => Middleware[]} [setupMiddlewares]
-         */
         description: string;
         link: string;
       };
@@ -1841,15 +1770,6 @@ declare class Server {
       ClientWebSocketTransportString: {
         type: string;
         minLength: number;
-        /**
-         * @typedef {Object} WebSocketURL
-         * @property {string} [hostname]
-         * @property {string} [password]
-         * @property {string} [pathname]
-         * @property {number | string} [port]
-         * @property {string} [protocol]
-         * @property {string} [username]
-         */
       };
       ClientWebSocketURL: {
         description: string;
@@ -1863,6 +1783,36 @@ declare class Server {
             }
           | {
               type: string;
+              /**
+               * @typedef {Object} Configuration
+               * @property {boolean | string} [ipc]
+               * @property {Host} [host]
+               * @property {Port} [port]
+               * @property {boolean | "only"} [hot]
+               * @property {boolean} [liveReload]
+               * @property {DevMiddlewareOptions<Request, Response>} [devMiddleware]
+               * @property {boolean} [compress]
+               * @property {boolean} [magicHtml]
+               * @property {"auto" | "all" | string | string[]} [allowedHosts]
+               * @property {boolean | ConnectHistoryApiFallbackOptions} [historyApiFallback]
+               * @property {boolean} [setupExitSignals]
+               * @property {boolean | Record<string, never> | BonjourOptions} [bonjour]
+               * @property {string | string[] | WatchFiles | Array<string | WatchFiles>} [watchFiles]
+               * @property {boolean | string | Static | Array<string | Static>} [static]
+               * @property {boolean | ServerOptions} [https]
+               * @property {boolean} [http2]
+               * @property {"http" | "https" | "spdy" | string | ServerConfiguration} [server]
+               * @property {boolean | "sockjs" | "ws" | string | WebSocketServerConfiguration} [webSocketServer]
+               * @property {ProxyConfigMap | ProxyConfigArrayItem | ProxyConfigArray} [proxy]
+               * @property {boolean | string | Open | Array<string | Open>} [open]
+               * @property {boolean} [setupExitSignals]
+               * @property {boolean | ClientConfiguration} [client]
+               * @property {Headers | ((req: Request, res: Response, context: DevMiddlewareContext<Request, Response>) => Headers)} [headers]
+               * @property {(devServer: Server) => void} [onAfterSetupMiddleware]
+               * @property {(devServer: Server) => void} [onBeforeSetupMiddleware]
+               * @property {(devServer: Server) => void} [onListening]
+               * @property {(middlewares: Middleware[], devServer: Server) => Middleware[]} [setupMiddlewares]
+               */
               additionalProperties: boolean;
               properties: {
                 hostname: {
@@ -1953,7 +1903,7 @@ declare class Server {
               properties: {
                 passphrase: {
                   type: string;
-                  description: string /** @type {Schema} */;
+                  description: string;
                 };
                 requestCert: {
                   type: string;
@@ -1961,6 +1911,10 @@ declare class Server {
                   cli: {
                     negatedDescription: string;
                   };
+                  /**
+                   * @private
+                   * @type {RequestHandler[]}
+                   */
                 };
                 ca: {
                   anyOf: (
@@ -2067,10 +2021,6 @@ declare class Server {
                               }
                             | {
                                 instanceof: string;
-                                /**
-                                 * @param {"v4" | "v6"} family
-                                 * @returns {string | undefined}
-                                 */
                                 type?: undefined;
                               }
                           )[];
@@ -2228,7 +2178,7 @@ declare class Server {
             }
           | {
               type: string;
-              description: string;
+              /** @type {WebSocketURL} */ description: string;
               link: string;
               cli?: undefined /** @typedef {import("express").Request} Request */;
             }
@@ -2242,7 +2192,7 @@ declare class Server {
         anyOf: (
           | {
               enum: string[];
-              type?: undefined;
+              /** @type {ServerConfiguration} */ type?: undefined;
               minLength?: undefined;
             }
           | {
@@ -2250,7 +2200,7 @@ declare class Server {
               minLength: number;
               enum?: undefined;
             }
-        )[] /** @type {string} */;
+        )[];
       };
       Hot: {
         anyOf: (
@@ -2326,7 +2276,7 @@ declare class Server {
                   $ref: string;
                 }[];
               };
-              /** @type {string} */ $ref?: undefined;
+              $ref?: undefined;
             }
           | {
               $ref: string;
@@ -2413,6 +2363,12 @@ declare class Server {
           };
         };
       };
+      /**
+       * prependEntry Method for webpack 4
+       * @param {any} originalEntry
+       * @param {any} newAdditionalEntries
+       * @returns {any}
+       */
       OpenString: {
         type: string;
         minLength: number;
@@ -2467,6 +2423,7 @@ declare class Server {
             }
         )[];
         description: string;
+        /** @type {any} */
         link: string;
       };
       Server: {
@@ -2474,7 +2431,7 @@ declare class Server {
           $ref: string;
         }[];
         link: string;
-        /** @type {any} */ description: string;
+        description: string;
       };
       ServerType: {
         enum: string[];
@@ -2525,7 +2482,6 @@ declare class Server {
             anyOf: (
               | {
                   type: string;
-                  /** @type {MultiCompiler} */
                   items: {
                     anyOf: (
                       | {
@@ -2665,10 +2621,6 @@ declare class Server {
                       | {
                           type: string;
                           additionalProperties: boolean;
-                          /**
-                           * @param {string | Static | undefined} [optionsForStatic]
-                           * @returns {NormalizedStatic}
-                           */
                           instanceof?: undefined;
                         }
                     )[];
@@ -2912,7 +2864,6 @@ declare class Server {
         description: string;
         link: string;
       };
-      /** @type {ServerConfiguration} */
       WebSocketServerType: {
         enum: string[];
       };
@@ -2936,9 +2887,8 @@ declare class Server {
         };
       };
       WebSocketServerFunction: {
-        instanceof: string;
+        instanceof: string /** @type {ServerOptions} */;
       };
-      /** @type {ServerOptions} */
       WebSocketServerObject: {
         type: string;
         properties: {
@@ -2959,7 +2909,7 @@ declare class Server {
       };
       WebSocketServerString: {
         type: string;
-        /** @type {ServerOptions} */ minLength: number;
+        minLength: number;
       };
     };
     additionalProperties: boolean;
@@ -2991,10 +2941,6 @@ declare class Server {
       hot: {
         $ref: string;
       };
-      /**
-       * @param {string | Buffer | undefined} item
-       * @returns {string | Buffer | undefined}
-       */
       http2: {
         $ref: string;
       };
@@ -3010,6 +2956,7 @@ declare class Server {
       magicHtml: {
         $ref: string;
       };
+      /** @type {any} */
       onAfterSetupMiddleware: {
         $ref: string;
       };
@@ -3023,9 +2970,8 @@ declare class Server {
         $ref: string;
       };
       port: {
-        $ref: string /** @type {any} */;
+        $ref: string;
       };
-      /** @type {any} */
       proxy: {
         $ref: string;
       };

--- a/types/lib/Server.d.ts
+++ b/types/lib/Server.d.ts
@@ -138,7 +138,7 @@ declare class Server {
         /**
          * @typedef {Object} ClientConfiguration
          * @property {"log" | "info" | "warn" | "error" | "none" | "verbose"} [logging]
-         * @property {boolean  | { warnings?: boolean, errors?: boolean }} [overlay]
+         * @property {boolean  | { warnings?: boolean, errors?: boolean, runtimeErrors?: boolean }} [overlay]
          * @property {boolean} [progress]
          * @property {boolean | number} [reconnect]
          * @property {"ws" | "sockjs" | string} [webSocketTransport]
@@ -316,7 +316,7 @@ declare class Server {
         /**
          * @typedef {Object} ClientConfiguration
          * @property {"log" | "info" | "warn" | "error" | "none" | "verbose"} [logging]
-         * @property {boolean  | { warnings?: boolean, errors?: boolean }} [overlay]
+         * @property {boolean  | { warnings?: boolean, errors?: boolean, runtimeErrors?: boolean }} [overlay]
          * @property {boolean} [progress]
          * @property {boolean | number} [reconnect]
          * @property {"ws" | "sockjs" | string} [webSocketTransport]
@@ -440,7 +440,7 @@ declare class Server {
       /**
        * @typedef {Object} ClientConfiguration
        * @property {"log" | "info" | "warn" | "error" | "none" | "verbose"} [logging]
-       * @property {boolean  | { warnings?: boolean, errors?: boolean }} [overlay]
+       * @property {boolean  | { warnings?: boolean, errors?: boolean, runtimeErrors?: boolean }} [overlay]
        * @property {boolean} [progress]
        * @property {boolean | number} [reconnect]
        * @property {"ws" | "sockjs" | string} [webSocketTransport]
@@ -574,10 +574,10 @@ declare class Server {
           path: string;
         }[];
         description: string;
+        simpleType: string;
         /**
          * @type {FSWatcher[]}
          */
-        simpleType: string;
         multiple: boolean;
       };
       "client-web-socket-url-protocol": {
@@ -587,6 +587,10 @@ declare class Server {
               multiple: boolean;
               path: string;
               type: string;
+              /**
+               * @private
+               * @type {RequestHandler[]}
+               */
               values: string[];
             }
           | {
@@ -611,10 +615,6 @@ declare class Server {
         simpleType: string;
         multiple: boolean;
       };
-      /**
-       * @param {string} URL
-       * @returns {boolean}
-       */
       compress: {
         configs: {
           type: string;
@@ -625,12 +625,12 @@ declare class Server {
         }[];
         description: string;
         simpleType: string;
-        /**
-         * @param {string} gateway
-         * @returns {string | undefined}
-         */
         multiple: boolean;
       };
+      /**
+       * @param {string} gateway
+       * @returns {string | undefined}
+       */
       "history-api-fallback": {
         configs: {
           type: string;
@@ -661,12 +661,12 @@ declare class Server {
         )[];
         description: string;
         simpleType: string;
-        /**
-         * @param {Host} hostname
-         * @returns {Promise<string>}
-         */
         multiple: boolean;
       };
+      /**
+       * @param {Host} hostname
+       * @returns {Promise<string>}
+       */
       hot: {
         configs: (
           | {
@@ -706,6 +706,9 @@ declare class Server {
           multiple: boolean;
           description: string;
           negatedDescription: string;
+          /**
+           * @returns {string}
+           */
           path: string;
         }[];
         description: string;
@@ -761,8 +764,9 @@ declare class Server {
           type: string;
           multiple: boolean;
           description: string;
-          path: string /** @type {string} */;
+          path: string;
         }[];
+        /** @type {string} */
         description: string;
         simpleType: string;
         multiple: boolean;
@@ -775,7 +779,7 @@ declare class Server {
           type: string;
         }[];
         description: string;
-        multiple: boolean;
+        /** @type {string} */ multiple: boolean;
         simpleType: string;
       };
       "https-crl": {
@@ -796,7 +800,7 @@ declare class Server {
           path: string;
           type: string;
         }[];
-        /** @type {number | string} */ description: string;
+        description: string;
         multiple: boolean;
         simpleType: string;
       };
@@ -818,7 +822,7 @@ declare class Server {
           path: string;
           type: string;
         }[];
-        /** @type {string} */ description: string;
+        description: string;
         multiple: boolean;
         simpleType: string;
       };
@@ -886,12 +890,6 @@ declare class Server {
         description: string;
         simpleType: string;
         multiple: boolean;
-        /**
-         * prependEntry Method for webpack 4
-         * @param {any} originalEntry
-         * @param {any} newAdditionalEntries
-         * @returns {any}
-         */
       };
       "live-reload": {
         configs: {
@@ -913,6 +911,7 @@ declare class Server {
           negatedDescription: string;
           path: string;
         }[];
+        /** @type {any} */
         description: string;
         simpleType: string;
         multiple: boolean;
@@ -964,7 +963,7 @@ declare class Server {
           type: string;
           multiple: boolean;
           description: string;
-          path: string /** @type {Compiler} */;
+          path: string;
         }[];
         description: string;
         simpleType: string;
@@ -1014,6 +1013,10 @@ declare class Server {
           | {
               type: string;
               values: string[];
+              /**
+               * @param {string | Static | undefined} [optionsForStatic]
+               * @returns {NormalizedStatic}
+               */
               multiple: boolean;
               description: string;
               path: string;
@@ -1028,6 +1031,7 @@ declare class Server {
           description: string;
           multiple: boolean;
           path: string;
+          /** @type {NormalizedStatic} */
           type: string;
         }[];
         description: string;
@@ -1206,9 +1210,9 @@ declare class Server {
               path: string;
             }
         )[];
-        /** @type {ServerOptions} */ description: string;
-        /** @type {Array<keyof ServerOptions>} */ simpleType: string;
-        multiple: boolean;
+        description: string;
+        simpleType: string;
+        /** @type {Array<keyof ServerOptions>} */ multiple: boolean;
       };
       "static-directory": {
         configs: {
@@ -1248,7 +1252,7 @@ declare class Server {
           type: string;
           multiple: boolean;
           description: string;
-          path: string /** @type {ServerOptions} */;
+          path: string;
         }[];
         description: string;
         simpleType: string;
@@ -1542,7 +1546,7 @@ declare class Server {
                 /**
                  * @typedef {Object} ClientConfiguration
                  * @property {"log" | "info" | "warn" | "error" | "none" | "verbose"} [logging]
-                 * @property {boolean  | { warnings?: boolean, errors?: boolean }} [overlay]
+                 * @property {boolean  | { warnings?: boolean, errors?: boolean, runtimeErrors?: boolean }} [overlay]
                  * @property {boolean} [progress]
                  * @property {boolean | number} [reconnect]
                  * @property {"ws" | "sockjs" | string} [webSocketTransport]
@@ -1700,7 +1704,7 @@ declare class Server {
               /**
                * @typedef {Object} ClientConfiguration
                * @property {"log" | "info" | "warn" | "error" | "none" | "verbose"} [logging]
-               * @property {boolean  | { warnings?: boolean, errors?: boolean }} [overlay]
+               * @property {boolean  | { warnings?: boolean, errors?: boolean, runtimeErrors?: boolean }} [overlay]
                * @property {boolean} [progress]
                * @property {boolean | number} [reconnect]
                * @property {"ws" | "sockjs" | string} [webSocketTransport]
@@ -1786,7 +1790,7 @@ declare class Server {
         /**
          * @typedef {Object} ClientConfiguration
          * @property {"log" | "info" | "warn" | "error" | "none" | "verbose"} [logging]
-         * @property {boolean  | { warnings?: boolean, errors?: boolean }} [overlay]
+         * @property {boolean  | { warnings?: boolean, errors?: boolean, runtimeErrors?: boolean }} [overlay]
          * @property {boolean} [progress]
          * @property {boolean | number} [reconnect]
          * @property {"ws" | "sockjs" | string} [webSocketTransport]
@@ -1949,7 +1953,7 @@ declare class Server {
               properties: {
                 passphrase: {
                   type: string;
-                  description: string;
+                  description: string /** @type {Schema} */;
                 };
                 requestCert: {
                   type: string;
@@ -2052,10 +2056,6 @@ declare class Server {
                   description: string;
                 };
                 crl: {
-                  /**
-                   * @param {"v4" | "v6"} family
-                   * @returns {Promise<string | undefined>}
-                   */
                   anyOf: (
                     | {
                         type: string;
@@ -2067,6 +2067,10 @@ declare class Server {
                               }
                             | {
                                 instanceof: string;
+                                /**
+                                 * @param {"v4" | "v6"} family
+                                 * @returns {string | undefined}
+                                 */
                                 type?: undefined;
                               }
                           )[];
@@ -2246,7 +2250,7 @@ declare class Server {
               minLength: number;
               enum?: undefined;
             }
-        )[];
+        )[] /** @type {string} */;
       };
       Hot: {
         anyOf: (
@@ -2322,7 +2326,7 @@ declare class Server {
                   $ref: string;
                 }[];
               };
-              $ref?: undefined;
+              /** @type {string} */ $ref?: undefined;
             }
           | {
               $ref: string;
@@ -2339,7 +2343,6 @@ declare class Server {
           negatedDescription: string;
         };
       };
-      /** @type {ClientConfiguration} */
       OpenObject: {
         type: string;
         additionalProperties: boolean;
@@ -2470,9 +2473,8 @@ declare class Server {
         anyOf: {
           $ref: string;
         }[];
-        /** @type {any} */
         link: string;
-        description: string;
+        /** @type {any} */ description: string;
       };
       ServerType: {
         enum: string[];
@@ -2492,7 +2494,6 @@ declare class Server {
       };
       ServerObject: {
         type: string;
-        /** @type {string} */
         properties: {
           type: {
             anyOf: {
@@ -2500,7 +2501,7 @@ declare class Server {
             }[];
           };
           options: {
-            $ref: string /** @type {MultiCompiler} */;
+            $ref: string;
           };
         };
         additionalProperties: boolean;
@@ -2513,7 +2514,6 @@ declare class Server {
             type: string;
             description: string;
           };
-          /** @type {MultiCompiler} */
           requestCert: {
             type: string;
             description: string;
@@ -2525,6 +2525,7 @@ declare class Server {
             anyOf: (
               | {
                   type: string;
+                  /** @type {MultiCompiler} */
                   items: {
                     anyOf: (
                       | {
@@ -2664,6 +2665,10 @@ declare class Server {
                       | {
                           type: string;
                           additionalProperties: boolean;
+                          /**
+                           * @param {string | Static | undefined} [optionsForStatic]
+                           * @returns {NormalizedStatic}
+                           */
                           instanceof?: undefined;
                         }
                     )[];
@@ -2907,6 +2912,7 @@ declare class Server {
         description: string;
         link: string;
       };
+      /** @type {ServerConfiguration} */
       WebSocketServerType: {
         enum: string[];
       };
@@ -2932,6 +2938,7 @@ declare class Server {
       WebSocketServerFunction: {
         instanceof: string;
       };
+      /** @type {ServerOptions} */
       WebSocketServerObject: {
         type: string;
         properties: {
@@ -2942,7 +2949,6 @@ declare class Server {
           };
           options: {
             type: string;
-            /** @type {Array<keyof ServerOptions>} */
             additionalProperties: boolean;
             cli: {
               exclude: boolean;
@@ -2953,7 +2959,7 @@ declare class Server {
       };
       WebSocketServerString: {
         type: string;
-        minLength: number;
+        /** @type {ServerOptions} */ minLength: number;
       };
     };
     additionalProperties: boolean;
@@ -2979,13 +2985,16 @@ declare class Server {
       historyApiFallback: {
         $ref: string;
       };
-      /** @type {ServerOptions} */
       host: {
         $ref: string;
       };
       hot: {
         $ref: string;
       };
+      /**
+       * @param {string | Buffer | undefined} item
+       * @returns {string | Buffer | undefined}
+       */
       http2: {
         $ref: string;
       };
@@ -3014,8 +3023,9 @@ declare class Server {
         $ref: string;
       };
       port: {
-        $ref: string;
+        $ref: string /** @type {any} */;
       };
+      /** @type {any} */
       proxy: {
         $ref: string;
       };
@@ -3625,6 +3635,7 @@ type ClientConfiguration = {
     | {
         warnings?: boolean | undefined;
         errors?: boolean | undefined;
+        runtimeErrors?: boolean | undefined;
       }
     | undefined;
   progress?: boolean | undefined;

--- a/types/lib/Server.d.ts
+++ b/types/lib/Server.d.ts
@@ -416,6 +416,82 @@ declare class Server {
         simpleType: string;
         multiple: boolean;
       };
+      "client-overlay-runtime-errors": {
+        configs: {
+          type: string;
+          multiple: boolean;
+          description: string;
+          /**
+           * @typedef {Object} Open
+           * @property {string | string[] | OpenApp} [app]
+           * @property {string | string[]} [target]
+           */
+          /**
+           * @typedef {Object} NormalizedOpen
+           * @property {string} target
+           * @property {import("open").Options} options
+           */
+          /**
+           * @typedef {Object} WebSocketURL
+           * @property {string} [hostname]
+           * @property {string} [password]
+           * @property {string} [pathname]
+           * @property {number | string} [port]
+           * @property {string} [protocol]
+           * @property {string} [username]
+           */
+          /**
+           * @typedef {Object} ClientConfiguration
+           * @property {"log" | "info" | "warn" | "error" | "none" | "verbose"} [logging]
+           * @property {boolean  | { warnings?: boolean, errors?: boolean, runtimeErrors?: boolean }} [overlay]
+           * @property {boolean} [progress]
+           * @property {boolean | number} [reconnect]
+           * @property {"ws" | "sockjs" | string} [webSocketTransport]
+           * @property {string | WebSocketURL} [webSocketURL]
+           */
+          /**
+           * @typedef {Array<{ key: string; value: string }> | Record<string, string | string[]>} Headers
+           */
+          /**
+           * @typedef {{ name?: string, path?: string, middleware: ExpressRequestHandler | ExpressErrorRequestHandler } | ExpressRequestHandler | ExpressErrorRequestHandler} Middleware
+           */
+          /**
+           * @typedef {Object} Configuration
+           * @property {boolean | string} [ipc]
+           * @property {Host} [host]
+           * @property {Port} [port]
+           * @property {boolean | "only"} [hot]
+           * @property {boolean} [liveReload]
+           * @property {DevMiddlewareOptions<Request, Response>} [devMiddleware]
+           * @property {boolean} [compress]
+           * @property {boolean} [magicHtml]
+           * @property {"auto" | "all" | string | string[]} [allowedHosts]
+           * @property {boolean | ConnectHistoryApiFallbackOptions} [historyApiFallback]
+           * @property {boolean} [setupExitSignals]
+           * @property {boolean | Record<string, never> | BonjourOptions} [bonjour]
+           * @property {string | string[] | WatchFiles | Array<string | WatchFiles>} [watchFiles]
+           * @property {boolean | string | Static | Array<string | Static>} [static]
+           * @property {boolean | ServerOptions} [https]
+           * @property {boolean} [http2]
+           * @property {"http" | "https" | "spdy" | string | ServerConfiguration} [server]
+           * @property {boolean | "sockjs" | "ws" | string | WebSocketServerConfiguration} [webSocketServer]
+           * @property {ProxyConfigMap | ProxyConfigArrayItem | ProxyConfigArray} [proxy]
+           * @property {boolean | string | Open | Array<string | Open>} [open]
+           * @property {boolean} [setupExitSignals]
+           * @property {boolean | ClientConfiguration} [client]
+           * @property {Headers | ((req: Request, res: Response, context: DevMiddlewareContext<Request, Response>) => Headers)} [headers]
+           * @property {(devServer: Server) => void} [onAfterSetupMiddleware]
+           * @property {(devServer: Server) => void} [onBeforeSetupMiddleware]
+           * @property {(devServer: Server) => void} [onListening]
+           * @property {(middlewares: Middleware[], devServer: Server) => Middleware[]} [setupMiddlewares]
+           */
+          negatedDescription: string;
+          path: string;
+        }[];
+        description: string;
+        simpleType: string;
+        multiple: boolean;
+      };
       "client-progress": {
         configs: {
           type: string;
@@ -428,60 +504,6 @@ declare class Server {
         simpleType: string;
         multiple: boolean;
       };
-      /**
-       * @typedef {Object} WebSocketURL
-       * @property {string} [hostname]
-       * @property {string} [password]
-       * @property {string} [pathname]
-       * @property {number | string} [port]
-       * @property {string} [protocol]
-       * @property {string} [username]
-       */
-      /**
-       * @typedef {Object} ClientConfiguration
-       * @property {"log" | "info" | "warn" | "error" | "none" | "verbose"} [logging]
-       * @property {boolean  | { warnings?: boolean, errors?: boolean, runtimeErrors?: boolean }} [overlay]
-       * @property {boolean} [progress]
-       * @property {boolean | number} [reconnect]
-       * @property {"ws" | "sockjs" | string} [webSocketTransport]
-       * @property {string | WebSocketURL} [webSocketURL]
-       */
-      /**
-       * @typedef {Array<{ key: string; value: string }> | Record<string, string | string[]>} Headers
-       */
-      /**
-       * @typedef {{ name?: string, path?: string, middleware: ExpressRequestHandler | ExpressErrorRequestHandler } | ExpressRequestHandler | ExpressErrorRequestHandler} Middleware
-       */
-      /**
-       * @typedef {Object} Configuration
-       * @property {boolean | string} [ipc]
-       * @property {Host} [host]
-       * @property {Port} [port]
-       * @property {boolean | "only"} [hot]
-       * @property {boolean} [liveReload]
-       * @property {DevMiddlewareOptions<Request, Response>} [devMiddleware]
-       * @property {boolean} [compress]
-       * @property {boolean} [magicHtml]
-       * @property {"auto" | "all" | string | string[]} [allowedHosts]
-       * @property {boolean | ConnectHistoryApiFallbackOptions} [historyApiFallback]
-       * @property {boolean} [setupExitSignals]
-       * @property {boolean | Record<string, never> | BonjourOptions} [bonjour]
-       * @property {string | string[] | WatchFiles | Array<string | WatchFiles>} [watchFiles]
-       * @property {boolean | string | Static | Array<string | Static>} [static]
-       * @property {boolean | ServerOptions} [https]
-       * @property {boolean} [http2]
-       * @property {"http" | "https" | "spdy" | string | ServerConfiguration} [server]
-       * @property {boolean | "sockjs" | "ws" | string | WebSocketServerConfiguration} [webSocketServer]
-       * @property {ProxyConfigMap | ProxyConfigArrayItem | ProxyConfigArray} [proxy]
-       * @property {boolean | string | Open | Array<string | Open>} [open]
-       * @property {boolean} [setupExitSignals]
-       * @property {boolean | ClientConfiguration} [client]
-       * @property {Headers | ((req: Request, res: Response, context: DevMiddlewareContext<Request, Response>) => Headers)} [headers]
-       * @property {(devServer: Server) => void} [onAfterSetupMiddleware]
-       * @property {(devServer: Server) => void} [onBeforeSetupMiddleware]
-       * @property {(devServer: Server) => void} [onListening]
-       * @property {(middlewares: Middleware[], devServer: Server) => Middleware[]} [setupMiddlewares]
-       */
       "client-reconnect": {
         configs: (
           | {
@@ -540,6 +562,10 @@ declare class Server {
           description: string;
           path: string;
         }[];
+        /**
+         * @param {Configuration | Compiler | MultiCompiler} options
+         * @param {Compiler | MultiCompiler | Configuration} compiler
+         */
         description: string;
         simpleType: string;
         multiple: boolean;
@@ -565,19 +591,23 @@ declare class Server {
         description: string;
         simpleType: string;
         multiple: boolean;
+        /**
+         * @type {FSWatcher[]}
+         */
       };
       "client-web-socket-url-port": {
         configs: {
           type: string;
           multiple: boolean;
           description: string;
+          /**
+           * @private
+           * @type {RequestHandler[]}
+           */
           path: string;
         }[];
         description: string;
         simpleType: string;
-        /**
-         * @type {FSWatcher[]}
-         */
         multiple: boolean;
       };
       "client-web-socket-url-protocol": {
@@ -587,10 +617,6 @@ declare class Server {
               multiple: boolean;
               path: string;
               type: string;
-              /**
-               * @private
-               * @type {RequestHandler[]}
-               */
               values: string[];
             }
           | {
@@ -627,10 +653,6 @@ declare class Server {
         simpleType: string;
         multiple: boolean;
       };
-      /**
-       * @param {string} gateway
-       * @returns {string | undefined}
-       */
       "history-api-fallback": {
         configs: {
           type: string;
@@ -663,10 +685,6 @@ declare class Server {
         simpleType: string;
         multiple: boolean;
       };
-      /**
-       * @param {Host} hostname
-       * @returns {Promise<string>}
-       */
       hot: {
         configs: (
           | {
@@ -706,9 +724,6 @@ declare class Server {
           multiple: boolean;
           description: string;
           negatedDescription: string;
-          /**
-           * @returns {string}
-           */
           path: string;
         }[];
         description: string;
@@ -757,6 +772,7 @@ declare class Server {
         }[];
         description: string;
         multiple: boolean;
+        /** @type {ServerConfiguration} */
         simpleType: string;
       };
       "https-cert": {
@@ -766,9 +782,8 @@ declare class Server {
           description: string;
           path: string;
         }[];
-        /** @type {string} */
         description: string;
-        simpleType: string;
+        /** @type {string} */ simpleType: string;
         multiple: boolean;
       };
       "https-cert-reset": {
@@ -779,7 +794,7 @@ declare class Server {
           type: string;
         }[];
         description: string;
-        /** @type {string} */ multiple: boolean;
+        multiple: boolean;
         simpleType: string;
       };
       "https-crl": {
@@ -891,6 +906,7 @@ declare class Server {
         simpleType: string;
         multiple: boolean;
       };
+      /** @type {Object<string,string>} */
       "live-reload": {
         configs: {
           type: string;
@@ -911,7 +927,6 @@ declare class Server {
           negatedDescription: string;
           path: string;
         }[];
-        /** @type {any} */
         description: string;
         simpleType: string;
         multiple: boolean;
@@ -953,6 +968,10 @@ declare class Server {
           multiple: boolean;
           description: string;
           path: string;
+          /**
+           * @private
+           * @returns {Promise<void>}
+           */
         }[];
         description: string;
         simpleType: string;
@@ -1013,10 +1032,6 @@ declare class Server {
           | {
               type: string;
               values: string[];
-              /**
-               * @param {string | Static | undefined} [optionsForStatic]
-               * @returns {NormalizedStatic}
-               */
               multiple: boolean;
               description: string;
               path: string;
@@ -1031,7 +1046,6 @@ declare class Server {
           description: string;
           multiple: boolean;
           path: string;
-          /** @type {NormalizedStatic} */
           type: string;
         }[];
         description: string;
@@ -1212,7 +1226,7 @@ declare class Server {
         )[];
         description: string;
         simpleType: string;
-        /** @type {Array<keyof ServerOptions>} */ multiple: boolean;
+        multiple: boolean;
       };
       "static-directory": {
         configs: {
@@ -1222,6 +1236,10 @@ declare class Server {
           path: string;
         }[];
         description: string;
+        /**
+         * @param {string | Buffer | undefined} item
+         * @returns {string | Buffer | undefined}
+         */
         simpleType: string;
         multiple: boolean;
       };
@@ -1234,7 +1252,7 @@ declare class Server {
         }[];
         description: string;
         simpleType: string;
-        multiple: boolean;
+        multiple: boolean /** @type {any} */;
       };
       "static-public-path-reset": {
         configs: {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [x] This is a **bugfix**
- [x] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

Reported in #4771

fixes https://github.com/webpack/webpack-dev-server/issues/4774
fixes #4771

- Added `client.overlay.runtimeErrors` options - default to `true`.

### For Bugs and Features; did you add new tests?

<!-- Please note that we won't approve your changes if you don't add tests. -->

### Motivation / Use-Case

<!--
  What existing problem does the pull request solve?

  Please explain the motivation or use-case for making this change.
  If this Pull Request addresses an issue, please link to the issue.
-->

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  potential migration path for existing applications.
-->

### Additional Info
