### PR TITLE
fix: replace :: with localhost before openBrowser()

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -2955,7 +2955,9 @@ class Server {
 
       if (/** @type {NormalizedOpen[]} */ (this.options.open).length > 0) {
         const openTarget = prettyPrintURL(
-          !this.options.host || this.options.host === "0.0.0.0"
+          !this.options.host ||
+            this.options.host === "0.0.0.0" ||
+            this.options.host === "::"
             ? "localhost"
             : this.options.host
         );

--- a/test/server/open-option.test.js
+++ b/test/server/open-option.test.js
@@ -134,7 +134,7 @@ describe('"open" option', () => {
     await server.start();
     await server.stop();
 
-    expect(open).toHaveBeenCalledWith(`http://[${host}]:${port}/`, {
+    expect(open).toHaveBeenCalledWith(`http://localhost:${port}/`, {
       wait: false,
     });
   });


### PR DESCRIPTION
- [x] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [x] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

[test/server/open-option.test.js](https://github.com/webpack/webpack-dev-server/compare/master...chousheng:webpack-dev-server:fix-ipv6-unspecified-addr-open-browser?expand=1#diff-9b579ac0614b984311440c72f67e512825ea9e553424a2360fb7503556d15625) is modified.

### Motivation / Use-Case

This PR resolves #4855. See #4855 for more details.

### Breaking Changes

N/A

### Additional Info

Below are the screencasts showing the fix on Windows and GitHub Codespaces.

Windows:

| Before fix     | After fix      |
| -------------- | -------------- |
| <video src="https://github.com/webpack/webpack-dev-server/assets/38355699/57d2fa7f-744b-47aa-b274-553351c27833"> | <video src="https://github.com/webpack/webpack-dev-server/assets/38355699/12cf49f9-03a9-49c2-b347-b0b40f271b97"> |

GitHub Codespaces:

| Before fix     | After fix      |
| -------------- | -------------- |
| <video src="https://github.com/webpack/webpack-dev-server/assets/38355699/f8ed93d4-65fc-4cce-a4bf-5b72289d7755"> | <video src="https://github.com/webpack/webpack-dev-server/assets/38355699/b56161c3-7f74-48b6-bd11-06a7190332cb"> |



