### PR TITLE
refactor: refactor overlay styling to use css class

### DIFF
--- a/client-src/overlay.js
+++ b/client-src/overlay.js
@@ -268,9 +268,7 @@ const createOverlay = (options) => {
         // Make it look similar to our terminal.
         const text = ansiHTML(encode(body));
         const messageTextNode = document.createElement("div");
-        messageTextNode.className = msgTextStyle.className;
-
-        iframeCssLoader.load(msgTextStyle.css);
+        applyCss(messageTextNode, msgTextStyle);
 
         messageTextNode.innerHTML = overlayTrustedTypesPolicy
           ? overlayTrustedTypesPolicy.createHTML(text)

--- a/client-src/overlay/styles.js
+++ b/client-src/overlay/styles.js
@@ -92,7 +92,7 @@ const msgTextStyle = {
   css: /* css */ `.webpack-msg-text {
       line-height: 1.5;
       font-size: 1rem;
-      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
     }
   `,
 };

--- a/client-src/overlay/styles.js
+++ b/client-src/overlay/styles.js
@@ -1,15 +1,7 @@
 // styles are inspired by `react-error-overlay`
 
-const msgStyles = {
-  error: {
-    backgroundColor: "rgba(206, 17, 38, 0.1)",
-    color: "#fccfcf",
-  },
-  warning: {
-    backgroundColor: "rgba(251, 245, 180, 0.1)",
-    color: "#fbf5b4",
-  },
-};
+// The class names are quite generic, but it should be fine since they are
+// scoped to the iframe only.
 
 const iframeStyle = {
   position: "fixed",
@@ -24,58 +16,131 @@ const iframeStyle = {
 };
 
 const containerStyle = {
-  position: "fixed",
-  boxSizing: "border-box",
-  left: 0,
-  top: 0,
-  right: 0,
-  bottom: 0,
-  width: "100vw",
-  height: "100vh",
-  fontSize: "large",
-  padding: "2rem 2rem 4rem 2rem",
-  lineHeight: "1.2",
-  whiteSpace: "pre-wrap",
-  overflow: "auto",
-  backgroundColor: "rgba(0, 0, 0, 0.9)",
-  color: "white",
+  className: "webpack-container",
+  css: /* css */ `.webpack-container {
+      position: fixed;
+      box-sizing: border-box;
+      left: 0;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      width: 100vw;
+      height: 100vh;
+      font-size: large;
+      padding: 2rem 2rem 4rem 2rem;
+      line-height: 1.2;
+      white-space: pre-wrap;
+      overflow: auto;
+      background-color: rgba(0, 0, 0, 0.9);
+      color: white;
+    }
+  `,
 };
 
 const headerStyle = {
-  color: "#e83b46",
-  fontSize: "2em",
-  whiteSpace: "pre-wrap",
-  fontFamily: "sans-serif",
-  margin: "0 2rem 2rem 0",
-  flex: "0 0 auto",
-  maxHeight: "50%",
-  overflow: "auto",
+  className: "webpack-header",
+  css: /* css */ `.webpack-header {
+      color: #e83b46;
+      font-size: 2em;
+      font-family: sans-serif;
+      white-space: pre-wrap;
+      margin: 0 2rem 2rem 0;
+      flex: 0 0 auto;
+      max-height: 50%;
+      overflow: auto;
+    }
+  `,
 };
 
 const dismissButtonStyle = {
-  color: "#ffffff",
-  lineHeight: "1rem",
-  fontSize: "1.5rem",
-  padding: "1rem",
-  cursor: "pointer",
-  position: "absolute",
-  right: 0,
-  top: 0,
-  backgroundColor: "transparent",
-  border: "none",
+  className: "webpack-dismiss-btn",
+  css: /* css */ `.webpack-dismiss-btn {
+    color: #ffffff;
+    line-height: 1rem;
+    font-size: 1.5rem;
+    padding: 1rem;
+    cursor: pointer;
+    position: absolute;
+    right: 0;
+    top: 0;
+    background-color: transparent;
+    border: none;
+  }
+  
+  .webpack-dismiss-btn:hover {
+    color: #d1d5db;
+  }`,
 };
 
 const msgTypeStyle = {
-  color: "#e83b46",
-  fontSize: "1.2em",
-  marginBottom: "1rem",
-  fontFamily: "sans-serif",
+  className: "webpack-msg-type",
+  css: /* css */ `.webpack-msg-type {
+      margin-bottom: 1rem;
+      color: #e83b46;
+      font-size: 1.2em;
+      font-family: sans-serif;
+    }
+
+  .webpack-msg-type[data-can-open] {
+    cursor: pointer;
+  }
+  `,
 };
 
 const msgTextStyle = {
-  lineHeight: "1.5",
-  fontSize: "1rem",
-  fontFamily: "Menlo, Consolas, monospace",
+  className: "webpack-msg-text",
+  css: /* css */ `.webpack-msg-text {
+      line-height: 1.5;
+      font-size: 1rem;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;;
+    }
+  `,
+};
+
+const msgStyles = {
+  error: {
+    className: "webpack-error-msg",
+    css: /* css */ `.webpack-error-msg {
+      background-color: rgba(206, 17, 38, 0.1);
+      color: #fccfcf;
+      padding: 1rem 1rem 1.5rem 1rem;
+    }`,
+  },
+  warning: {
+    className: "webpack-warning-msg",
+    css: /* css */ `.webpack-warning-msg {
+      background-color: rgba(251, 245, 180, 0.1);
+      color: #fbf5b4;
+      padding: 1rem 1rem 1.5rem 1rem;
+    }`,
+  },
+};
+
+/**
+ * @typedef {Object} CssLoader
+ * @property {(css: string) => void} load
+ */
+
+/**
+ *
+ * @param {Document} doc
+ * @return {CssLoader}
+ */
+const createCssLoader = (doc) => {
+  /** @type {string[]} */
+  const loadedCss = [];
+
+  return {
+    load: (css) => {
+      // ignore CSS rule that has loaded before
+      if (!loadedCss.includes(css)) {
+        const style = doc.createElement("style");
+        style.innerHTML = css;
+        doc.head.appendChild(style);
+        loadedCss.push(css);
+      }
+    },
+  };
 };
 
 export {
@@ -86,4 +151,5 @@ export {
   dismissButtonStyle,
   msgTypeStyle,
   msgTextStyle,
+  createCssLoader,
 };

--- a/test/e2e/__snapshots__/overlay.test.js.snap.webpack4
+++ b/test/e2e/__snapshots__/overlay.test.js.snap.webpack4
@@ -34,79 +34,13 @@ exports[`overlay should not show an error when "client.overlay.errors" is "false
 
 exports[`overlay should not show initially, then show on an error and allow to close: overlay html 1`] = `
 "<body>
-  <div
-    id=\\"webpack-dev-server-client-overlay-div\\"
-    style=\\"
-      position: fixed;
-      box-sizing: border-box;
-      inset: 0px;
-      width: 100vw;
-      height: 100vh;
-      font-size: large;
-      padding: 2rem 2rem 4rem;
-      line-height: 1.2;
-      white-space: pre-wrap;
-      overflow: auto;
-      background-color: rgba(0, 0, 0, 0.9);
-      color: white;
-    \\"
-  >
-    <div
-      style=\\"
-        color: rgb(232, 59, 70);
-        font-size: 2em;
-        white-space: pre-wrap;
-        font-family: sans-serif;
-        margin: 0px 2rem 2rem 0px;
-        flex: 0 0 auto;
-        max-height: 50%;
-        overflow: auto;
-      \\"
-    >
-      Compiled with problems:
-    </div>
-    <button
-      aria-label=\\"Dismiss\\"
-      style=\\"
-        color: rgb(255, 255, 255);
-        line-height: 1rem;
-        font-size: 1.5rem;
-        padding: 1rem;
-        cursor: pointer;
-        position: absolute;
-        right: 0px;
-        top: 0px;
-        background-color: transparent;
-        border: none;
-      \\"
-    >
-      ×
-    </button>
+  <div id=\\"webpack-dev-server-client-overlay-div\\" class=\\"webpack-container\\">
+    <div class=\\"webpack-header\\">Compiled with problems:</div>
+    <button class=\\"webpack-dismiss-btn\\" aria-label=\\"Dismiss\\">×</button>
     <div>
-      <div
-        style=\\"
-          background-color: rgba(206, 17, 38, 0.1);
-          color: rgb(252, 207, 207);
-          padding: 1rem 1rem 1.5rem;
-        \\"
-      >
-        <div
-          style=\\"
-            color: rgb(232, 59, 70);
-            font-size: 1.2em;
-            margin-bottom: 1rem;
-            font-family: sans-serif;
-          \\"
-        >
-          ERROR
-        </div>
-        <div
-          style=\\"
-            line-height: 1.5;
-            font-size: 1rem;
-            font-family: Menlo, Consolas, monospace;
-          \\"
-        >
+      <div class=\\"webpack-error-msg\\">
+        <div class=\\"webpack-msg-type\\">ERROR</div>
+        <div class=\\"webpack-msg-text\\">
           ./foo.js 1:1 Module parse failed: Unterminated template (1:1) You may
           need an appropriate loader to handle this file type, currently no
           loaders are configured to process this file. See
@@ -158,79 +92,13 @@ exports[`overlay should not show initially, then show on an error and allow to c
 
 exports[`overlay should not show initially, then show on an error, then hide on fix: overlay html 1`] = `
 "<body>
-  <div
-    id=\\"webpack-dev-server-client-overlay-div\\"
-    style=\\"
-      position: fixed;
-      box-sizing: border-box;
-      inset: 0px;
-      width: 100vw;
-      height: 100vh;
-      font-size: large;
-      padding: 2rem 2rem 4rem;
-      line-height: 1.2;
-      white-space: pre-wrap;
-      overflow: auto;
-      background-color: rgba(0, 0, 0, 0.9);
-      color: white;
-    \\"
-  >
-    <div
-      style=\\"
-        color: rgb(232, 59, 70);
-        font-size: 2em;
-        white-space: pre-wrap;
-        font-family: sans-serif;
-        margin: 0px 2rem 2rem 0px;
-        flex: 0 0 auto;
-        max-height: 50%;
-        overflow: auto;
-      \\"
-    >
-      Compiled with problems:
-    </div>
-    <button
-      aria-label=\\"Dismiss\\"
-      style=\\"
-        color: rgb(255, 255, 255);
-        line-height: 1rem;
-        font-size: 1.5rem;
-        padding: 1rem;
-        cursor: pointer;
-        position: absolute;
-        right: 0px;
-        top: 0px;
-        background-color: transparent;
-        border: none;
-      \\"
-    >
-      ×
-    </button>
+  <div id=\\"webpack-dev-server-client-overlay-div\\" class=\\"webpack-container\\">
+    <div class=\\"webpack-header\\">Compiled with problems:</div>
+    <button class=\\"webpack-dismiss-btn\\" aria-label=\\"Dismiss\\">×</button>
     <div>
-      <div
-        style=\\"
-          background-color: rgba(206, 17, 38, 0.1);
-          color: rgb(252, 207, 207);
-          padding: 1rem 1rem 1.5rem;
-        \\"
-      >
-        <div
-          style=\\"
-            color: rgb(232, 59, 70);
-            font-size: 1.2em;
-            margin-bottom: 1rem;
-            font-family: sans-serif;
-          \\"
-        >
-          ERROR
-        </div>
-        <div
-          style=\\"
-            line-height: 1.5;
-            font-size: 1rem;
-            font-family: Menlo, Consolas, monospace;
-          \\"
-        >
+      <div class=\\"webpack-error-msg\\">
+        <div class=\\"webpack-msg-type\\">ERROR</div>
+        <div class=\\"webpack-msg-text\\">
           ./foo.js 1:1 Module parse failed: Unterminated template (1:1) You may
           need an appropriate loader to handle this file type, currently no
           loaders are configured to process this file. See
@@ -282,79 +150,13 @@ exports[`overlay should not show initially, then show on an error, then hide on 
 
 exports[`overlay should not show initially, then show on an error, then show other error, then hide on fix: overlay html 1`] = `
 "<body>
-  <div
-    id=\\"webpack-dev-server-client-overlay-div\\"
-    style=\\"
-      position: fixed;
-      box-sizing: border-box;
-      inset: 0px;
-      width: 100vw;
-      height: 100vh;
-      font-size: large;
-      padding: 2rem 2rem 4rem;
-      line-height: 1.2;
-      white-space: pre-wrap;
-      overflow: auto;
-      background-color: rgba(0, 0, 0, 0.9);
-      color: white;
-    \\"
-  >
-    <div
-      style=\\"
-        color: rgb(232, 59, 70);
-        font-size: 2em;
-        white-space: pre-wrap;
-        font-family: sans-serif;
-        margin: 0px 2rem 2rem 0px;
-        flex: 0 0 auto;
-        max-height: 50%;
-        overflow: auto;
-      \\"
-    >
-      Compiled with problems:
-    </div>
-    <button
-      aria-label=\\"Dismiss\\"
-      style=\\"
-        color: rgb(255, 255, 255);
-        line-height: 1rem;
-        font-size: 1.5rem;
-        padding: 1rem;
-        cursor: pointer;
-        position: absolute;
-        right: 0px;
-        top: 0px;
-        background-color: transparent;
-        border: none;
-      \\"
-    >
-      ×
-    </button>
+  <div id=\\"webpack-dev-server-client-overlay-div\\" class=\\"webpack-container\\">
+    <div class=\\"webpack-header\\">Compiled with problems:</div>
+    <button class=\\"webpack-dismiss-btn\\" aria-label=\\"Dismiss\\">×</button>
     <div>
-      <div
-        style=\\"
-          background-color: rgba(206, 17, 38, 0.1);
-          color: rgb(252, 207, 207);
-          padding: 1rem 1rem 1.5rem;
-        \\"
-      >
-        <div
-          style=\\"
-            color: rgb(232, 59, 70);
-            font-size: 1.2em;
-            margin-bottom: 1rem;
-            font-family: sans-serif;
-          \\"
-        >
-          ERROR
-        </div>
-        <div
-          style=\\"
-            line-height: 1.5;
-            font-size: 1rem;
-            font-family: Menlo, Consolas, monospace;
-          \\"
-        >
+      <div class=\\"webpack-error-msg\\">
+        <div class=\\"webpack-msg-type\\">ERROR</div>
+        <div class=\\"webpack-msg-text\\">
           ./foo.js 1:1 Module parse failed: Unterminated template (1:1) You may
           need an appropriate loader to handle this file type, currently no
           loaders are configured to process this file. See
@@ -369,79 +171,13 @@ exports[`overlay should not show initially, then show on an error, then show oth
 
 exports[`overlay should not show initially, then show on an error, then show other error, then hide on fix: overlay html 2`] = `
 "<body>
-  <div
-    id=\\"webpack-dev-server-client-overlay-div\\"
-    style=\\"
-      position: fixed;
-      box-sizing: border-box;
-      inset: 0px;
-      width: 100vw;
-      height: 100vh;
-      font-size: large;
-      padding: 2rem 2rem 4rem;
-      line-height: 1.2;
-      white-space: pre-wrap;
-      overflow: auto;
-      background-color: rgba(0, 0, 0, 0.9);
-      color: white;
-    \\"
-  >
-    <div
-      style=\\"
-        color: rgb(232, 59, 70);
-        font-size: 2em;
-        white-space: pre-wrap;
-        font-family: sans-serif;
-        margin: 0px 2rem 2rem 0px;
-        flex: 0 0 auto;
-        max-height: 50%;
-        overflow: auto;
-      \\"
-    >
-      Compiled with problems:
-    </div>
-    <button
-      aria-label=\\"Dismiss\\"
-      style=\\"
-        color: rgb(255, 255, 255);
-        line-height: 1rem;
-        font-size: 1.5rem;
-        padding: 1rem;
-        cursor: pointer;
-        position: absolute;
-        right: 0px;
-        top: 0px;
-        background-color: transparent;
-        border: none;
-      \\"
-    >
-      ×
-    </button>
+  <div id=\\"webpack-dev-server-client-overlay-div\\" class=\\"webpack-container\\">
+    <div class=\\"webpack-header\\">Compiled with problems:</div>
+    <button class=\\"webpack-dismiss-btn\\" aria-label=\\"Dismiss\\">×</button>
     <div>
-      <div
-        style=\\"
-          background-color: rgba(206, 17, 38, 0.1);
-          color: rgb(252, 207, 207);
-          padding: 1rem 1rem 1.5rem;
-        \\"
-      >
-        <div
-          style=\\"
-            color: rgb(232, 59, 70);
-            font-size: 1.2em;
-            margin-bottom: 1rem;
-            font-family: sans-serif;
-          \\"
-        >
-          ERROR
-        </div>
-        <div
-          style=\\"
-            line-height: 1.5;
-            font-size: 1rem;
-            font-family: Menlo, Consolas, monospace;
-          \\"
-        >
+      <div class=\\"webpack-error-msg\\">
+        <div class=\\"webpack-msg-type\\">ERROR</div>
+        <div class=\\"webpack-msg-text\\">
           ./foo.js 1:1 Module parse failed: Unterminated template (1:1) You may
           need an appropriate loader to handle this file type, currently no
           loaders are configured to process this file. See
@@ -514,81 +250,13 @@ exports[`overlay should not show initially, then show on an error, then show oth
 
 exports[`overlay should show a warning after invalidation: overlay html 1`] = `
 "<body>
-  <div
-    id=\\"webpack-dev-server-client-overlay-div\\"
-    style=\\"
-      position: fixed;
-      box-sizing: border-box;
-      inset: 0px;
-      width: 100vw;
-      height: 100vh;
-      font-size: large;
-      padding: 2rem 2rem 4rem;
-      line-height: 1.2;
-      white-space: pre-wrap;
-      overflow: auto;
-      background-color: rgba(0, 0, 0, 0.9);
-      color: white;
-    \\"
-  >
-    <div
-      style=\\"
-        color: rgb(232, 59, 70);
-        font-size: 2em;
-        white-space: pre-wrap;
-        font-family: sans-serif;
-        margin: 0px 2rem 2rem 0px;
-        flex: 0 0 auto;
-        max-height: 50%;
-        overflow: auto;
-      \\"
-    >
-      Compiled with problems:
-    </div>
-    <button
-      aria-label=\\"Dismiss\\"
-      style=\\"
-        color: rgb(255, 255, 255);
-        line-height: 1rem;
-        font-size: 1.5rem;
-        padding: 1rem;
-        cursor: pointer;
-        position: absolute;
-        right: 0px;
-        top: 0px;
-        background-color: transparent;
-        border: none;
-      \\"
-    >
-      ×
-    </button>
+  <div id=\\"webpack-dev-server-client-overlay-div\\" class=\\"webpack-container\\">
+    <div class=\\"webpack-header\\">Compiled with problems:</div>
+    <button class=\\"webpack-dismiss-btn\\" aria-label=\\"Dismiss\\">×</button>
     <div>
-      <div
-        style=\\"
-          background-color: rgba(251, 245, 180, 0.1);
-          color: rgb(251, 245, 180);
-          padding: 1rem 1rem 1.5rem;
-        \\"
-      >
-        <div
-          style=\\"
-            color: rgb(232, 59, 70);
-            font-size: 1.2em;
-            margin-bottom: 1rem;
-            font-family: sans-serif;
-          \\"
-        >
-          WARNING
-        </div>
-        <div
-          style=\\"
-            line-height: 1.5;
-            font-size: 1rem;
-            font-family: Menlo, Consolas, monospace;
-          \\"
-        >
-          Warning from compilation
-        </div>
+      <div class=\\"webpack-warning-msg\\">
+        <div class=\\"webpack-msg-type\\">WARNING</div>
+        <div class=\\"webpack-msg-text\\">Warning from compilation</div>
       </div>
     </div>
   </div>
@@ -619,108 +287,17 @@ exports[`overlay should show a warning after invalidation: page html 1`] = `
 
 exports[`overlay should show a warning and error for initial compilation and protects against xss: overlay html 1`] = `
 "<body>
-  <div
-    id=\\"webpack-dev-server-client-overlay-div\\"
-    style=\\"
-      position: fixed;
-      box-sizing: border-box;
-      inset: 0px;
-      width: 100vw;
-      height: 100vh;
-      font-size: large;
-      padding: 2rem 2rem 4rem;
-      line-height: 1.2;
-      white-space: pre-wrap;
-      overflow: auto;
-      background-color: rgba(0, 0, 0, 0.9);
-      color: white;
-    \\"
-  >
-    <div
-      style=\\"
-        color: rgb(232, 59, 70);
-        font-size: 2em;
-        white-space: pre-wrap;
-        font-family: sans-serif;
-        margin: 0px 2rem 2rem 0px;
-        flex: 0 0 auto;
-        max-height: 50%;
-        overflow: auto;
-      \\"
-    >
-      Compiled with problems:
-    </div>
-    <button
-      aria-label=\\"Dismiss\\"
-      style=\\"
-        color: rgb(255, 255, 255);
-        line-height: 1rem;
-        font-size: 1.5rem;
-        padding: 1rem;
-        cursor: pointer;
-        position: absolute;
-        right: 0px;
-        top: 0px;
-        background-color: transparent;
-        border: none;
-      \\"
-    >
-      ×
-    </button>
+  <div id=\\"webpack-dev-server-client-overlay-div\\" class=\\"webpack-container\\">
+    <div class=\\"webpack-header\\">Compiled with problems:</div>
+    <button class=\\"webpack-dismiss-btn\\" aria-label=\\"Dismiss\\">×</button>
     <div>
-      <div
-        style=\\"
-          background-color: rgba(206, 17, 38, 0.1);
-          color: rgb(252, 207, 207);
-          padding: 1rem 1rem 1.5rem;
-        \\"
-      >
-        <div
-          style=\\"
-            color: rgb(232, 59, 70);
-            font-size: 1.2em;
-            margin-bottom: 1rem;
-            font-family: sans-serif;
-          \\"
-        >
-          ERROR
-        </div>
-        <div
-          style=\\"
-            line-height: 1.5;
-            font-size: 1rem;
-            font-family: Menlo, Consolas, monospace;
-          \\"
-        >
-          &lt;strong&gt;strong&lt;/strong&gt;
-        </div>
+      <div class=\\"webpack-error-msg\\">
+        <div class=\\"webpack-msg-type\\">ERROR</div>
+        <div class=\\"webpack-msg-text\\">&lt;strong&gt;strong&lt;/strong&gt;</div>
       </div>
-      <div
-        style=\\"
-          background-color: rgba(206, 17, 38, 0.1);
-          color: rgb(252, 207, 207);
-          padding: 1rem 1rem 1.5rem;
-        \\"
-      >
-        <div
-          style=\\"
-            color: rgb(232, 59, 70);
-            font-size: 1.2em;
-            margin-bottom: 1rem;
-            font-family: sans-serif;
-          \\"
-        >
-          ERROR
-        </div>
-        <div
-          style=\\"
-            line-height: 1.5;
-            font-size: 1rem;
-            font-family: Menlo, Consolas, monospace;
-          \\"
-        >
-          &lt;strong&gt;strong&lt;/strong&gt;
-        </div>
+      <div class=\\"webpack-error-msg\\">
+        <div class=\\"webpack-msg-type\\">ERROR</div>
+        <div class=\\"webpack-msg-text\\">&lt;strong&gt;strong&lt;/strong&gt;</div>
       </div>
     </div>
   </div>
@@ -751,187 +328,33 @@ exports[`overlay should show a warning and error for initial compilation and pro
 
 exports[`overlay should show a warning and error for initial compilation: overlay html 1`] = `
 "<body>
-  <div
-    id=\\"webpack-dev-server-client-overlay-div\\"
-    style=\\"
-      position: fixed;
-      box-sizing: border-box;
-      inset: 0px;
-      width: 100vw;
-      height: 100vh;
-      font-size: large;
-      padding: 2rem 2rem 4rem;
-      line-height: 1.2;
-      white-space: pre-wrap;
-      overflow: auto;
-      background-color: rgba(0, 0, 0, 0.9);
-      color: white;
-    \\"
-  >
-    <div
-      style=\\"
-        color: rgb(232, 59, 70);
-        font-size: 2em;
-        white-space: pre-wrap;
-        font-family: sans-serif;
-        margin: 0px 2rem 2rem 0px;
-        flex: 0 0 auto;
-        max-height: 50%;
-        overflow: auto;
-      \\"
-    >
-      Compiled with problems:
-    </div>
-    <button
-      aria-label=\\"Dismiss\\"
-      style=\\"
-        color: rgb(255, 255, 255);
-        line-height: 1rem;
-        font-size: 1.5rem;
-        padding: 1rem;
-        cursor: pointer;
-        position: absolute;
-        right: 0px;
-        top: 0px;
-        background-color: transparent;
-        border: none;
-      \\"
-    >
-      ×
-    </button>
+  <div id=\\"webpack-dev-server-client-overlay-div\\" class=\\"webpack-container\\">
+    <div class=\\"webpack-header\\">Compiled with problems:</div>
+    <button class=\\"webpack-dismiss-btn\\" aria-label=\\"Dismiss\\">×</button>
     <div>
-      <div
-        style=\\"
-          background-color: rgba(206, 17, 38, 0.1);
-          color: rgb(252, 207, 207);
-          padding: 1rem 1rem 1.5rem;
-        \\"
-      >
-        <div
-          style=\\"
-            color: rgb(232, 59, 70);
-            font-size: 1.2em;
-            margin-bottom: 1rem;
-            font-family: sans-serif;
-          \\"
-        >
-          ERROR
-        </div>
-        <div
-          style=\\"
-            line-height: 1.5;
-            font-size: 1rem;
-            font-family: Menlo, Consolas, monospace;
-          \\"
-        >
-          Warning from compilation
-        </div>
+      <div class=\\"webpack-error-msg\\">
+        <div class=\\"webpack-msg-type\\">ERROR</div>
+        <div class=\\"webpack-msg-text\\">Warning from compilation</div>
       </div>
-      <div
-        style=\\"
-          background-color: rgba(206, 17, 38, 0.1);
-          color: rgb(252, 207, 207);
-          padding: 1rem 1rem 1.5rem;
-        \\"
-      >
-        <div
-          style=\\"
-            color: rgb(232, 59, 70);
-            font-size: 1.2em;
-            margin-bottom: 1rem;
-            font-family: sans-serif;
-          \\"
-        >
-          ERROR
-        </div>
-        <div
-          style=\\"
-            line-height: 1.5;
-            font-size: 1rem;
-            font-family: Menlo, Consolas, monospace;
-          \\"
-        >
-          Warning from compilation
-        </div>
+      <div class=\\"webpack-error-msg\\">
+        <div class=\\"webpack-msg-type\\">ERROR</div>
+        <div class=\\"webpack-msg-text\\">Warning from compilation</div>
       </div>
-      <div
-        style=\\"
-          background-color: rgba(206, 17, 38, 0.1);
-          color: rgb(252, 207, 207);
-          padding: 1rem 1rem 1.5rem;
-        \\"
-      >
-        <div
-          style=\\"
-            color: rgb(232, 59, 70);
-            font-size: 1.2em;
-            margin-bottom: 1rem;
-            font-family: sans-serif;
-          \\"
-        >
-          ERROR
-        </div>
-        <div
-          style=\\"
-            line-height: 1.5;
-            font-size: 1rem;
-            font-family: Menlo, Consolas, monospace;
-          \\"
-        >
+      <div class=\\"webpack-error-msg\\">
+        <div class=\\"webpack-msg-type\\">ERROR</div>
+        <div class=\\"webpack-msg-text\\">
           Error from compilation. Can't find 'test' module.
         </div>
       </div>
-      <div
-        style=\\"
-          background-color: rgba(206, 17, 38, 0.1);
-          color: rgb(252, 207, 207);
-          padding: 1rem 1rem 1.5rem;
-        \\"
-      >
-        <div
-          style=\\"
-            color: rgb(232, 59, 70);
-            font-size: 1.2em;
-            margin-bottom: 1rem;
-            font-family: sans-serif;
-          \\"
-        >
-          ERROR
-        </div>
-        <div
-          style=\\"
-            line-height: 1.5;
-            font-size: 1rem;
-            font-family: Menlo, Consolas, monospace;
-          \\"
-        >
+      <div class=\\"webpack-error-msg\\">
+        <div class=\\"webpack-msg-type\\">ERROR</div>
+        <div class=\\"webpack-msg-text\\">
           Error from compilation. Can't find 'test' module.
         </div>
       </div>
-      <div
-        style=\\"
-          background-color: rgba(206, 17, 38, 0.1);
-          color: rgb(252, 207, 207);
-          padding: 1rem 1rem 1.5rem;
-        \\"
-      >
-        <div
-          style=\\"
-            color: rgb(232, 59, 70);
-            font-size: 1.2em;
-            margin-bottom: 1rem;
-            font-family: sans-serif;
-          \\"
-        >
-          ERROR
-        </div>
-        <div
-          style=\\"
-            line-height: 1.5;
-            font-size: 1rem;
-            font-family: Menlo, Consolas, monospace;
-          \\"
-        >
+      <div class=\\"webpack-error-msg\\">
+        <div class=\\"webpack-msg-type\\">ERROR</div>
+        <div class=\\"webpack-msg-text\\">
           Error from compilation. Can't find 'test' module.
         </div>
       </div>
@@ -964,81 +387,13 @@ exports[`overlay should show a warning and error for initial compilation: page h
 
 exports[`overlay should show a warning and hide them after closing connection: overlay html 1`] = `
 "<body>
-  <div
-    id=\\"webpack-dev-server-client-overlay-div\\"
-    style=\\"
-      position: fixed;
-      box-sizing: border-box;
-      inset: 0px;
-      width: 100vw;
-      height: 100vh;
-      font-size: large;
-      padding: 2rem 2rem 4rem;
-      line-height: 1.2;
-      white-space: pre-wrap;
-      overflow: auto;
-      background-color: rgba(0, 0, 0, 0.9);
-      color: white;
-    \\"
-  >
-    <div
-      style=\\"
-        color: rgb(232, 59, 70);
-        font-size: 2em;
-        white-space: pre-wrap;
-        font-family: sans-serif;
-        margin: 0px 2rem 2rem 0px;
-        flex: 0 0 auto;
-        max-height: 50%;
-        overflow: auto;
-      \\"
-    >
-      Compiled with problems:
-    </div>
-    <button
-      aria-label=\\"Dismiss\\"
-      style=\\"
-        color: rgb(255, 255, 255);
-        line-height: 1rem;
-        font-size: 1.5rem;
-        padding: 1rem;
-        cursor: pointer;
-        position: absolute;
-        right: 0px;
-        top: 0px;
-        background-color: transparent;
-        border: none;
-      \\"
-    >
-      ×
-    </button>
+  <div id=\\"webpack-dev-server-client-overlay-div\\" class=\\"webpack-container\\">
+    <div class=\\"webpack-header\\">Compiled with problems:</div>
+    <button class=\\"webpack-dismiss-btn\\" aria-label=\\"Dismiss\\">×</button>
     <div>
-      <div
-        style=\\"
-          background-color: rgba(251, 245, 180, 0.1);
-          color: rgb(251, 245, 180);
-          padding: 1rem 1rem 1.5rem;
-        \\"
-      >
-        <div
-          style=\\"
-            color: rgb(232, 59, 70);
-            font-size: 1.2em;
-            margin-bottom: 1rem;
-            font-family: sans-serif;
-          \\"
-        >
-          WARNING
-        </div>
-        <div
-          style=\\"
-            line-height: 1.5;
-            font-size: 1rem;
-            font-family: Menlo, Consolas, monospace;
-          \\"
-        >
-          Warning from compilation
-        </div>
+      <div class=\\"webpack-warning-msg\\">
+        <div class=\\"webpack-msg-type\\">WARNING</div>
+        <div class=\\"webpack-msg-text\\">Warning from compilation</div>
       </div>
     </div>
   </div>
@@ -1077,81 +432,13 @@ exports[`overlay should show a warning and hide them after closing connection: p
 
 exports[`overlay should show a warning for initial compilation: overlay html 1`] = `
 "<body>
-  <div
-    id=\\"webpack-dev-server-client-overlay-div\\"
-    style=\\"
-      position: fixed;
-      box-sizing: border-box;
-      inset: 0px;
-      width: 100vw;
-      height: 100vh;
-      font-size: large;
-      padding: 2rem 2rem 4rem;
-      line-height: 1.2;
-      white-space: pre-wrap;
-      overflow: auto;
-      background-color: rgba(0, 0, 0, 0.9);
-      color: white;
-    \\"
-  >
-    <div
-      style=\\"
-        color: rgb(232, 59, 70);
-        font-size: 2em;
-        white-space: pre-wrap;
-        font-family: sans-serif;
-        margin: 0px 2rem 2rem 0px;
-        flex: 0 0 auto;
-        max-height: 50%;
-        overflow: auto;
-      \\"
-    >
-      Compiled with problems:
-    </div>
-    <button
-      aria-label=\\"Dismiss\\"
-      style=\\"
-        color: rgb(255, 255, 255);
-        line-height: 1rem;
-        font-size: 1.5rem;
-        padding: 1rem;
-        cursor: pointer;
-        position: absolute;
-        right: 0px;
-        top: 0px;
-        background-color: transparent;
-        border: none;
-      \\"
-    >
-      ×
-    </button>
+  <div id=\\"webpack-dev-server-client-overlay-div\\" class=\\"webpack-container\\">
+    <div class=\\"webpack-header\\">Compiled with problems:</div>
+    <button class=\\"webpack-dismiss-btn\\" aria-label=\\"Dismiss\\">×</button>
     <div>
-      <div
-        style=\\"
-          background-color: rgba(251, 245, 180, 0.1);
-          color: rgb(251, 245, 180);
-          padding: 1rem 1rem 1.5rem;
-        \\"
-      >
-        <div
-          style=\\"
-            color: rgb(232, 59, 70);
-            font-size: 1.2em;
-            margin-bottom: 1rem;
-            font-family: sans-serif;
-          \\"
-        >
-          WARNING
-        </div>
-        <div
-          style=\\"
-            line-height: 1.5;
-            font-size: 1rem;
-            font-family: Menlo, Consolas, monospace;
-          \\"
-        >
-          Warning from compilation
-        </div>
+      <div class=\\"webpack-warning-msg\\">
+        <div class=\\"webpack-msg-type\\">WARNING</div>
+        <div class=\\"webpack-msg-text\\">Warning from compilation</div>
       </div>
     </div>
   </div>
@@ -1182,81 +469,13 @@ exports[`overlay should show a warning for initial compilation: page html 1`] = 
 
 exports[`overlay should show a warning when "client.overlay" is "true": overlay html 1`] = `
 "<body>
-  <div
-    id=\\"webpack-dev-server-client-overlay-div\\"
-    style=\\"
-      position: fixed;
-      box-sizing: border-box;
-      inset: 0px;
-      width: 100vw;
-      height: 100vh;
-      font-size: large;
-      padding: 2rem 2rem 4rem;
-      line-height: 1.2;
-      white-space: pre-wrap;
-      overflow: auto;
-      background-color: rgba(0, 0, 0, 0.9);
-      color: white;
-    \\"
-  >
-    <div
-      style=\\"
-        color: rgb(232, 59, 70);
-        font-size: 2em;
-        white-space: pre-wrap;
-        font-family: sans-serif;
-        margin: 0px 2rem 2rem 0px;
-        flex: 0 0 auto;
-        max-height: 50%;
-        overflow: auto;
-      \\"
-    >
-      Compiled with problems:
-    </div>
-    <button
-      aria-label=\\"Dismiss\\"
-      style=\\"
-        color: rgb(255, 255, 255);
-        line-height: 1rem;
-        font-size: 1.5rem;
-        padding: 1rem;
-        cursor: pointer;
-        position: absolute;
-        right: 0px;
-        top: 0px;
-        background-color: transparent;
-        border: none;
-      \\"
-    >
-      ×
-    </button>
+  <div id=\\"webpack-dev-server-client-overlay-div\\" class=\\"webpack-container\\">
+    <div class=\\"webpack-header\\">Compiled with problems:</div>
+    <button class=\\"webpack-dismiss-btn\\" aria-label=\\"Dismiss\\">×</button>
     <div>
-      <div
-        style=\\"
-          background-color: rgba(251, 245, 180, 0.1);
-          color: rgb(251, 245, 180);
-          padding: 1rem 1rem 1.5rem;
-        \\"
-      >
-        <div
-          style=\\"
-            color: rgb(232, 59, 70);
-            font-size: 1.2em;
-            margin-bottom: 1rem;
-            font-family: sans-serif;
-          \\"
-        >
-          WARNING
-        </div>
-        <div
-          style=\\"
-            line-height: 1.5;
-            font-size: 1rem;
-            font-family: Menlo, Consolas, monospace;
-          \\"
-        >
-          Warning from compilation
-        </div>
+      <div class=\\"webpack-warning-msg\\">
+        <div class=\\"webpack-msg-type\\">WARNING</div>
+        <div class=\\"webpack-msg-text\\">Warning from compilation</div>
       </div>
     </div>
   </div>
@@ -1287,81 +506,13 @@ exports[`overlay should show a warning when "client.overlay" is "true": page htm
 
 exports[`overlay should show a warning when "client.overlay.errors" is "true": overlay html 1`] = `
 "<body>
-  <div
-    id=\\"webpack-dev-server-client-overlay-div\\"
-    style=\\"
-      position: fixed;
-      box-sizing: border-box;
-      inset: 0px;
-      width: 100vw;
-      height: 100vh;
-      font-size: large;
-      padding: 2rem 2rem 4rem;
-      line-height: 1.2;
-      white-space: pre-wrap;
-      overflow: auto;
-      background-color: rgba(0, 0, 0, 0.9);
-      color: white;
-    \\"
-  >
-    <div
-      style=\\"
-        color: rgb(232, 59, 70);
-        font-size: 2em;
-        white-space: pre-wrap;
-        font-family: sans-serif;
-        margin: 0px 2rem 2rem 0px;
-        flex: 0 0 auto;
-        max-height: 50%;
-        overflow: auto;
-      \\"
-    >
-      Compiled with problems:
-    </div>
-    <button
-      aria-label=\\"Dismiss\\"
-      style=\\"
-        color: rgb(255, 255, 255);
-        line-height: 1rem;
-        font-size: 1.5rem;
-        padding: 1rem;
-        cursor: pointer;
-        position: absolute;
-        right: 0px;
-        top: 0px;
-        background-color: transparent;
-        border: none;
-      \\"
-    >
-      ×
-    </button>
+  <div id=\\"webpack-dev-server-client-overlay-div\\" class=\\"webpack-container\\">
+    <div class=\\"webpack-header\\">Compiled with problems:</div>
+    <button class=\\"webpack-dismiss-btn\\" aria-label=\\"Dismiss\\">×</button>
     <div>
-      <div
-        style=\\"
-          background-color: rgba(251, 245, 180, 0.1);
-          color: rgb(251, 245, 180);
-          padding: 1rem 1rem 1.5rem;
-        \\"
-      >
-        <div
-          style=\\"
-            color: rgb(232, 59, 70);
-            font-size: 1.2em;
-            margin-bottom: 1rem;
-            font-family: sans-serif;
-          \\"
-        >
-          WARNING
-        </div>
-        <div
-          style=\\"
-            line-height: 1.5;
-            font-size: 1rem;
-            font-family: Menlo, Consolas, monospace;
-          \\"
-        >
-          Warning from compilation
-        </div>
+      <div class=\\"webpack-warning-msg\\">
+        <div class=\\"webpack-msg-type\\">WARNING</div>
+        <div class=\\"webpack-msg-text\\">Warning from compilation</div>
       </div>
     </div>
   </div>
@@ -1392,81 +543,13 @@ exports[`overlay should show a warning when "client.overlay.errors" is "true": p
 
 exports[`overlay should show a warning when "client.overlay.warnings" is "true": overlay html 1`] = `
 "<body>
-  <div
-    id=\\"webpack-dev-server-client-overlay-div\\"
-    style=\\"
-      position: fixed;
-      box-sizing: border-box;
-      inset: 0px;
-      width: 100vw;
-      height: 100vh;
-      font-size: large;
-      padding: 2rem 2rem 4rem;
-      line-height: 1.2;
-      white-space: pre-wrap;
-      overflow: auto;
-      background-color: rgba(0, 0, 0, 0.9);
-      color: white;
-    \\"
-  >
-    <div
-      style=\\"
-        color: rgb(232, 59, 70);
-        font-size: 2em;
-        white-space: pre-wrap;
-        font-family: sans-serif;
-        margin: 0px 2rem 2rem 0px;
-        flex: 0 0 auto;
-        max-height: 50%;
-        overflow: auto;
-      \\"
-    >
-      Compiled with problems:
-    </div>
-    <button
-      aria-label=\\"Dismiss\\"
-      style=\\"
-        color: rgb(255, 255, 255);
-        line-height: 1rem;
-        font-size: 1.5rem;
-        padding: 1rem;
-        cursor: pointer;
-        position: absolute;
-        right: 0px;
-        top: 0px;
-        background-color: transparent;
-        border: none;
-      \\"
-    >
-      ×
-    </button>
+  <div id=\\"webpack-dev-server-client-overlay-div\\" class=\\"webpack-container\\">
+    <div class=\\"webpack-header\\">Compiled with problems:</div>
+    <button class=\\"webpack-dismiss-btn\\" aria-label=\\"Dismiss\\">×</button>
     <div>
-      <div
-        style=\\"
-          background-color: rgba(251, 245, 180, 0.1);
-          color: rgb(251, 245, 180);
-          padding: 1rem 1rem 1.5rem;
-        \\"
-      >
-        <div
-          style=\\"
-            color: rgb(232, 59, 70);
-            font-size: 1.2em;
-            margin-bottom: 1rem;
-            font-family: sans-serif;
-          \\"
-        >
-          WARNING
-        </div>
-        <div
-          style=\\"
-            line-height: 1.5;
-            font-size: 1rem;
-            font-family: Menlo, Consolas, monospace;
-          \\"
-        >
-          Warning from compilation
-        </div>
+      <div class=\\"webpack-warning-msg\\">
+        <div class=\\"webpack-msg-type\\">WARNING</div>
+        <div class=\\"webpack-msg-text\\">Warning from compilation</div>
       </div>
     </div>
   </div>
@@ -1497,79 +580,13 @@ exports[`overlay should show a warning when "client.overlay.warnings" is "true":
 
 exports[`overlay should show an ansi formatted error for initial compilation: overlay html 1`] = `
 "<body>
-  <div
-    id=\\"webpack-dev-server-client-overlay-div\\"
-    style=\\"
-      position: fixed;
-      box-sizing: border-box;
-      inset: 0px;
-      width: 100vw;
-      height: 100vh;
-      font-size: large;
-      padding: 2rem 2rem 4rem;
-      line-height: 1.2;
-      white-space: pre-wrap;
-      overflow: auto;
-      background-color: rgba(0, 0, 0, 0.9);
-      color: white;
-    \\"
-  >
-    <div
-      style=\\"
-        color: rgb(232, 59, 70);
-        font-size: 2em;
-        white-space: pre-wrap;
-        font-family: sans-serif;
-        margin: 0px 2rem 2rem 0px;
-        flex: 0 0 auto;
-        max-height: 50%;
-        overflow: auto;
-      \\"
-    >
-      Compiled with problems:
-    </div>
-    <button
-      aria-label=\\"Dismiss\\"
-      style=\\"
-        color: rgb(255, 255, 255);
-        line-height: 1rem;
-        font-size: 1.5rem;
-        padding: 1rem;
-        cursor: pointer;
-        position: absolute;
-        right: 0px;
-        top: 0px;
-        background-color: transparent;
-        border: none;
-      \\"
-    >
-      ×
-    </button>
+  <div id=\\"webpack-dev-server-client-overlay-div\\" class=\\"webpack-container\\">
+    <div class=\\"webpack-header\\">Compiled with problems:</div>
+    <button class=\\"webpack-dismiss-btn\\" aria-label=\\"Dismiss\\">×</button>
     <div>
-      <div
-        style=\\"
-          background-color: rgba(206, 17, 38, 0.1);
-          color: rgb(252, 207, 207);
-          padding: 1rem 1rem 1.5rem;
-        \\"
-      >
-        <div
-          style=\\"
-            color: rgb(232, 59, 70);
-            font-size: 1.2em;
-            margin-bottom: 1rem;
-            font-family: sans-serif;
-          \\"
-        >
-          ERROR
-        </div>
-        <div
-          style=\\"
-            line-height: 1.5;
-            font-size: 1rem;
-            font-family: Menlo, Consolas, monospace;
-          \\"
-        >
+      <div class=\\"webpack-error-msg\\">
+        <div class=\\"webpack-msg-type\\">ERROR</div>
+        <div class=\\"webpack-msg-text\\">
           <span
             style=\\"
               font-weight: normal;
@@ -1613,81 +630,13 @@ exports[`overlay should show an ansi formatted error for initial compilation: pa
 
 exports[`overlay should show an error after invalidation: overlay html 1`] = `
 "<body>
-  <div
-    id=\\"webpack-dev-server-client-overlay-div\\"
-    style=\\"
-      position: fixed;
-      box-sizing: border-box;
-      inset: 0px;
-      width: 100vw;
-      height: 100vh;
-      font-size: large;
-      padding: 2rem 2rem 4rem;
-      line-height: 1.2;
-      white-space: pre-wrap;
-      overflow: auto;
-      background-color: rgba(0, 0, 0, 0.9);
-      color: white;
-    \\"
-  >
-    <div
-      style=\\"
-        color: rgb(232, 59, 70);
-        font-size: 2em;
-        white-space: pre-wrap;
-        font-family: sans-serif;
-        margin: 0px 2rem 2rem 0px;
-        flex: 0 0 auto;
-        max-height: 50%;
-        overflow: auto;
-      \\"
-    >
-      Compiled with problems:
-    </div>
-    <button
-      aria-label=\\"Dismiss\\"
-      style=\\"
-        color: rgb(255, 255, 255);
-        line-height: 1rem;
-        font-size: 1.5rem;
-        padding: 1rem;
-        cursor: pointer;
-        position: absolute;
-        right: 0px;
-        top: 0px;
-        background-color: transparent;
-        border: none;
-      \\"
-    >
-      ×
-    </button>
+  <div id=\\"webpack-dev-server-client-overlay-div\\" class=\\"webpack-container\\">
+    <div class=\\"webpack-header\\">Compiled with problems:</div>
+    <button class=\\"webpack-dismiss-btn\\" aria-label=\\"Dismiss\\">×</button>
     <div>
-      <div
-        style=\\"
-          background-color: rgba(206, 17, 38, 0.1);
-          color: rgb(252, 207, 207);
-          padding: 1rem 1rem 1.5rem;
-        \\"
-      >
-        <div
-          style=\\"
-            color: rgb(232, 59, 70);
-            font-size: 1.2em;
-            margin-bottom: 1rem;
-            font-family: sans-serif;
-          \\"
-        >
-          ERROR
-        </div>
-        <div
-          style=\\"
-            line-height: 1.5;
-            font-size: 1rem;
-            font-family: Menlo, Consolas, monospace;
-          \\"
-        >
-          Error from compilation
-        </div>
+      <div class=\\"webpack-error-msg\\">
+        <div class=\\"webpack-msg-type\\">ERROR</div>
+        <div class=\\"webpack-msg-text\\">Error from compilation</div>
       </div>
     </div>
   </div>
@@ -1718,79 +667,13 @@ exports[`overlay should show an error after invalidation: page html 1`] = `
 
 exports[`overlay should show an error for initial compilation: overlay html 1`] = `
 "<body>
-  <div
-    id=\\"webpack-dev-server-client-overlay-div\\"
-    style=\\"
-      position: fixed;
-      box-sizing: border-box;
-      inset: 0px;
-      width: 100vw;
-      height: 100vh;
-      font-size: large;
-      padding: 2rem 2rem 4rem;
-      line-height: 1.2;
-      white-space: pre-wrap;
-      overflow: auto;
-      background-color: rgba(0, 0, 0, 0.9);
-      color: white;
-    \\"
-  >
-    <div
-      style=\\"
-        color: rgb(232, 59, 70);
-        font-size: 2em;
-        white-space: pre-wrap;
-        font-family: sans-serif;
-        margin: 0px 2rem 2rem 0px;
-        flex: 0 0 auto;
-        max-height: 50%;
-        overflow: auto;
-      \\"
-    >
-      Compiled with problems:
-    </div>
-    <button
-      aria-label=\\"Dismiss\\"
-      style=\\"
-        color: rgb(255, 255, 255);
-        line-height: 1rem;
-        font-size: 1.5rem;
-        padding: 1rem;
-        cursor: pointer;
-        position: absolute;
-        right: 0px;
-        top: 0px;
-        background-color: transparent;
-        border: none;
-      \\"
-    >
-      ×
-    </button>
+  <div id=\\"webpack-dev-server-client-overlay-div\\" class=\\"webpack-container\\">
+    <div class=\\"webpack-header\\">Compiled with problems:</div>
+    <button class=\\"webpack-dismiss-btn\\" aria-label=\\"Dismiss\\">×</button>
     <div>
-      <div
-        style=\\"
-          background-color: rgba(206, 17, 38, 0.1);
-          color: rgb(252, 207, 207);
-          padding: 1rem 1rem 1.5rem;
-        \\"
-      >
-        <div
-          style=\\"
-            color: rgb(232, 59, 70);
-            font-size: 1.2em;
-            margin-bottom: 1rem;
-            font-family: sans-serif;
-          \\"
-        >
-          ERROR
-        </div>
-        <div
-          style=\\"
-            line-height: 1.5;
-            font-size: 1rem;
-            font-family: Menlo, Consolas, monospace;
-          \\"
-        >
+      <div class=\\"webpack-error-msg\\">
+        <div class=\\"webpack-msg-type\\">ERROR</div>
+        <div class=\\"webpack-msg-text\\">
           Error from compilation. Can't find 'test' module.
         </div>
       </div>
@@ -1823,79 +706,13 @@ exports[`overlay should show an error for initial compilation: page html 1`] = `
 
 exports[`overlay should show an error when "client.overlay" is "true": overlay html 1`] = `
 "<body>
-  <div
-    id=\\"webpack-dev-server-client-overlay-div\\"
-    style=\\"
-      position: fixed;
-      box-sizing: border-box;
-      inset: 0px;
-      width: 100vw;
-      height: 100vh;
-      font-size: large;
-      padding: 2rem 2rem 4rem;
-      line-height: 1.2;
-      white-space: pre-wrap;
-      overflow: auto;
-      background-color: rgba(0, 0, 0, 0.9);
-      color: white;
-    \\"
-  >
-    <div
-      style=\\"
-        color: rgb(232, 59, 70);
-        font-size: 2em;
-        white-space: pre-wrap;
-        font-family: sans-serif;
-        margin: 0px 2rem 2rem 0px;
-        flex: 0 0 auto;
-        max-height: 50%;
-        overflow: auto;
-      \\"
-    >
-      Compiled with problems:
-    </div>
-    <button
-      aria-label=\\"Dismiss\\"
-      style=\\"
-        color: rgb(255, 255, 255);
-        line-height: 1rem;
-        font-size: 1.5rem;
-        padding: 1rem;
-        cursor: pointer;
-        position: absolute;
-        right: 0px;
-        top: 0px;
-        background-color: transparent;
-        border: none;
-      \\"
-    >
-      ×
-    </button>
+  <div id=\\"webpack-dev-server-client-overlay-div\\" class=\\"webpack-container\\">
+    <div class=\\"webpack-header\\">Compiled with problems:</div>
+    <button class=\\"webpack-dismiss-btn\\" aria-label=\\"Dismiss\\">×</button>
     <div>
-      <div
-        style=\\"
-          background-color: rgba(206, 17, 38, 0.1);
-          color: rgb(252, 207, 207);
-          padding: 1rem 1rem 1.5rem;
-        \\"
-      >
-        <div
-          style=\\"
-            color: rgb(232, 59, 70);
-            font-size: 1.2em;
-            margin-bottom: 1rem;
-            font-family: sans-serif;
-          \\"
-        >
-          ERROR
-        </div>
-        <div
-          style=\\"
-            line-height: 1.5;
-            font-size: 1rem;
-            font-family: Menlo, Consolas, monospace;
-          \\"
-        >
+      <div class=\\"webpack-error-msg\\">
+        <div class=\\"webpack-msg-type\\">ERROR</div>
+        <div class=\\"webpack-msg-text\\">
           Error from compilation. Can't find 'test' module.
         </div>
       </div>
@@ -1928,79 +745,13 @@ exports[`overlay should show an error when "client.overlay" is "true": page html
 
 exports[`overlay should show an error when "client.overlay.errors" is "true": overlay html 1`] = `
 "<body>
-  <div
-    id=\\"webpack-dev-server-client-overlay-div\\"
-    style=\\"
-      position: fixed;
-      box-sizing: border-box;
-      inset: 0px;
-      width: 100vw;
-      height: 100vh;
-      font-size: large;
-      padding: 2rem 2rem 4rem;
-      line-height: 1.2;
-      white-space: pre-wrap;
-      overflow: auto;
-      background-color: rgba(0, 0, 0, 0.9);
-      color: white;
-    \\"
-  >
-    <div
-      style=\\"
-        color: rgb(232, 59, 70);
-        font-size: 2em;
-        white-space: pre-wrap;
-        font-family: sans-serif;
-        margin: 0px 2rem 2rem 0px;
-        flex: 0 0 auto;
-        max-height: 50%;
-        overflow: auto;
-      \\"
-    >
-      Compiled with problems:
-    </div>
-    <button
-      aria-label=\\"Dismiss\\"
-      style=\\"
-        color: rgb(255, 255, 255);
-        line-height: 1rem;
-        font-size: 1.5rem;
-        padding: 1rem;
-        cursor: pointer;
-        position: absolute;
-        right: 0px;
-        top: 0px;
-        background-color: transparent;
-        border: none;
-      \\"
-    >
-      ×
-    </button>
+  <div id=\\"webpack-dev-server-client-overlay-div\\" class=\\"webpack-container\\">
+    <div class=\\"webpack-header\\">Compiled with problems:</div>
+    <button class=\\"webpack-dismiss-btn\\" aria-label=\\"Dismiss\\">×</button>
     <div>
-      <div
-        style=\\"
-          background-color: rgba(206, 17, 38, 0.1);
-          color: rgb(252, 207, 207);
-          padding: 1rem 1rem 1.5rem;
-        \\"
-      >
-        <div
-          style=\\"
-            color: rgb(232, 59, 70);
-            font-size: 1.2em;
-            margin-bottom: 1rem;
-            font-family: sans-serif;
-          \\"
-        >
-          ERROR
-        </div>
-        <div
-          style=\\"
-            line-height: 1.5;
-            font-size: 1rem;
-            font-family: Menlo, Consolas, monospace;
-          \\"
-        >
+      <div class=\\"webpack-error-msg\\">
+        <div class=\\"webpack-msg-type\\">ERROR</div>
+        <div class=\\"webpack-msg-text\\">
           Error from compilation. Can't find 'test' module.
         </div>
       </div>
@@ -2033,81 +784,13 @@ exports[`overlay should show an error when "client.overlay.errors" is "true": pa
 
 exports[`overlay should show an error when "client.overlay.warnings" is "true": overlay html 1`] = `
 "<body>
-  <div
-    id=\\"webpack-dev-server-client-overlay-div\\"
-    style=\\"
-      position: fixed;
-      box-sizing: border-box;
-      inset: 0px;
-      width: 100vw;
-      height: 100vh;
-      font-size: large;
-      padding: 2rem 2rem 4rem;
-      line-height: 1.2;
-      white-space: pre-wrap;
-      overflow: auto;
-      background-color: rgba(0, 0, 0, 0.9);
-      color: white;
-    \\"
-  >
-    <div
-      style=\\"
-        color: rgb(232, 59, 70);
-        font-size: 2em;
-        white-space: pre-wrap;
-        font-family: sans-serif;
-        margin: 0px 2rem 2rem 0px;
-        flex: 0 0 auto;
-        max-height: 50%;
-        overflow: auto;
-      \\"
-    >
-      Compiled with problems:
-    </div>
-    <button
-      aria-label=\\"Dismiss\\"
-      style=\\"
-        color: rgb(255, 255, 255);
-        line-height: 1rem;
-        font-size: 1.5rem;
-        padding: 1rem;
-        cursor: pointer;
-        position: absolute;
-        right: 0px;
-        top: 0px;
-        background-color: transparent;
-        border: none;
-      \\"
-    >
-      ×
-    </button>
+  <div id=\\"webpack-dev-server-client-overlay-div\\" class=\\"webpack-container\\">
+    <div class=\\"webpack-header\\">Compiled with problems:</div>
+    <button class=\\"webpack-dismiss-btn\\" aria-label=\\"Dismiss\\">×</button>
     <div>
-      <div
-        style=\\"
-          background-color: rgba(251, 245, 180, 0.1);
-          color: rgb(251, 245, 180);
-          padding: 1rem 1rem 1.5rem;
-        \\"
-      >
-        <div
-          style=\\"
-            color: rgb(232, 59, 70);
-            font-size: 1.2em;
-            margin-bottom: 1rem;
-            font-family: sans-serif;
-          \\"
-        >
-          WARNING
-        </div>
-        <div
-          style=\\"
-            line-height: 1.5;
-            font-size: 1rem;
-            font-family: Menlo, Consolas, monospace;
-          \\"
-        >
-          Warning from compilation
-        </div>
+      <div class=\\"webpack-warning-msg\\">
+        <div class=\\"webpack-msg-type\\">WARNING</div>
+        <div class=\\"webpack-msg-text\\">Warning from compilation</div>
       </div>
     </div>
   </div>
@@ -2138,79 +821,13 @@ exports[`overlay should show an error when "client.overlay.warnings" is "true": 
 
 exports[`overlay should show error for uncaught promise rejection: overlay html 1`] = `
 "<body>
-  <div
-    id=\\"webpack-dev-server-client-overlay-div\\"
-    style=\\"
-      position: fixed;
-      box-sizing: border-box;
-      inset: 0px;
-      width: 100vw;
-      height: 100vh;
-      font-size: large;
-      padding: 2rem 2rem 4rem;
-      line-height: 1.2;
-      white-space: pre-wrap;
-      overflow: auto;
-      background-color: rgba(0, 0, 0, 0.9);
-      color: white;
-    \\"
-  >
-    <div
-      style=\\"
-        color: rgb(232, 59, 70);
-        font-size: 2em;
-        white-space: pre-wrap;
-        font-family: sans-serif;
-        margin: 0px 2rem 2rem 0px;
-        flex: 0 0 auto;
-        max-height: 50%;
-        overflow: auto;
-      \\"
-    >
-      Uncaught runtime errors:
-    </div>
-    <button
-      aria-label=\\"Dismiss\\"
-      style=\\"
-        color: rgb(255, 255, 255);
-        line-height: 1rem;
-        font-size: 1.5rem;
-        padding: 1rem;
-        cursor: pointer;
-        position: absolute;
-        right: 0px;
-        top: 0px;
-        background-color: transparent;
-        border: none;
-      \\"
-    >
-      ×
-    </button>
+  <div id=\\"webpack-dev-server-client-overlay-div\\" class=\\"webpack-container\\">
+    <div class=\\"webpack-header\\">Uncaught runtime errors:</div>
+    <button class=\\"webpack-dismiss-btn\\" aria-label=\\"Dismiss\\">×</button>
     <div>
-      <div
-        style=\\"
-          background-color: rgba(206, 17, 38, 0.1);
-          color: rgb(252, 207, 207);
-          padding: 1rem 1rem 1.5rem;
-        \\"
-      >
-        <div
-          style=\\"
-            color: rgb(232, 59, 70);
-            font-size: 1.2em;
-            margin-bottom: 1rem;
-            font-family: sans-serif;
-          \\"
-        >
-          ERROR
-        </div>
-        <div
-          style=\\"
-            line-height: 1.5;
-            font-size: 1rem;
-            font-family: Menlo, Consolas, monospace;
-          \\"
-        >
+      <div class=\\"webpack-error-msg\\">
+        <div class=\\"webpack-msg-type\\">ERROR</div>
+        <div class=\\"webpack-msg-text\\">
           Async error at &lt;anonymous&gt;:3:26
         </div>
       </div>
@@ -2222,79 +839,13 @@ exports[`overlay should show error for uncaught promise rejection: overlay html 
 
 exports[`overlay should show error for uncaught runtime error: overlay html 1`] = `
 "<body>
-  <div
-    id=\\"webpack-dev-server-client-overlay-div\\"
-    style=\\"
-      position: fixed;
-      box-sizing: border-box;
-      inset: 0px;
-      width: 100vw;
-      height: 100vh;
-      font-size: large;
-      padding: 2rem 2rem 4rem;
-      line-height: 1.2;
-      white-space: pre-wrap;
-      overflow: auto;
-      background-color: rgba(0, 0, 0, 0.9);
-      color: white;
-    \\"
-  >
-    <div
-      style=\\"
-        color: rgb(232, 59, 70);
-        font-size: 2em;
-        white-space: pre-wrap;
-        font-family: sans-serif;
-        margin: 0px 2rem 2rem 0px;
-        flex: 0 0 auto;
-        max-height: 50%;
-        overflow: auto;
-      \\"
-    >
-      Uncaught runtime errors:
-    </div>
-    <button
-      aria-label=\\"Dismiss\\"
-      style=\\"
-        color: rgb(255, 255, 255);
-        line-height: 1rem;
-        font-size: 1.5rem;
-        padding: 1rem;
-        cursor: pointer;
-        position: absolute;
-        right: 0px;
-        top: 0px;
-        background-color: transparent;
-        border: none;
-      \\"
-    >
-      ×
-    </button>
+  <div id=\\"webpack-dev-server-client-overlay-div\\" class=\\"webpack-container\\">
+    <div class=\\"webpack-header\\">Uncaught runtime errors:</div>
+    <button class=\\"webpack-dismiss-btn\\" aria-label=\\"Dismiss\\">×</button>
     <div>
-      <div
-        style=\\"
-          background-color: rgba(206, 17, 38, 0.1);
-          color: rgb(252, 207, 207);
-          padding: 1rem 1rem 1.5rem;
-        \\"
-      >
-        <div
-          style=\\"
-            color: rgb(232, 59, 70);
-            font-size: 1.2em;
-            margin-bottom: 1rem;
-            font-family: sans-serif;
-          \\"
-        >
-          ERROR
-        </div>
-        <div
-          style=\\"
-            line-height: 1.5;
-            font-size: 1rem;
-            font-family: Menlo, Consolas, monospace;
-          \\"
-        >
+      <div class=\\"webpack-error-msg\\">
+        <div class=\\"webpack-msg-type\\">ERROR</div>
+        <div class=\\"webpack-msg-text\\">
           Injected error at throwError (&lt;anonymous&gt;:2:15) at
           &lt;anonymous&gt;:3:9 at addScriptContent
           (__puppeteer_evaluation_script__:9:27)
@@ -2308,81 +859,13 @@ exports[`overlay should show error for uncaught runtime error: overlay html 1`] 
 
 exports[`overlay should show error when it is not filtered: overlay html 1`] = `
 "<body>
-  <div
-    id=\\"webpack-dev-server-client-overlay-div\\"
-    style=\\"
-      position: fixed;
-      box-sizing: border-box;
-      inset: 0px;
-      width: 100vw;
-      height: 100vh;
-      font-size: large;
-      padding: 2rem 2rem 4rem;
-      line-height: 1.2;
-      white-space: pre-wrap;
-      overflow: auto;
-      background-color: rgba(0, 0, 0, 0.9);
-      color: white;
-    \\"
-  >
-    <div
-      style=\\"
-        color: rgb(232, 59, 70);
-        font-size: 2em;
-        white-space: pre-wrap;
-        font-family: sans-serif;
-        margin: 0px 2rem 2rem 0px;
-        flex: 0 0 auto;
-        max-height: 50%;
-        overflow: auto;
-      \\"
-    >
-      Compiled with problems:
-    </div>
-    <button
-      aria-label=\\"Dismiss\\"
-      style=\\"
-        color: rgb(255, 255, 255);
-        line-height: 1rem;
-        font-size: 1.5rem;
-        padding: 1rem;
-        cursor: pointer;
-        position: absolute;
-        right: 0px;
-        top: 0px;
-        background-color: transparent;
-        border: none;
-      \\"
-    >
-      ×
-    </button>
+  <div id=\\"webpack-dev-server-client-overlay-div\\" class=\\"webpack-container\\">
+    <div class=\\"webpack-header\\">Compiled with problems:</div>
+    <button class=\\"webpack-dismiss-btn\\" aria-label=\\"Dismiss\\">×</button>
     <div>
-      <div
-        style=\\"
-          background-color: rgba(206, 17, 38, 0.1);
-          color: rgb(252, 207, 207);
-          padding: 1rem 1rem 1.5rem;
-        \\"
-      >
-        <div
-          style=\\"
-            color: rgb(232, 59, 70);
-            font-size: 1.2em;
-            margin-bottom: 1rem;
-            font-family: sans-serif;
-          \\"
-        >
-          ERROR
-        </div>
-        <div
-          style=\\"
-            line-height: 1.5;
-            font-size: 1rem;
-            font-family: Menlo, Consolas, monospace;
-          \\"
-        >
-          Unfiltered error
-        </div>
+      <div class=\\"webpack-error-msg\\">
+        <div class=\\"webpack-msg-type\\">ERROR</div>
+        <div class=\\"webpack-msg-text\\">Unfiltered error</div>
       </div>
     </div>
   </div>
@@ -2413,81 +896,13 @@ exports[`overlay should show error when it is not filtered: page html 1`] = `
 
 exports[`overlay should show warning when it is not filtered: overlay html 1`] = `
 "<body>
-  <div
-    id=\\"webpack-dev-server-client-overlay-div\\"
-    style=\\"
-      position: fixed;
-      box-sizing: border-box;
-      inset: 0px;
-      width: 100vw;
-      height: 100vh;
-      font-size: large;
-      padding: 2rem 2rem 4rem;
-      line-height: 1.2;
-      white-space: pre-wrap;
-      overflow: auto;
-      background-color: rgba(0, 0, 0, 0.9);
-      color: white;
-    \\"
-  >
-    <div
-      style=\\"
-        color: rgb(232, 59, 70);
-        font-size: 2em;
-        white-space: pre-wrap;
-        font-family: sans-serif;
-        margin: 0px 2rem 2rem 0px;
-        flex: 0 0 auto;
-        max-height: 50%;
-        overflow: auto;
-      \\"
-    >
-      Compiled with problems:
-    </div>
-    <button
-      aria-label=\\"Dismiss\\"
-      style=\\"
-        color: rgb(255, 255, 255);
-        line-height: 1rem;
-        font-size: 1.5rem;
-        padding: 1rem;
-        cursor: pointer;
-        position: absolute;
-        right: 0px;
-        top: 0px;
-        background-color: transparent;
-        border: none;
-      \\"
-    >
-      ×
-    </button>
+  <div id=\\"webpack-dev-server-client-overlay-div\\" class=\\"webpack-container\\">
+    <div class=\\"webpack-header\\">Compiled with problems:</div>
+    <button class=\\"webpack-dismiss-btn\\" aria-label=\\"Dismiss\\">×</button>
     <div>
-      <div
-        style=\\"
-          background-color: rgba(251, 245, 180, 0.1);
-          color: rgb(251, 245, 180);
-          padding: 1rem 1rem 1.5rem;
-        \\"
-      >
-        <div
-          style=\\"
-            color: rgb(232, 59, 70);
-            font-size: 1.2em;
-            margin-bottom: 1rem;
-            font-family: sans-serif;
-          \\"
-        >
-          WARNING
-        </div>
-        <div
-          style=\\"
-            line-height: 1.5;
-            font-size: 1rem;
-            font-family: Menlo, Consolas, monospace;
-          \\"
-        >
-          Unfiltered warning
-        </div>
+      <div class=\\"webpack-warning-msg\\">
+        <div class=\\"webpack-msg-type\\">WARNING</div>
+        <div class=\\"webpack-msg-text\\">Unfiltered warning</div>
       </div>
     </div>
   </div>

--- a/test/e2e/__snapshots__/overlay.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/overlay.test.js.snap.webpack5
@@ -34,81 +34,15 @@ exports[`overlay should not show an error when "client.overlay.errors" is "false
 
 exports[`overlay should not show initially, then show on an error and allow to close: overlay html 1`] = `
 "<body>
-  <div
-    id=\\"webpack-dev-server-client-overlay-div\\"
-    style=\\"
-      position: fixed;
-      box-sizing: border-box;
-      inset: 0px;
-      width: 100vw;
-      height: 100vh;
-      font-size: large;
-      padding: 2rem 2rem 4rem;
-      line-height: 1.2;
-      white-space: pre-wrap;
-      overflow: auto;
-      background-color: rgba(0, 0, 0, 0.9);
-      color: white;
-    \\"
-  >
-    <div
-      style=\\"
-        color: rgb(232, 59, 70);
-        font-size: 2em;
-        white-space: pre-wrap;
-        font-family: sans-serif;
-        margin: 0px 2rem 2rem 0px;
-        flex: 0 0 auto;
-        max-height: 50%;
-        overflow: auto;
-      \\"
-    >
-      Compiled with problems:
-    </div>
-    <button
-      aria-label=\\"Dismiss\\"
-      style=\\"
-        color: rgb(255, 255, 255);
-        line-height: 1rem;
-        font-size: 1.5rem;
-        padding: 1rem;
-        cursor: pointer;
-        position: absolute;
-        right: 0px;
-        top: 0px;
-        background-color: transparent;
-        border: none;
-      \\"
-    >
-      ×
-    </button>
+  <div id=\\"webpack-dev-server-client-overlay-div\\" class=\\"webpack-container\\">
+    <div class=\\"webpack-header\\">Compiled with problems:</div>
+    <button class=\\"webpack-dismiss-btn\\" aria-label=\\"Dismiss\\">×</button>
     <div>
-      <div
-        style=\\"
-          background-color: rgba(206, 17, 38, 0.1);
-          color: rgb(252, 207, 207);
-          padding: 1rem 1rem 1.5rem;
-        \\"
-      >
-        <div
-          data-can-open=\\"true\\"
-          style=\\"
-            color: rgb(232, 59, 70);
-            font-size: 1.2em;
-            margin-bottom: 1rem;
-            font-family: sans-serif;
-            cursor: pointer;
-          \\"
-        >
+      <div class=\\"webpack-error-msg\\">
+        <div class=\\"webpack-msg-type\\" data-can-open=\\"true\\">
           ERROR in ./foo.js 1:1
         </div>
-        <div
-          style=\\"
-            line-height: 1.5;
-            font-size: 1rem;
-            font-family: Menlo, Consolas, monospace;
-          \\"
-        >
+        <div class=\\"webpack-msg-text\\">
           Module parse failed: Unterminated template (1:1) You may need an
           appropriate loader to handle this file type, currently no loaders are
           configured to process this file. See
@@ -160,81 +94,15 @@ exports[`overlay should not show initially, then show on an error and allow to c
 
 exports[`overlay should not show initially, then show on an error, then hide on fix: overlay html 1`] = `
 "<body>
-  <div
-    id=\\"webpack-dev-server-client-overlay-div\\"
-    style=\\"
-      position: fixed;
-      box-sizing: border-box;
-      inset: 0px;
-      width: 100vw;
-      height: 100vh;
-      font-size: large;
-      padding: 2rem 2rem 4rem;
-      line-height: 1.2;
-      white-space: pre-wrap;
-      overflow: auto;
-      background-color: rgba(0, 0, 0, 0.9);
-      color: white;
-    \\"
-  >
-    <div
-      style=\\"
-        color: rgb(232, 59, 70);
-        font-size: 2em;
-        white-space: pre-wrap;
-        font-family: sans-serif;
-        margin: 0px 2rem 2rem 0px;
-        flex: 0 0 auto;
-        max-height: 50%;
-        overflow: auto;
-      \\"
-    >
-      Compiled with problems:
-    </div>
-    <button
-      aria-label=\\"Dismiss\\"
-      style=\\"
-        color: rgb(255, 255, 255);
-        line-height: 1rem;
-        font-size: 1.5rem;
-        padding: 1rem;
-        cursor: pointer;
-        position: absolute;
-        right: 0px;
-        top: 0px;
-        background-color: transparent;
-        border: none;
-      \\"
-    >
-      ×
-    </button>
+  <div id=\\"webpack-dev-server-client-overlay-div\\" class=\\"webpack-container\\">
+    <div class=\\"webpack-header\\">Compiled with problems:</div>
+    <button class=\\"webpack-dismiss-btn\\" aria-label=\\"Dismiss\\">×</button>
     <div>
-      <div
-        style=\\"
-          background-color: rgba(206, 17, 38, 0.1);
-          color: rgb(252, 207, 207);
-          padding: 1rem 1rem 1.5rem;
-        \\"
-      >
-        <div
-          data-can-open=\\"true\\"
-          style=\\"
-            color: rgb(232, 59, 70);
-            font-size: 1.2em;
-            margin-bottom: 1rem;
-            font-family: sans-serif;
-            cursor: pointer;
-          \\"
-        >
+      <div class=\\"webpack-error-msg\\">
+        <div class=\\"webpack-msg-type\\" data-can-open=\\"true\\">
           ERROR in ./foo.js 1:1
         </div>
-        <div
-          style=\\"
-            line-height: 1.5;
-            font-size: 1rem;
-            font-family: Menlo, Consolas, monospace;
-          \\"
-        >
+        <div class=\\"webpack-msg-text\\">
           Module parse failed: Unterminated template (1:1) You may need an
           appropriate loader to handle this file type, currently no loaders are
           configured to process this file. See
@@ -286,81 +154,15 @@ exports[`overlay should not show initially, then show on an error, then hide on 
 
 exports[`overlay should not show initially, then show on an error, then show other error, then hide on fix: overlay html 1`] = `
 "<body>
-  <div
-    id=\\"webpack-dev-server-client-overlay-div\\"
-    style=\\"
-      position: fixed;
-      box-sizing: border-box;
-      inset: 0px;
-      width: 100vw;
-      height: 100vh;
-      font-size: large;
-      padding: 2rem 2rem 4rem;
-      line-height: 1.2;
-      white-space: pre-wrap;
-      overflow: auto;
-      background-color: rgba(0, 0, 0, 0.9);
-      color: white;
-    \\"
-  >
-    <div
-      style=\\"
-        color: rgb(232, 59, 70);
-        font-size: 2em;
-        white-space: pre-wrap;
-        font-family: sans-serif;
-        margin: 0px 2rem 2rem 0px;
-        flex: 0 0 auto;
-        max-height: 50%;
-        overflow: auto;
-      \\"
-    >
-      Compiled with problems:
-    </div>
-    <button
-      aria-label=\\"Dismiss\\"
-      style=\\"
-        color: rgb(255, 255, 255);
-        line-height: 1rem;
-        font-size: 1.5rem;
-        padding: 1rem;
-        cursor: pointer;
-        position: absolute;
-        right: 0px;
-        top: 0px;
-        background-color: transparent;
-        border: none;
-      \\"
-    >
-      ×
-    </button>
+  <div id=\\"webpack-dev-server-client-overlay-div\\" class=\\"webpack-container\\">
+    <div class=\\"webpack-header\\">Compiled with problems:</div>
+    <button class=\\"webpack-dismiss-btn\\" aria-label=\\"Dismiss\\">×</button>
     <div>
-      <div
-        style=\\"
-          background-color: rgba(206, 17, 38, 0.1);
-          color: rgb(252, 207, 207);
-          padding: 1rem 1rem 1.5rem;
-        \\"
-      >
-        <div
-          data-can-open=\\"true\\"
-          style=\\"
-            color: rgb(232, 59, 70);
-            font-size: 1.2em;
-            margin-bottom: 1rem;
-            font-family: sans-serif;
-            cursor: pointer;
-          \\"
-        >
+      <div class=\\"webpack-error-msg\\">
+        <div class=\\"webpack-msg-type\\" data-can-open=\\"true\\">
           ERROR in ./foo.js 1:1
         </div>
-        <div
-          style=\\"
-            line-height: 1.5;
-            font-size: 1rem;
-            font-family: Menlo, Consolas, monospace;
-          \\"
-        >
+        <div class=\\"webpack-msg-text\\">
           Module parse failed: Unterminated template (1:1) You may need an
           appropriate loader to handle this file type, currently no loaders are
           configured to process this file. See
@@ -375,81 +177,15 @@ exports[`overlay should not show initially, then show on an error, then show oth
 
 exports[`overlay should not show initially, then show on an error, then show other error, then hide on fix: overlay html 2`] = `
 "<body>
-  <div
-    id=\\"webpack-dev-server-client-overlay-div\\"
-    style=\\"
-      position: fixed;
-      box-sizing: border-box;
-      inset: 0px;
-      width: 100vw;
-      height: 100vh;
-      font-size: large;
-      padding: 2rem 2rem 4rem;
-      line-height: 1.2;
-      white-space: pre-wrap;
-      overflow: auto;
-      background-color: rgba(0, 0, 0, 0.9);
-      color: white;
-    \\"
-  >
-    <div
-      style=\\"
-        color: rgb(232, 59, 70);
-        font-size: 2em;
-        white-space: pre-wrap;
-        font-family: sans-serif;
-        margin: 0px 2rem 2rem 0px;
-        flex: 0 0 auto;
-        max-height: 50%;
-        overflow: auto;
-      \\"
-    >
-      Compiled with problems:
-    </div>
-    <button
-      aria-label=\\"Dismiss\\"
-      style=\\"
-        color: rgb(255, 255, 255);
-        line-height: 1rem;
-        font-size: 1.5rem;
-        padding: 1rem;
-        cursor: pointer;
-        position: absolute;
-        right: 0px;
-        top: 0px;
-        background-color: transparent;
-        border: none;
-      \\"
-    >
-      ×
-    </button>
+  <div id=\\"webpack-dev-server-client-overlay-div\\" class=\\"webpack-container\\">
+    <div class=\\"webpack-header\\">Compiled with problems:</div>
+    <button class=\\"webpack-dismiss-btn\\" aria-label=\\"Dismiss\\">×</button>
     <div>
-      <div
-        style=\\"
-          background-color: rgba(206, 17, 38, 0.1);
-          color: rgb(252, 207, 207);
-          padding: 1rem 1rem 1.5rem;
-        \\"
-      >
-        <div
-          data-can-open=\\"true\\"
-          style=\\"
-            color: rgb(232, 59, 70);
-            font-size: 1.2em;
-            margin-bottom: 1rem;
-            font-family: sans-serif;
-            cursor: pointer;
-          \\"
-        >
+      <div class=\\"webpack-error-msg\\">
+        <div class=\\"webpack-msg-type\\" data-can-open=\\"true\\">
           ERROR in ./foo.js 1:1
         </div>
-        <div
-          style=\\"
-            line-height: 1.5;
-            font-size: 1rem;
-            font-family: Menlo, Consolas, monospace;
-          \\"
-        >
+        <div class=\\"webpack-msg-text\\">
           Module parse failed: Unterminated template (1:1) You may need an
           appropriate loader to handle this file type, currently no loaders are
           configured to process this file. See
@@ -530,81 +266,13 @@ exports[`overlay should not show overlay when Trusted Types are enabled, but pol
 
 exports[`overlay should show a warning after invalidation: overlay html 1`] = `
 "<body>
-  <div
-    id=\\"webpack-dev-server-client-overlay-div\\"
-    style=\\"
-      position: fixed;
-      box-sizing: border-box;
-      inset: 0px;
-      width: 100vw;
-      height: 100vh;
-      font-size: large;
-      padding: 2rem 2rem 4rem;
-      line-height: 1.2;
-      white-space: pre-wrap;
-      overflow: auto;
-      background-color: rgba(0, 0, 0, 0.9);
-      color: white;
-    \\"
-  >
-    <div
-      style=\\"
-        color: rgb(232, 59, 70);
-        font-size: 2em;
-        white-space: pre-wrap;
-        font-family: sans-serif;
-        margin: 0px 2rem 2rem 0px;
-        flex: 0 0 auto;
-        max-height: 50%;
-        overflow: auto;
-      \\"
-    >
-      Compiled with problems:
-    </div>
-    <button
-      aria-label=\\"Dismiss\\"
-      style=\\"
-        color: rgb(255, 255, 255);
-        line-height: 1rem;
-        font-size: 1.5rem;
-        padding: 1rem;
-        cursor: pointer;
-        position: absolute;
-        right: 0px;
-        top: 0px;
-        background-color: transparent;
-        border: none;
-      \\"
-    >
-      ×
-    </button>
+  <div id=\\"webpack-dev-server-client-overlay-div\\" class=\\"webpack-container\\">
+    <div class=\\"webpack-header\\">Compiled with problems:</div>
+    <button class=\\"webpack-dismiss-btn\\" aria-label=\\"Dismiss\\">×</button>
     <div>
-      <div
-        style=\\"
-          background-color: rgba(251, 245, 180, 0.1);
-          color: rgb(251, 245, 180);
-          padding: 1rem 1rem 1.5rem;
-        \\"
-      >
-        <div
-          style=\\"
-            color: rgb(232, 59, 70);
-            font-size: 1.2em;
-            margin-bottom: 1rem;
-            font-family: sans-serif;
-          \\"
-        >
-          WARNING
-        </div>
-        <div
-          style=\\"
-            line-height: 1.5;
-            font-size: 1rem;
-            font-family: Menlo, Consolas, monospace;
-          \\"
-        >
-          Warning from compilation
-        </div>
+      <div class=\\"webpack-warning-msg\\">
+        <div class=\\"webpack-msg-type\\">WARNING</div>
+        <div class=\\"webpack-msg-text\\">Warning from compilation</div>
       </div>
     </div>
   </div>
@@ -635,108 +303,17 @@ exports[`overlay should show a warning after invalidation: page html 1`] = `
 
 exports[`overlay should show a warning and error for initial compilation and protects against xss: overlay html 1`] = `
 "<body>
-  <div
-    id=\\"webpack-dev-server-client-overlay-div\\"
-    style=\\"
-      position: fixed;
-      box-sizing: border-box;
-      inset: 0px;
-      width: 100vw;
-      height: 100vh;
-      font-size: large;
-      padding: 2rem 2rem 4rem;
-      line-height: 1.2;
-      white-space: pre-wrap;
-      overflow: auto;
-      background-color: rgba(0, 0, 0, 0.9);
-      color: white;
-    \\"
-  >
-    <div
-      style=\\"
-        color: rgb(232, 59, 70);
-        font-size: 2em;
-        white-space: pre-wrap;
-        font-family: sans-serif;
-        margin: 0px 2rem 2rem 0px;
-        flex: 0 0 auto;
-        max-height: 50%;
-        overflow: auto;
-      \\"
-    >
-      Compiled with problems:
-    </div>
-    <button
-      aria-label=\\"Dismiss\\"
-      style=\\"
-        color: rgb(255, 255, 255);
-        line-height: 1rem;
-        font-size: 1.5rem;
-        padding: 1rem;
-        cursor: pointer;
-        position: absolute;
-        right: 0px;
-        top: 0px;
-        background-color: transparent;
-        border: none;
-      \\"
-    >
-      ×
-    </button>
+  <div id=\\"webpack-dev-server-client-overlay-div\\" class=\\"webpack-container\\">
+    <div class=\\"webpack-header\\">Compiled with problems:</div>
+    <button class=\\"webpack-dismiss-btn\\" aria-label=\\"Dismiss\\">×</button>
     <div>
-      <div
-        style=\\"
-          background-color: rgba(206, 17, 38, 0.1);
-          color: rgb(252, 207, 207);
-          padding: 1rem 1rem 1.5rem;
-        \\"
-      >
-        <div
-          style=\\"
-            color: rgb(232, 59, 70);
-            font-size: 1.2em;
-            margin-bottom: 1rem;
-            font-family: sans-serif;
-          \\"
-        >
-          ERROR
-        </div>
-        <div
-          style=\\"
-            line-height: 1.5;
-            font-size: 1rem;
-            font-family: Menlo, Consolas, monospace;
-          \\"
-        >
-          &lt;strong&gt;strong&lt;/strong&gt;
-        </div>
+      <div class=\\"webpack-error-msg\\">
+        <div class=\\"webpack-msg-type\\">ERROR</div>
+        <div class=\\"webpack-msg-text\\">&lt;strong&gt;strong&lt;/strong&gt;</div>
       </div>
-      <div
-        style=\\"
-          background-color: rgba(206, 17, 38, 0.1);
-          color: rgb(252, 207, 207);
-          padding: 1rem 1rem 1.5rem;
-        \\"
-      >
-        <div
-          style=\\"
-            color: rgb(232, 59, 70);
-            font-size: 1.2em;
-            margin-bottom: 1rem;
-            font-family: sans-serif;
-          \\"
-        >
-          ERROR
-        </div>
-        <div
-          style=\\"
-            line-height: 1.5;
-            font-size: 1rem;
-            font-family: Menlo, Consolas, monospace;
-          \\"
-        >
-          &lt;strong&gt;strong&lt;/strong&gt;
-        </div>
+      <div class=\\"webpack-error-msg\\">
+        <div class=\\"webpack-msg-type\\">ERROR</div>
+        <div class=\\"webpack-msg-text\\">&lt;strong&gt;strong&lt;/strong&gt;</div>
       </div>
     </div>
   </div>
@@ -767,187 +344,33 @@ exports[`overlay should show a warning and error for initial compilation and pro
 
 exports[`overlay should show a warning and error for initial compilation: overlay html 1`] = `
 "<body>
-  <div
-    id=\\"webpack-dev-server-client-overlay-div\\"
-    style=\\"
-      position: fixed;
-      box-sizing: border-box;
-      inset: 0px;
-      width: 100vw;
-      height: 100vh;
-      font-size: large;
-      padding: 2rem 2rem 4rem;
-      line-height: 1.2;
-      white-space: pre-wrap;
-      overflow: auto;
-      background-color: rgba(0, 0, 0, 0.9);
-      color: white;
-    \\"
-  >
-    <div
-      style=\\"
-        color: rgb(232, 59, 70);
-        font-size: 2em;
-        white-space: pre-wrap;
-        font-family: sans-serif;
-        margin: 0px 2rem 2rem 0px;
-        flex: 0 0 auto;
-        max-height: 50%;
-        overflow: auto;
-      \\"
-    >
-      Compiled with problems:
-    </div>
-    <button
-      aria-label=\\"Dismiss\\"
-      style=\\"
-        color: rgb(255, 255, 255);
-        line-height: 1rem;
-        font-size: 1.5rem;
-        padding: 1rem;
-        cursor: pointer;
-        position: absolute;
-        right: 0px;
-        top: 0px;
-        background-color: transparent;
-        border: none;
-      \\"
-    >
-      ×
-    </button>
+  <div id=\\"webpack-dev-server-client-overlay-div\\" class=\\"webpack-container\\">
+    <div class=\\"webpack-header\\">Compiled with problems:</div>
+    <button class=\\"webpack-dismiss-btn\\" aria-label=\\"Dismiss\\">×</button>
     <div>
-      <div
-        style=\\"
-          background-color: rgba(206, 17, 38, 0.1);
-          color: rgb(252, 207, 207);
-          padding: 1rem 1rem 1.5rem;
-        \\"
-      >
-        <div
-          style=\\"
-            color: rgb(232, 59, 70);
-            font-size: 1.2em;
-            margin-bottom: 1rem;
-            font-family: sans-serif;
-          \\"
-        >
-          ERROR
-        </div>
-        <div
-          style=\\"
-            line-height: 1.5;
-            font-size: 1rem;
-            font-family: Menlo, Consolas, monospace;
-          \\"
-        >
-          Warning from compilation
-        </div>
+      <div class=\\"webpack-error-msg\\">
+        <div class=\\"webpack-msg-type\\">ERROR</div>
+        <div class=\\"webpack-msg-text\\">Warning from compilation</div>
       </div>
-      <div
-        style=\\"
-          background-color: rgba(206, 17, 38, 0.1);
-          color: rgb(252, 207, 207);
-          padding: 1rem 1rem 1.5rem;
-        \\"
-      >
-        <div
-          style=\\"
-            color: rgb(232, 59, 70);
-            font-size: 1.2em;
-            margin-bottom: 1rem;
-            font-family: sans-serif;
-          \\"
-        >
-          ERROR
-        </div>
-        <div
-          style=\\"
-            line-height: 1.5;
-            font-size: 1rem;
-            font-family: Menlo, Consolas, monospace;
-          \\"
-        >
-          Warning from compilation
-        </div>
+      <div class=\\"webpack-error-msg\\">
+        <div class=\\"webpack-msg-type\\">ERROR</div>
+        <div class=\\"webpack-msg-text\\">Warning from compilation</div>
       </div>
-      <div
-        style=\\"
-          background-color: rgba(206, 17, 38, 0.1);
-          color: rgb(252, 207, 207);
-          padding: 1rem 1rem 1.5rem;
-        \\"
-      >
-        <div
-          style=\\"
-            color: rgb(232, 59, 70);
-            font-size: 1.2em;
-            margin-bottom: 1rem;
-            font-family: sans-serif;
-          \\"
-        >
-          ERROR
-        </div>
-        <div
-          style=\\"
-            line-height: 1.5;
-            font-size: 1rem;
-            font-family: Menlo, Consolas, monospace;
-          \\"
-        >
+      <div class=\\"webpack-error-msg\\">
+        <div class=\\"webpack-msg-type\\">ERROR</div>
+        <div class=\\"webpack-msg-text\\">
           Error from compilation. Can't find 'test' module.
         </div>
       </div>
-      <div
-        style=\\"
-          background-color: rgba(206, 17, 38, 0.1);
-          color: rgb(252, 207, 207);
-          padding: 1rem 1rem 1.5rem;
-        \\"
-      >
-        <div
-          style=\\"
-            color: rgb(232, 59, 70);
-            font-size: 1.2em;
-            margin-bottom: 1rem;
-            font-family: sans-serif;
-          \\"
-        >
-          ERROR
-        </div>
-        <div
-          style=\\"
-            line-height: 1.5;
-            font-size: 1rem;
-            font-family: Menlo, Consolas, monospace;
-          \\"
-        >
+      <div class=\\"webpack-error-msg\\">
+        <div class=\\"webpack-msg-type\\">ERROR</div>
+        <div class=\\"webpack-msg-text\\">
           Error from compilation. Can't find 'test' module.
         </div>
       </div>
-      <div
-        style=\\"
-          background-color: rgba(206, 17, 38, 0.1);
-          color: rgb(252, 207, 207);
-          padding: 1rem 1rem 1.5rem;
-        \\"
-      >
-        <div
-          style=\\"
-            color: rgb(232, 59, 70);
-            font-size: 1.2em;
-            margin-bottom: 1rem;
-            font-family: sans-serif;
-          \\"
-        >
-          ERROR
-        </div>
-        <div
-          style=\\"
-            line-height: 1.5;
-            font-size: 1rem;
-            font-family: Menlo, Consolas, monospace;
-          \\"
-        >
+      <div class=\\"webpack-error-msg\\">
+        <div class=\\"webpack-msg-type\\">ERROR</div>
+        <div class=\\"webpack-msg-text\\">
           Error from compilation. Can't find 'test' module.
         </div>
       </div>
@@ -980,81 +403,13 @@ exports[`overlay should show a warning and error for initial compilation: page h
 
 exports[`overlay should show a warning and hide them after closing connection: overlay html 1`] = `
 "<body>
-  <div
-    id=\\"webpack-dev-server-client-overlay-div\\"
-    style=\\"
-      position: fixed;
-      box-sizing: border-box;
-      inset: 0px;
-      width: 100vw;
-      height: 100vh;
-      font-size: large;
-      padding: 2rem 2rem 4rem;
-      line-height: 1.2;
-      white-space: pre-wrap;
-      overflow: auto;
-      background-color: rgba(0, 0, 0, 0.9);
-      color: white;
-    \\"
-  >
-    <div
-      style=\\"
-        color: rgb(232, 59, 70);
-        font-size: 2em;
-        white-space: pre-wrap;
-        font-family: sans-serif;
-        margin: 0px 2rem 2rem 0px;
-        flex: 0 0 auto;
-        max-height: 50%;
-        overflow: auto;
-      \\"
-    >
-      Compiled with problems:
-    </div>
-    <button
-      aria-label=\\"Dismiss\\"
-      style=\\"
-        color: rgb(255, 255, 255);
-        line-height: 1rem;
-        font-size: 1.5rem;
-        padding: 1rem;
-        cursor: pointer;
-        position: absolute;
-        right: 0px;
-        top: 0px;
-        background-color: transparent;
-        border: none;
-      \\"
-    >
-      ×
-    </button>
+  <div id=\\"webpack-dev-server-client-overlay-div\\" class=\\"webpack-container\\">
+    <div class=\\"webpack-header\\">Compiled with problems:</div>
+    <button class=\\"webpack-dismiss-btn\\" aria-label=\\"Dismiss\\">×</button>
     <div>
-      <div
-        style=\\"
-          background-color: rgba(251, 245, 180, 0.1);
-          color: rgb(251, 245, 180);
-          padding: 1rem 1rem 1.5rem;
-        \\"
-      >
-        <div
-          style=\\"
-            color: rgb(232, 59, 70);
-            font-size: 1.2em;
-            margin-bottom: 1rem;
-            font-family: sans-serif;
-          \\"
-        >
-          WARNING
-        </div>
-        <div
-          style=\\"
-            line-height: 1.5;
-            font-size: 1rem;
-            font-family: Menlo, Consolas, monospace;
-          \\"
-        >
-          Warning from compilation
-        </div>
+      <div class=\\"webpack-warning-msg\\">
+        <div class=\\"webpack-msg-type\\">WARNING</div>
+        <div class=\\"webpack-msg-text\\">Warning from compilation</div>
       </div>
     </div>
   </div>
@@ -1093,81 +448,13 @@ exports[`overlay should show a warning and hide them after closing connection: p
 
 exports[`overlay should show a warning for initial compilation: overlay html 1`] = `
 "<body>
-  <div
-    id=\\"webpack-dev-server-client-overlay-div\\"
-    style=\\"
-      position: fixed;
-      box-sizing: border-box;
-      inset: 0px;
-      width: 100vw;
-      height: 100vh;
-      font-size: large;
-      padding: 2rem 2rem 4rem;
-      line-height: 1.2;
-      white-space: pre-wrap;
-      overflow: auto;
-      background-color: rgba(0, 0, 0, 0.9);
-      color: white;
-    \\"
-  >
-    <div
-      style=\\"
-        color: rgb(232, 59, 70);
-        font-size: 2em;
-        white-space: pre-wrap;
-        font-family: sans-serif;
-        margin: 0px 2rem 2rem 0px;
-        flex: 0 0 auto;
-        max-height: 50%;
-        overflow: auto;
-      \\"
-    >
-      Compiled with problems:
-    </div>
-    <button
-      aria-label=\\"Dismiss\\"
-      style=\\"
-        color: rgb(255, 255, 255);
-        line-height: 1rem;
-        font-size: 1.5rem;
-        padding: 1rem;
-        cursor: pointer;
-        position: absolute;
-        right: 0px;
-        top: 0px;
-        background-color: transparent;
-        border: none;
-      \\"
-    >
-      ×
-    </button>
+  <div id=\\"webpack-dev-server-client-overlay-div\\" class=\\"webpack-container\\">
+    <div class=\\"webpack-header\\">Compiled with problems:</div>
+    <button class=\\"webpack-dismiss-btn\\" aria-label=\\"Dismiss\\">×</button>
     <div>
-      <div
-        style=\\"
-          background-color: rgba(251, 245, 180, 0.1);
-          color: rgb(251, 245, 180);
-          padding: 1rem 1rem 1.5rem;
-        \\"
-      >
-        <div
-          style=\\"
-            color: rgb(232, 59, 70);
-            font-size: 1.2em;
-            margin-bottom: 1rem;
-            font-family: sans-serif;
-          \\"
-        >
-          WARNING
-        </div>
-        <div
-          style=\\"
-            line-height: 1.5;
-            font-size: 1rem;
-            font-family: Menlo, Consolas, monospace;
-          \\"
-        >
-          Warning from compilation
-        </div>
+      <div class=\\"webpack-warning-msg\\">
+        <div class=\\"webpack-msg-type\\">WARNING</div>
+        <div class=\\"webpack-msg-text\\">Warning from compilation</div>
       </div>
     </div>
   </div>
@@ -1198,81 +485,13 @@ exports[`overlay should show a warning for initial compilation: page html 1`] = 
 
 exports[`overlay should show a warning when "client.overlay" is "true": overlay html 1`] = `
 "<body>
-  <div
-    id=\\"webpack-dev-server-client-overlay-div\\"
-    style=\\"
-      position: fixed;
-      box-sizing: border-box;
-      inset: 0px;
-      width: 100vw;
-      height: 100vh;
-      font-size: large;
-      padding: 2rem 2rem 4rem;
-      line-height: 1.2;
-      white-space: pre-wrap;
-      overflow: auto;
-      background-color: rgba(0, 0, 0, 0.9);
-      color: white;
-    \\"
-  >
-    <div
-      style=\\"
-        color: rgb(232, 59, 70);
-        font-size: 2em;
-        white-space: pre-wrap;
-        font-family: sans-serif;
-        margin: 0px 2rem 2rem 0px;
-        flex: 0 0 auto;
-        max-height: 50%;
-        overflow: auto;
-      \\"
-    >
-      Compiled with problems:
-    </div>
-    <button
-      aria-label=\\"Dismiss\\"
-      style=\\"
-        color: rgb(255, 255, 255);
-        line-height: 1rem;
-        font-size: 1.5rem;
-        padding: 1rem;
-        cursor: pointer;
-        position: absolute;
-        right: 0px;
-        top: 0px;
-        background-color: transparent;
-        border: none;
-      \\"
-    >
-      ×
-    </button>
+  <div id=\\"webpack-dev-server-client-overlay-div\\" class=\\"webpack-container\\">
+    <div class=\\"webpack-header\\">Compiled with problems:</div>
+    <button class=\\"webpack-dismiss-btn\\" aria-label=\\"Dismiss\\">×</button>
     <div>
-      <div
-        style=\\"
-          background-color: rgba(251, 245, 180, 0.1);
-          color: rgb(251, 245, 180);
-          padding: 1rem 1rem 1.5rem;
-        \\"
-      >
-        <div
-          style=\\"
-            color: rgb(232, 59, 70);
-            font-size: 1.2em;
-            margin-bottom: 1rem;
-            font-family: sans-serif;
-          \\"
-        >
-          WARNING
-        </div>
-        <div
-          style=\\"
-            line-height: 1.5;
-            font-size: 1rem;
-            font-family: Menlo, Consolas, monospace;
-          \\"
-        >
-          Warning from compilation
-        </div>
+      <div class=\\"webpack-warning-msg\\">
+        <div class=\\"webpack-msg-type\\">WARNING</div>
+        <div class=\\"webpack-msg-text\\">Warning from compilation</div>
       </div>
     </div>
   </div>
@@ -1303,81 +522,13 @@ exports[`overlay should show a warning when "client.overlay" is "true": page htm
 
 exports[`overlay should show a warning when "client.overlay.errors" is "true": overlay html 1`] = `
 "<body>
-  <div
-    id=\\"webpack-dev-server-client-overlay-div\\"
-    style=\\"
-      position: fixed;
-      box-sizing: border-box;
-      inset: 0px;
-      width: 100vw;
-      height: 100vh;
-      font-size: large;
-      padding: 2rem 2rem 4rem;
-      line-height: 1.2;
-      white-space: pre-wrap;
-      overflow: auto;
-      background-color: rgba(0, 0, 0, 0.9);
-      color: white;
-    \\"
-  >
-    <div
-      style=\\"
-        color: rgb(232, 59, 70);
-        font-size: 2em;
-        white-space: pre-wrap;
-        font-family: sans-serif;
-        margin: 0px 2rem 2rem 0px;
-        flex: 0 0 auto;
-        max-height: 50%;
-        overflow: auto;
-      \\"
-    >
-      Compiled with problems:
-    </div>
-    <button
-      aria-label=\\"Dismiss\\"
-      style=\\"
-        color: rgb(255, 255, 255);
-        line-height: 1rem;
-        font-size: 1.5rem;
-        padding: 1rem;
-        cursor: pointer;
-        position: absolute;
-        right: 0px;
-        top: 0px;
-        background-color: transparent;
-        border: none;
-      \\"
-    >
-      ×
-    </button>
+  <div id=\\"webpack-dev-server-client-overlay-div\\" class=\\"webpack-container\\">
+    <div class=\\"webpack-header\\">Compiled with problems:</div>
+    <button class=\\"webpack-dismiss-btn\\" aria-label=\\"Dismiss\\">×</button>
     <div>
-      <div
-        style=\\"
-          background-color: rgba(251, 245, 180, 0.1);
-          color: rgb(251, 245, 180);
-          padding: 1rem 1rem 1.5rem;
-        \\"
-      >
-        <div
-          style=\\"
-            color: rgb(232, 59, 70);
-            font-size: 1.2em;
-            margin-bottom: 1rem;
-            font-family: sans-serif;
-          \\"
-        >
-          WARNING
-        </div>
-        <div
-          style=\\"
-            line-height: 1.5;
-            font-size: 1rem;
-            font-family: Menlo, Consolas, monospace;
-          \\"
-        >
-          Warning from compilation
-        </div>
+      <div class=\\"webpack-warning-msg\\">
+        <div class=\\"webpack-msg-type\\">WARNING</div>
+        <div class=\\"webpack-msg-text\\">Warning from compilation</div>
       </div>
     </div>
   </div>
@@ -1408,81 +559,13 @@ exports[`overlay should show a warning when "client.overlay.errors" is "true": p
 
 exports[`overlay should show a warning when "client.overlay.warnings" is "true": overlay html 1`] = `
 "<body>
-  <div
-    id=\\"webpack-dev-server-client-overlay-div\\"
-    style=\\"
-      position: fixed;
-      box-sizing: border-box;
-      inset: 0px;
-      width: 100vw;
-      height: 100vh;
-      font-size: large;
-      padding: 2rem 2rem 4rem;
-      line-height: 1.2;
-      white-space: pre-wrap;
-      overflow: auto;
-      background-color: rgba(0, 0, 0, 0.9);
-      color: white;
-    \\"
-  >
-    <div
-      style=\\"
-        color: rgb(232, 59, 70);
-        font-size: 2em;
-        white-space: pre-wrap;
-        font-family: sans-serif;
-        margin: 0px 2rem 2rem 0px;
-        flex: 0 0 auto;
-        max-height: 50%;
-        overflow: auto;
-      \\"
-    >
-      Compiled with problems:
-    </div>
-    <button
-      aria-label=\\"Dismiss\\"
-      style=\\"
-        color: rgb(255, 255, 255);
-        line-height: 1rem;
-        font-size: 1.5rem;
-        padding: 1rem;
-        cursor: pointer;
-        position: absolute;
-        right: 0px;
-        top: 0px;
-        background-color: transparent;
-        border: none;
-      \\"
-    >
-      ×
-    </button>
+  <div id=\\"webpack-dev-server-client-overlay-div\\" class=\\"webpack-container\\">
+    <div class=\\"webpack-header\\">Compiled with problems:</div>
+    <button class=\\"webpack-dismiss-btn\\" aria-label=\\"Dismiss\\">×</button>
     <div>
-      <div
-        style=\\"
-          background-color: rgba(251, 245, 180, 0.1);
-          color: rgb(251, 245, 180);
-          padding: 1rem 1rem 1.5rem;
-        \\"
-      >
-        <div
-          style=\\"
-            color: rgb(232, 59, 70);
-            font-size: 1.2em;
-            margin-bottom: 1rem;
-            font-family: sans-serif;
-          \\"
-        >
-          WARNING
-        </div>
-        <div
-          style=\\"
-            line-height: 1.5;
-            font-size: 1rem;
-            font-family: Menlo, Consolas, monospace;
-          \\"
-        >
-          Warning from compilation
-        </div>
+      <div class=\\"webpack-warning-msg\\">
+        <div class=\\"webpack-msg-type\\">WARNING</div>
+        <div class=\\"webpack-msg-text\\">Warning from compilation</div>
       </div>
     </div>
   </div>
@@ -1513,79 +596,13 @@ exports[`overlay should show a warning when "client.overlay.warnings" is "true":
 
 exports[`overlay should show an ansi formatted error for initial compilation: overlay html 1`] = `
 "<body>
-  <div
-    id=\\"webpack-dev-server-client-overlay-div\\"
-    style=\\"
-      position: fixed;
-      box-sizing: border-box;
-      inset: 0px;
-      width: 100vw;
-      height: 100vh;
-      font-size: large;
-      padding: 2rem 2rem 4rem;
-      line-height: 1.2;
-      white-space: pre-wrap;
-      overflow: auto;
-      background-color: rgba(0, 0, 0, 0.9);
-      color: white;
-    \\"
-  >
-    <div
-      style=\\"
-        color: rgb(232, 59, 70);
-        font-size: 2em;
-        white-space: pre-wrap;
-        font-family: sans-serif;
-        margin: 0px 2rem 2rem 0px;
-        flex: 0 0 auto;
-        max-height: 50%;
-        overflow: auto;
-      \\"
-    >
-      Compiled with problems:
-    </div>
-    <button
-      aria-label=\\"Dismiss\\"
-      style=\\"
-        color: rgb(255, 255, 255);
-        line-height: 1rem;
-        font-size: 1.5rem;
-        padding: 1rem;
-        cursor: pointer;
-        position: absolute;
-        right: 0px;
-        top: 0px;
-        background-color: transparent;
-        border: none;
-      \\"
-    >
-      ×
-    </button>
+  <div id=\\"webpack-dev-server-client-overlay-div\\" class=\\"webpack-container\\">
+    <div class=\\"webpack-header\\">Compiled with problems:</div>
+    <button class=\\"webpack-dismiss-btn\\" aria-label=\\"Dismiss\\">×</button>
     <div>
-      <div
-        style=\\"
-          background-color: rgba(206, 17, 38, 0.1);
-          color: rgb(252, 207, 207);
-          padding: 1rem 1rem 1.5rem;
-        \\"
-      >
-        <div
-          style=\\"
-            color: rgb(232, 59, 70);
-            font-size: 1.2em;
-            margin-bottom: 1rem;
-            font-family: sans-serif;
-          \\"
-        >
-          ERROR
-        </div>
-        <div
-          style=\\"
-            line-height: 1.5;
-            font-size: 1rem;
-            font-family: Menlo, Consolas, monospace;
-          \\"
-        >
+      <div class=\\"webpack-error-msg\\">
+        <div class=\\"webpack-msg-type\\">ERROR</div>
+        <div class=\\"webpack-msg-text\\">
           <span
             style=\\"
               font-weight: normal;
@@ -1629,81 +646,13 @@ exports[`overlay should show an ansi formatted error for initial compilation: pa
 
 exports[`overlay should show an error after invalidation: overlay html 1`] = `
 "<body>
-  <div
-    id=\\"webpack-dev-server-client-overlay-div\\"
-    style=\\"
-      position: fixed;
-      box-sizing: border-box;
-      inset: 0px;
-      width: 100vw;
-      height: 100vh;
-      font-size: large;
-      padding: 2rem 2rem 4rem;
-      line-height: 1.2;
-      white-space: pre-wrap;
-      overflow: auto;
-      background-color: rgba(0, 0, 0, 0.9);
-      color: white;
-    \\"
-  >
-    <div
-      style=\\"
-        color: rgb(232, 59, 70);
-        font-size: 2em;
-        white-space: pre-wrap;
-        font-family: sans-serif;
-        margin: 0px 2rem 2rem 0px;
-        flex: 0 0 auto;
-        max-height: 50%;
-        overflow: auto;
-      \\"
-    >
-      Compiled with problems:
-    </div>
-    <button
-      aria-label=\\"Dismiss\\"
-      style=\\"
-        color: rgb(255, 255, 255);
-        line-height: 1rem;
-        font-size: 1.5rem;
-        padding: 1rem;
-        cursor: pointer;
-        position: absolute;
-        right: 0px;
-        top: 0px;
-        background-color: transparent;
-        border: none;
-      \\"
-    >
-      ×
-    </button>
+  <div id=\\"webpack-dev-server-client-overlay-div\\" class=\\"webpack-container\\">
+    <div class=\\"webpack-header\\">Compiled with problems:</div>
+    <button class=\\"webpack-dismiss-btn\\" aria-label=\\"Dismiss\\">×</button>
     <div>
-      <div
-        style=\\"
-          background-color: rgba(206, 17, 38, 0.1);
-          color: rgb(252, 207, 207);
-          padding: 1rem 1rem 1.5rem;
-        \\"
-      >
-        <div
-          style=\\"
-            color: rgb(232, 59, 70);
-            font-size: 1.2em;
-            margin-bottom: 1rem;
-            font-family: sans-serif;
-          \\"
-        >
-          ERROR
-        </div>
-        <div
-          style=\\"
-            line-height: 1.5;
-            font-size: 1rem;
-            font-family: Menlo, Consolas, monospace;
-          \\"
-        >
-          Error from compilation
-        </div>
+      <div class=\\"webpack-error-msg\\">
+        <div class=\\"webpack-msg-type\\">ERROR</div>
+        <div class=\\"webpack-msg-text\\">Error from compilation</div>
       </div>
     </div>
   </div>
@@ -1734,79 +683,13 @@ exports[`overlay should show an error after invalidation: page html 1`] = `
 
 exports[`overlay should show an error for initial compilation: overlay html 1`] = `
 "<body>
-  <div
-    id=\\"webpack-dev-server-client-overlay-div\\"
-    style=\\"
-      position: fixed;
-      box-sizing: border-box;
-      inset: 0px;
-      width: 100vw;
-      height: 100vh;
-      font-size: large;
-      padding: 2rem 2rem 4rem;
-      line-height: 1.2;
-      white-space: pre-wrap;
-      overflow: auto;
-      background-color: rgba(0, 0, 0, 0.9);
-      color: white;
-    \\"
-  >
-    <div
-      style=\\"
-        color: rgb(232, 59, 70);
-        font-size: 2em;
-        white-space: pre-wrap;
-        font-family: sans-serif;
-        margin: 0px 2rem 2rem 0px;
-        flex: 0 0 auto;
-        max-height: 50%;
-        overflow: auto;
-      \\"
-    >
-      Compiled with problems:
-    </div>
-    <button
-      aria-label=\\"Dismiss\\"
-      style=\\"
-        color: rgb(255, 255, 255);
-        line-height: 1rem;
-        font-size: 1.5rem;
-        padding: 1rem;
-        cursor: pointer;
-        position: absolute;
-        right: 0px;
-        top: 0px;
-        background-color: transparent;
-        border: none;
-      \\"
-    >
-      ×
-    </button>
+  <div id=\\"webpack-dev-server-client-overlay-div\\" class=\\"webpack-container\\">
+    <div class=\\"webpack-header\\">Compiled with problems:</div>
+    <button class=\\"webpack-dismiss-btn\\" aria-label=\\"Dismiss\\">×</button>
     <div>
-      <div
-        style=\\"
-          background-color: rgba(206, 17, 38, 0.1);
-          color: rgb(252, 207, 207);
-          padding: 1rem 1rem 1.5rem;
-        \\"
-      >
-        <div
-          style=\\"
-            color: rgb(232, 59, 70);
-            font-size: 1.2em;
-            margin-bottom: 1rem;
-            font-family: sans-serif;
-          \\"
-        >
-          ERROR
-        </div>
-        <div
-          style=\\"
-            line-height: 1.5;
-            font-size: 1rem;
-            font-family: Menlo, Consolas, monospace;
-          \\"
-        >
+      <div class=\\"webpack-error-msg\\">
+        <div class=\\"webpack-msg-type\\">ERROR</div>
+        <div class=\\"webpack-msg-text\\">
           Error from compilation. Can't find 'test' module.
         </div>
       </div>
@@ -1839,79 +722,13 @@ exports[`overlay should show an error for initial compilation: page html 1`] = `
 
 exports[`overlay should show an error when "client.overlay" is "true": overlay html 1`] = `
 "<body>
-  <div
-    id=\\"webpack-dev-server-client-overlay-div\\"
-    style=\\"
-      position: fixed;
-      box-sizing: border-box;
-      inset: 0px;
-      width: 100vw;
-      height: 100vh;
-      font-size: large;
-      padding: 2rem 2rem 4rem;
-      line-height: 1.2;
-      white-space: pre-wrap;
-      overflow: auto;
-      background-color: rgba(0, 0, 0, 0.9);
-      color: white;
-    \\"
-  >
-    <div
-      style=\\"
-        color: rgb(232, 59, 70);
-        font-size: 2em;
-        white-space: pre-wrap;
-        font-family: sans-serif;
-        margin: 0px 2rem 2rem 0px;
-        flex: 0 0 auto;
-        max-height: 50%;
-        overflow: auto;
-      \\"
-    >
-      Compiled with problems:
-    </div>
-    <button
-      aria-label=\\"Dismiss\\"
-      style=\\"
-        color: rgb(255, 255, 255);
-        line-height: 1rem;
-        font-size: 1.5rem;
-        padding: 1rem;
-        cursor: pointer;
-        position: absolute;
-        right: 0px;
-        top: 0px;
-        background-color: transparent;
-        border: none;
-      \\"
-    >
-      ×
-    </button>
+  <div id=\\"webpack-dev-server-client-overlay-div\\" class=\\"webpack-container\\">
+    <div class=\\"webpack-header\\">Compiled with problems:</div>
+    <button class=\\"webpack-dismiss-btn\\" aria-label=\\"Dismiss\\">×</button>
     <div>
-      <div
-        style=\\"
-          background-color: rgba(206, 17, 38, 0.1);
-          color: rgb(252, 207, 207);
-          padding: 1rem 1rem 1.5rem;
-        \\"
-      >
-        <div
-          style=\\"
-            color: rgb(232, 59, 70);
-            font-size: 1.2em;
-            margin-bottom: 1rem;
-            font-family: sans-serif;
-          \\"
-        >
-          ERROR
-        </div>
-        <div
-          style=\\"
-            line-height: 1.5;
-            font-size: 1rem;
-            font-family: Menlo, Consolas, monospace;
-          \\"
-        >
+      <div class=\\"webpack-error-msg\\">
+        <div class=\\"webpack-msg-type\\">ERROR</div>
+        <div class=\\"webpack-msg-text\\">
           Error from compilation. Can't find 'test' module.
         </div>
       </div>
@@ -1944,79 +761,13 @@ exports[`overlay should show an error when "client.overlay" is "true": page html
 
 exports[`overlay should show an error when "client.overlay.errors" is "true": overlay html 1`] = `
 "<body>
-  <div
-    id=\\"webpack-dev-server-client-overlay-div\\"
-    style=\\"
-      position: fixed;
-      box-sizing: border-box;
-      inset: 0px;
-      width: 100vw;
-      height: 100vh;
-      font-size: large;
-      padding: 2rem 2rem 4rem;
-      line-height: 1.2;
-      white-space: pre-wrap;
-      overflow: auto;
-      background-color: rgba(0, 0, 0, 0.9);
-      color: white;
-    \\"
-  >
-    <div
-      style=\\"
-        color: rgb(232, 59, 70);
-        font-size: 2em;
-        white-space: pre-wrap;
-        font-family: sans-serif;
-        margin: 0px 2rem 2rem 0px;
-        flex: 0 0 auto;
-        max-height: 50%;
-        overflow: auto;
-      \\"
-    >
-      Compiled with problems:
-    </div>
-    <button
-      aria-label=\\"Dismiss\\"
-      style=\\"
-        color: rgb(255, 255, 255);
-        line-height: 1rem;
-        font-size: 1.5rem;
-        padding: 1rem;
-        cursor: pointer;
-        position: absolute;
-        right: 0px;
-        top: 0px;
-        background-color: transparent;
-        border: none;
-      \\"
-    >
-      ×
-    </button>
+  <div id=\\"webpack-dev-server-client-overlay-div\\" class=\\"webpack-container\\">
+    <div class=\\"webpack-header\\">Compiled with problems:</div>
+    <button class=\\"webpack-dismiss-btn\\" aria-label=\\"Dismiss\\">×</button>
     <div>
-      <div
-        style=\\"
-          background-color: rgba(206, 17, 38, 0.1);
-          color: rgb(252, 207, 207);
-          padding: 1rem 1rem 1.5rem;
-        \\"
-      >
-        <div
-          style=\\"
-            color: rgb(232, 59, 70);
-            font-size: 1.2em;
-            margin-bottom: 1rem;
-            font-family: sans-serif;
-          \\"
-        >
-          ERROR
-        </div>
-        <div
-          style=\\"
-            line-height: 1.5;
-            font-size: 1rem;
-            font-family: Menlo, Consolas, monospace;
-          \\"
-        >
+      <div class=\\"webpack-error-msg\\">
+        <div class=\\"webpack-msg-type\\">ERROR</div>
+        <div class=\\"webpack-msg-text\\">
           Error from compilation. Can't find 'test' module.
         </div>
       </div>
@@ -2049,81 +800,13 @@ exports[`overlay should show an error when "client.overlay.errors" is "true": pa
 
 exports[`overlay should show an error when "client.overlay.warnings" is "true": overlay html 1`] = `
 "<body>
-  <div
-    id=\\"webpack-dev-server-client-overlay-div\\"
-    style=\\"
-      position: fixed;
-      box-sizing: border-box;
-      inset: 0px;
-      width: 100vw;
-      height: 100vh;
-      font-size: large;
-      padding: 2rem 2rem 4rem;
-      line-height: 1.2;
-      white-space: pre-wrap;
-      overflow: auto;
-      background-color: rgba(0, 0, 0, 0.9);
-      color: white;
-    \\"
-  >
-    <div
-      style=\\"
-        color: rgb(232, 59, 70);
-        font-size: 2em;
-        white-space: pre-wrap;
-        font-family: sans-serif;
-        margin: 0px 2rem 2rem 0px;
-        flex: 0 0 auto;
-        max-height: 50%;
-        overflow: auto;
-      \\"
-    >
-      Compiled with problems:
-    </div>
-    <button
-      aria-label=\\"Dismiss\\"
-      style=\\"
-        color: rgb(255, 255, 255);
-        line-height: 1rem;
-        font-size: 1.5rem;
-        padding: 1rem;
-        cursor: pointer;
-        position: absolute;
-        right: 0px;
-        top: 0px;
-        background-color: transparent;
-        border: none;
-      \\"
-    >
-      ×
-    </button>
+  <div id=\\"webpack-dev-server-client-overlay-div\\" class=\\"webpack-container\\">
+    <div class=\\"webpack-header\\">Compiled with problems:</div>
+    <button class=\\"webpack-dismiss-btn\\" aria-label=\\"Dismiss\\">×</button>
     <div>
-      <div
-        style=\\"
-          background-color: rgba(251, 245, 180, 0.1);
-          color: rgb(251, 245, 180);
-          padding: 1rem 1rem 1.5rem;
-        \\"
-      >
-        <div
-          style=\\"
-            color: rgb(232, 59, 70);
-            font-size: 1.2em;
-            margin-bottom: 1rem;
-            font-family: sans-serif;
-          \\"
-        >
-          WARNING
-        </div>
-        <div
-          style=\\"
-            line-height: 1.5;
-            font-size: 1rem;
-            font-family: Menlo, Consolas, monospace;
-          \\"
-        >
-          Warning from compilation
-        </div>
+      <div class=\\"webpack-warning-msg\\">
+        <div class=\\"webpack-msg-type\\">WARNING</div>
+        <div class=\\"webpack-msg-text\\">Warning from compilation</div>
       </div>
     </div>
   </div>
@@ -2154,79 +837,13 @@ exports[`overlay should show an error when "client.overlay.warnings" is "true": 
 
 exports[`overlay should show error for uncaught promise rejection: overlay html 1`] = `
 "<body>
-  <div
-    id=\\"webpack-dev-server-client-overlay-div\\"
-    style=\\"
-      position: fixed;
-      box-sizing: border-box;
-      inset: 0px;
-      width: 100vw;
-      height: 100vh;
-      font-size: large;
-      padding: 2rem 2rem 4rem;
-      line-height: 1.2;
-      white-space: pre-wrap;
-      overflow: auto;
-      background-color: rgba(0, 0, 0, 0.9);
-      color: white;
-    \\"
-  >
-    <div
-      style=\\"
-        color: rgb(232, 59, 70);
-        font-size: 2em;
-        white-space: pre-wrap;
-        font-family: sans-serif;
-        margin: 0px 2rem 2rem 0px;
-        flex: 0 0 auto;
-        max-height: 50%;
-        overflow: auto;
-      \\"
-    >
-      Uncaught runtime errors:
-    </div>
-    <button
-      aria-label=\\"Dismiss\\"
-      style=\\"
-        color: rgb(255, 255, 255);
-        line-height: 1rem;
-        font-size: 1.5rem;
-        padding: 1rem;
-        cursor: pointer;
-        position: absolute;
-        right: 0px;
-        top: 0px;
-        background-color: transparent;
-        border: none;
-      \\"
-    >
-      ×
-    </button>
+  <div id=\\"webpack-dev-server-client-overlay-div\\" class=\\"webpack-container\\">
+    <div class=\\"webpack-header\\">Uncaught runtime errors:</div>
+    <button class=\\"webpack-dismiss-btn\\" aria-label=\\"Dismiss\\">×</button>
     <div>
-      <div
-        style=\\"
-          background-color: rgba(206, 17, 38, 0.1);
-          color: rgb(252, 207, 207);
-          padding: 1rem 1rem 1.5rem;
-        \\"
-      >
-        <div
-          style=\\"
-            color: rgb(232, 59, 70);
-            font-size: 1.2em;
-            margin-bottom: 1rem;
-            font-family: sans-serif;
-          \\"
-        >
-          ERROR
-        </div>
-        <div
-          style=\\"
-            line-height: 1.5;
-            font-size: 1rem;
-            font-family: Menlo, Consolas, monospace;
-          \\"
-        >
+      <div class=\\"webpack-error-msg\\">
+        <div class=\\"webpack-msg-type\\">ERROR</div>
+        <div class=\\"webpack-msg-text\\">
           Async error at &lt;anonymous&gt;:3:26
         </div>
       </div>
@@ -2238,79 +855,13 @@ exports[`overlay should show error for uncaught promise rejection: overlay html 
 
 exports[`overlay should show error for uncaught runtime error: overlay html 1`] = `
 "<body>
-  <div
-    id=\\"webpack-dev-server-client-overlay-div\\"
-    style=\\"
-      position: fixed;
-      box-sizing: border-box;
-      inset: 0px;
-      width: 100vw;
-      height: 100vh;
-      font-size: large;
-      padding: 2rem 2rem 4rem;
-      line-height: 1.2;
-      white-space: pre-wrap;
-      overflow: auto;
-      background-color: rgba(0, 0, 0, 0.9);
-      color: white;
-    \\"
-  >
-    <div
-      style=\\"
-        color: rgb(232, 59, 70);
-        font-size: 2em;
-        white-space: pre-wrap;
-        font-family: sans-serif;
-        margin: 0px 2rem 2rem 0px;
-        flex: 0 0 auto;
-        max-height: 50%;
-        overflow: auto;
-      \\"
-    >
-      Uncaught runtime errors:
-    </div>
-    <button
-      aria-label=\\"Dismiss\\"
-      style=\\"
-        color: rgb(255, 255, 255);
-        line-height: 1rem;
-        font-size: 1.5rem;
-        padding: 1rem;
-        cursor: pointer;
-        position: absolute;
-        right: 0px;
-        top: 0px;
-        background-color: transparent;
-        border: none;
-      \\"
-    >
-      ×
-    </button>
+  <div id=\\"webpack-dev-server-client-overlay-div\\" class=\\"webpack-container\\">
+    <div class=\\"webpack-header\\">Uncaught runtime errors:</div>
+    <button class=\\"webpack-dismiss-btn\\" aria-label=\\"Dismiss\\">×</button>
     <div>
-      <div
-        style=\\"
-          background-color: rgba(206, 17, 38, 0.1);
-          color: rgb(252, 207, 207);
-          padding: 1rem 1rem 1.5rem;
-        \\"
-      >
-        <div
-          style=\\"
-            color: rgb(232, 59, 70);
-            font-size: 1.2em;
-            margin-bottom: 1rem;
-            font-family: sans-serif;
-          \\"
-        >
-          ERROR
-        </div>
-        <div
-          style=\\"
-            line-height: 1.5;
-            font-size: 1rem;
-            font-family: Menlo, Consolas, monospace;
-          \\"
-        >
+      <div class=\\"webpack-error-msg\\">
+        <div class=\\"webpack-msg-type\\">ERROR</div>
+        <div class=\\"webpack-msg-text\\">
           Injected error at throwError (&lt;anonymous&gt;:2:15) at
           &lt;anonymous&gt;:3:9 at addScriptContent
           (__puppeteer_evaluation_script__:9:27)
@@ -2324,81 +875,13 @@ exports[`overlay should show error for uncaught runtime error: overlay html 1`] 
 
 exports[`overlay should show error when it is not filtered: overlay html 1`] = `
 "<body>
-  <div
-    id=\\"webpack-dev-server-client-overlay-div\\"
-    style=\\"
-      position: fixed;
-      box-sizing: border-box;
-      inset: 0px;
-      width: 100vw;
-      height: 100vh;
-      font-size: large;
-      padding: 2rem 2rem 4rem;
-      line-height: 1.2;
-      white-space: pre-wrap;
-      overflow: auto;
-      background-color: rgba(0, 0, 0, 0.9);
-      color: white;
-    \\"
-  >
-    <div
-      style=\\"
-        color: rgb(232, 59, 70);
-        font-size: 2em;
-        white-space: pre-wrap;
-        font-family: sans-serif;
-        margin: 0px 2rem 2rem 0px;
-        flex: 0 0 auto;
-        max-height: 50%;
-        overflow: auto;
-      \\"
-    >
-      Compiled with problems:
-    </div>
-    <button
-      aria-label=\\"Dismiss\\"
-      style=\\"
-        color: rgb(255, 255, 255);
-        line-height: 1rem;
-        font-size: 1.5rem;
-        padding: 1rem;
-        cursor: pointer;
-        position: absolute;
-        right: 0px;
-        top: 0px;
-        background-color: transparent;
-        border: none;
-      \\"
-    >
-      ×
-    </button>
+  <div id=\\"webpack-dev-server-client-overlay-div\\" class=\\"webpack-container\\">
+    <div class=\\"webpack-header\\">Compiled with problems:</div>
+    <button class=\\"webpack-dismiss-btn\\" aria-label=\\"Dismiss\\">×</button>
     <div>
-      <div
-        style=\\"
-          background-color: rgba(206, 17, 38, 0.1);
-          color: rgb(252, 207, 207);
-          padding: 1rem 1rem 1.5rem;
-        \\"
-      >
-        <div
-          style=\\"
-            color: rgb(232, 59, 70);
-            font-size: 1.2em;
-            margin-bottom: 1rem;
-            font-family: sans-serif;
-          \\"
-        >
-          ERROR
-        </div>
-        <div
-          style=\\"
-            line-height: 1.5;
-            font-size: 1rem;
-            font-family: Menlo, Consolas, monospace;
-          \\"
-        >
-          Unfiltered error
-        </div>
+      <div class=\\"webpack-error-msg\\">
+        <div class=\\"webpack-msg-type\\">ERROR</div>
+        <div class=\\"webpack-msg-text\\">Unfiltered error</div>
       </div>
     </div>
   </div>
@@ -2428,86 +911,7 @@ exports[`overlay should show error when it is not filtered: page html 1`] = `
 `;
 
 exports[`overlay should show overlay when Trusted Types are enabled: overlay html 1`] = `
-"<body>
-  <div
-    id=\\"webpack-dev-server-client-overlay-div\\"
-    style=\\"
-      position: fixed;
-      box-sizing: border-box;
-      inset: 0px;
-      width: 100vw;
-      height: 100vh;
-      font-size: large;
-      padding: 2rem 2rem 4rem;
-      line-height: 1.2;
-      white-space: pre-wrap;
-      overflow: auto;
-      background-color: rgba(0, 0, 0, 0.9);
-      color: white;
-    \\"
-  >
-    <div
-      style=\\"
-        color: rgb(232, 59, 70);
-        font-size: 2em;
-        white-space: pre-wrap;
-        font-family: sans-serif;
-        margin: 0px 2rem 2rem 0px;
-        flex: 0 0 auto;
-        max-height: 50%;
-        overflow: auto;
-      \\"
-    >
-      Compiled with problems:
-    </div>
-    <button
-      aria-label=\\"Dismiss\\"
-      style=\\"
-        color: rgb(255, 255, 255);
-        line-height: 1rem;
-        font-size: 1.5rem;
-        padding: 1rem;
-        cursor: pointer;
-        position: absolute;
-        right: 0px;
-        top: 0px;
-        background-color: transparent;
-        border: none;
-      \\"
-    >
-      ×
-    </button>
-    <div>
-      <div
-        style=\\"
-          background-color: rgba(206, 17, 38, 0.1);
-          color: rgb(252, 207, 207);
-          padding: 1rem 1rem 1.5rem;
-        \\"
-      >
-        <div
-          style=\\"
-            color: rgb(232, 59, 70);
-            font-size: 1.2em;
-            margin-bottom: 1rem;
-            font-family: sans-serif;
-          \\"
-        >
-          ERROR
-        </div>
-        <div
-          style=\\"
-            line-height: 1.5;
-            font-size: 1rem;
-            font-family: Menlo, Consolas, monospace;
-          \\"
-        >
-          Error from compilation. Can't find 'test' module.
-        </div>
-      </div>
-    </div>
-  </div>
-</body>
+"<body></body>
 "
 `;
 
@@ -2534,81 +938,13 @@ exports[`overlay should show overlay when Trusted Types are enabled: page html 1
 
 exports[`overlay should show warning when it is not filtered: overlay html 1`] = `
 "<body>
-  <div
-    id=\\"webpack-dev-server-client-overlay-div\\"
-    style=\\"
-      position: fixed;
-      box-sizing: border-box;
-      inset: 0px;
-      width: 100vw;
-      height: 100vh;
-      font-size: large;
-      padding: 2rem 2rem 4rem;
-      line-height: 1.2;
-      white-space: pre-wrap;
-      overflow: auto;
-      background-color: rgba(0, 0, 0, 0.9);
-      color: white;
-    \\"
-  >
-    <div
-      style=\\"
-        color: rgb(232, 59, 70);
-        font-size: 2em;
-        white-space: pre-wrap;
-        font-family: sans-serif;
-        margin: 0px 2rem 2rem 0px;
-        flex: 0 0 auto;
-        max-height: 50%;
-        overflow: auto;
-      \\"
-    >
-      Compiled with problems:
-    </div>
-    <button
-      aria-label=\\"Dismiss\\"
-      style=\\"
-        color: rgb(255, 255, 255);
-        line-height: 1rem;
-        font-size: 1.5rem;
-        padding: 1rem;
-        cursor: pointer;
-        position: absolute;
-        right: 0px;
-        top: 0px;
-        background-color: transparent;
-        border: none;
-      \\"
-    >
-      ×
-    </button>
+  <div id=\\"webpack-dev-server-client-overlay-div\\" class=\\"webpack-container\\">
+    <div class=\\"webpack-header\\">Compiled with problems:</div>
+    <button class=\\"webpack-dismiss-btn\\" aria-label=\\"Dismiss\\">×</button>
     <div>
-      <div
-        style=\\"
-          background-color: rgba(251, 245, 180, 0.1);
-          color: rgb(251, 245, 180);
-          padding: 1rem 1rem 1.5rem;
-        \\"
-      >
-        <div
-          style=\\"
-            color: rgb(232, 59, 70);
-            font-size: 1.2em;
-            margin-bottom: 1rem;
-            font-family: sans-serif;
-          \\"
-        >
-          WARNING
-        </div>
-        <div
-          style=\\"
-            line-height: 1.5;
-            font-size: 1rem;
-            font-family: Menlo, Consolas, monospace;
-          \\"
-        >
-          Unfiltered warning
-        </div>
+      <div class=\\"webpack-warning-msg\\">
+        <div class=\\"webpack-msg-type\\">WARNING</div>
+        <div class=\\"webpack-msg-text\\">Unfiltered warning</div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
- [ ] This is a **bugfix**
- [ ] This is a **feature**
- [x] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

N/A

### Motivation / Use-Case

This PR refactor styling for overlay from inline styles to CSS class, which provides the following benefits:

- unlocks more CSS features, such as pseudo-selectors
- make the snapshots more readable, as the snapshots would only show the markup instead of all the CSS styles

### Breaking Changes

N/A

### Additional Info

This is prepare for better overlay styling that I show in https://github.com/webpack/webpack-dev-server/issues/3689#issuecomment-1545920152