### PR TITLE
feat: remove caret in @types/ws package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@types/serve-index": "^1.9.1",
     "@types/serve-static": "^1.13.10",
     "@types/sockjs": "^0.3.33",
-    "@types/ws": "^8.5.1",
+    "@types/ws": "8.5.1",
     "ansi-html-community": "^0.0.8",
     "bonjour-service": "^1.0.11",
     "chokidar": "^3.5.3",


### PR DESCRIPTION

I have error with version 8.5.5

node_modules/@types/ws/index.d.ts(328,18): error TS2315: Type 'Server' is not generic.