### PR TITLE
feat: improve `static.serveIndex` defaults

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -864,13 +864,20 @@ class Server {
                 ? optionsForStatic.publicPath
                 : [optionsForStatic.publicPath]
               : def.publicPath,
-          // TODO: do merge in the next major release
           serveIndex:
+            // Check if 'serveIndex' property is defined in 'optionsForStatic'
+            // If 'serveIndex' is a boolean and true, use default 'serveIndex'
+            // If 'serveIndex' is an object, merge its properties with default 'serveIndex'
+            // If 'serveIndex' is neither a boolean true nor an object, use it as-is
+            // If 'serveIndex' is not defined in 'optionsForStatic', use default 'serveIndex'
             // eslint-disable-next-line no-nested-ternary
             typeof optionsForStatic.serveIndex !== "undefined"
-              ? typeof optionsForStatic.serveIndex === "boolean" &&
+              ? // eslint-disable-next-line no-nested-ternary
+                typeof optionsForStatic.serveIndex === "boolean" &&
                 optionsForStatic.serveIndex
                 ? def.serveIndex
+                : typeof optionsForStatic.serveIndex === "object"
+                ? { ...def.serveIndex, ...optionsForStatic.serveIndex }
                 : optionsForStatic.serveIndex
               : def.serveIndex,
           watch:

--- a/test/__snapshots__/normalize-options.test.js.snap.webpack5
+++ b/test/__snapshots__/normalize-options.test.js.snap.webpack5
@@ -2304,7 +2304,66 @@ exports[`normalize options static publicPath is an array 1`] = `
 }
 `;
 
-exports[`normalize options static serveIndex is an object 1`] = `
+exports[`normalize options static serveIndex is an object more options 1`] = `
+{
+  "allowedHosts": "auto",
+  "bonjour": false,
+  "client": {
+    "logging": "info",
+    "overlay": true,
+    "reconnect": 10,
+    "webSocketURL": {},
+  },
+  "compress": true,
+  "devMiddleware": {},
+  "historyApiFallback": false,
+  "host": undefined,
+  "hot": true,
+  "liveReload": true,
+  "open": [],
+  "port": "<auto>",
+  "server": {
+    "options": {},
+    "type": "http",
+  },
+  "setupExitSignals": true,
+  "static": [
+    {
+      "directory": "<cwd>/public",
+      "publicPath": [
+        "/",
+      ],
+      "serveIndex": {
+        "hidden": true,
+        "icons": true,
+        "stylesheet": "https://example.com/style.css",
+        "view": "details",
+      },
+      "staticOptions": {},
+      "watch": {
+        "alwaysStat": true,
+        "atomic": false,
+        "followSymlinks": false,
+        "ignoreInitial": true,
+        "ignorePermissionErrors": true,
+        "ignored": undefined,
+        "interval": undefined,
+        "persistent": true,
+        "usePolling": false,
+      },
+    },
+  ],
+  "watchFiles": [],
+  "webSocketServer": {
+    "options": {
+      "path": "/ws",
+    },
+    "type": "ws",
+  },
+}
+`;
+
+exports[`normalize options static serveIndex is an object with icons false 1`] = `
 {
   "allowedHosts": "auto",
   "bonjour": false,

--- a/test/normalize-options.test.js
+++ b/test/normalize-options.test.js
@@ -456,12 +456,25 @@ describe("normalize options", () => {
       },
     },
     {
-      title: "static serveIndex is an object",
+      title: "static serveIndex is an object with icons false",
       multiCompiler: false,
       options: {
         static: {
           serveIndex: {
             icons: false,
+          },
+        },
+      },
+    },
+    {
+      title: "static serveIndex is an object more options",
+      multiCompiler: false,
+      options: {
+        static: {
+          serveIndex: {
+            hidden: true,
+            stylesheet: "https://example.com/style.css",
+            view: "details",
           },
         },
       },


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [ ] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [x] This is a **metadata update**

### For Bugs and Features; did you add new tests?
Yes.
<!-- Please note that we won't approve your changes if you don't add tests. -->

### Motivation / Use-Case
Resolve TODO.

- Check if 'serveIndex' property is defined in 'optionsForStatic'
- If 'serveIndex' is a boolean and true, use default 'serveIndex'
-  If 'serveIndex' is an object, merge its properties with default 'serveIndex'
-  If 'serveIndex' is neither a boolean true nor an object, use it as-is
<!--
  What existing problem does the pull request solve?

  Please explain the motivation or use-case for making this change.
  If this Pull Request addresses an issue, please link to the issue.
-->

### Breaking Changes
Yes, updated defaults.
<!--
  If this PR introduces a breaking change, please describe the impact and a
  potential migration path for existing applications.
-->

### Additional Info
No.