### PR TITLE
fix: clean 'close' event listeners on socket server after generating new proxy config.

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -2295,6 +2295,10 @@ class Server {
 
             if (newProxyConfig !== proxyConfig) {
               proxyConfig = newProxyConfig;
+              const server = (req.socket ?? req.connection)?.server;
+              if (server) {
+                server.removeAllListeners('close');
+              }
               proxyMiddleware =
                 /** @type {RequestHandler} */
                 (getProxyMiddleware(proxyConfig));

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -2295,9 +2295,11 @@ class Server {
 
             if (newProxyConfig !== proxyConfig) {
               proxyConfig = newProxyConfig;
-              const server = (req.socket ?? req.connection)?.server;
+              const socket = req.socket != null ? req.socket : req.connection;
+              // @ts-ignore
+              const server = socket != null ? socket.server : null;
               if (server) {
-                server.removeAllListeners('close');
+                server.removeAllListeners("close");
               }
               proxyMiddleware =
                 /** @type {RequestHandler} */

--- a/test/server/proxy-option.test.js
+++ b/test/server/proxy-option.test.js
@@ -70,9 +70,16 @@ let maxServerListeners = 0;
 const proxyOptionOfArray = [
   { context: "/proxy1", target: proxyOption.target },
   function proxy(req, res, next) {
-    const server = (req?.socket ?? req?.connection)?.server;
-    if (server) {
-      maxServerListeners = Math.max(maxServerListeners, server.listeners('close').length)
+    if (req != null) {
+      const socket = req.socket != null ? req.socket : req.connection;
+      // @ts-ignore
+      const server = socket != null ? socket.server : null;
+      if (server) {
+        maxServerListeners = Math.max(
+          maxServerListeners,
+          server.listeners("close").length
+        );
+      }
     }
     return {
       context: "/api/proxy2",
@@ -445,7 +452,6 @@ describe("proxy option", () => {
     it("should not exist multiple close events registered", async () => {
       expect(maxServerListeners).toBeLessThanOrEqual(1);
     });
-    
   });
 
   describe("as an array without the `route` option", () => {


### PR DESCRIPTION
- [x] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

yes, test cases added.

### Motivation / Use-Case

when pass a function to proxy config. every time firing `handler` function, a new proxyServer were set, and events on old proxyServer has not been cleared.

### Breaking Changes

no

### Additional Info
