### PR TITLE
fix: add 'mode' property in second array object

### DIFF
--- a/examples/general/config-array/webpack.config.js
+++ b/examples/general/config-array/webpack.config.js
@@ -34,6 +34,7 @@ module.exports = [
     output: {
       filename: "bundle2.js",
     },
+    mode: "development",
     module: {
       rules: [
         {


### PR DESCRIPTION
Resolve issue in examples/general/config-array where absence of 'mode' property in second configuration object caused an error.

Fixes #5085

<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [x] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?
Not required

<!-- Please note that we won't approve your changes if you don't add tests. -->

### Motivation / Use-Case
I am new to Open Source and was testing the examples when I found that one of the examples (fixed in this PR) is not running and giving an error. I already have created an issue (#5085) for this PR.

<!--
  What existing problem does the pull request solve?

  Please explain the motivation or use-case for making this change.
  If this Pull Request addresses an issue, please link to the issue.
-->

### Breaking Changes
No breaking changes.
<!--
  If this PR introduces a breaking change, please describe the impact and a
  potential migration path for existing applications.
-->
