### PR TITLE
chore: upgrading express from version 4.17.3 to version 4.19.2 due to vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "compression": "^1.7.4",
         "connect-history-api-fallback": "^2.0.0",
         "default-gateway": "^6.0.3",
-        "express": "^4.17.3",
+        "express": "^4.19.2",
         "graceful-fs": "^4.2.6",
         "html-entities": "^2.4.0",
         "http-proxy-middleware": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "compression": "^1.7.4",
     "connect-history-api-fallback": "^2.0.0",
     "default-gateway": "^6.0.3",
-    "express": "^4.17.3",
+    "express": "^4.19.2",
     "graceful-fs": "^4.2.6",
     "html-entities": "^2.4.0",
     "http-proxy-middleware": "^2.0.3",


### PR DESCRIPTION
- [ ] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [x] This is a **metadata update**

### For Bugs and Features; did you add new tests?

<!-- Please note that we won't approve your changes if you don't add tests. -->

This is not a bug or a feature and does not need tests.

### Motivation / Use-Case

<!--
  What existing problem does the pull request solve?

  Please explain the motivation or use-case for making this change.
  If this Pull Request addresses an issue, please link to the issue.
-->

This pull request solves the vulnerability in Express that was recently discovered in all versions 4.19.1 and below. It has been fixed in version 4.19.2. The vulnerability is [CVE-2024-29041](https://nvd.nist.gov/vuln/detail/CVE-2024-29041).

This is preventing application security software such as Veracode from passing security checks for any applications that utilize webpack-dev-server. 

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  potential migration path for existing applications.
-->

No Breaking changes that I am aware of.

### Additional Info

Thank you very much!