### PR TITLE
Update package.json (change ws dependency to pull ^8.18.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "sockjs": "^0.3.24",
     "spdy": "^4.0.2",
     "webpack-dev-middleware": "^7.1.0",
-    "ws": "^8.16.0"
+    "ws": "^8.18.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.22.5",


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [x] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

<!-- Please note that we won't approve your changes if you don't add tests. -->

### Motivation / Use-Case

This PR addresses this package advisory: https://github.com/advisories/GHSA-3h5v-q93c-6h6q
Theoretically, just a rebuild of the project is necessary to fix this, but explicitly pulling this dependency helps.

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  potential migration path for existing applications.
-->

### Additional Info

While this advisory is theoretically a minor bug (this being a development tool), and a mitigatable one at that, it's nice to have this dependency updated to prevent consumers of this package from having to take mitigation steps other than pulling a minor/patch version.