### PR TITLE
feat: http2 support for `connect` compatibility application

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -31,6 +31,7 @@ const schema = require("./options.json");
 /** @typedef {import("ipaddr.js").IPv4} IPv4 */
 /** @typedef {import("ipaddr.js").IPv6} IPv6 */
 /** @typedef {import("net").Socket} Socket */
+/** @typedef {import("http").Server} HTTPServer*/
 /** @typedef {import("http").IncomingMessage} IncomingMessage */
 /** @typedef {import("http").ServerResponse} ServerResponse */
 /** @typedef {import("open").Options} OpenOptions */
@@ -199,8 +200,11 @@ const schema = require("./options.json");
  * @typedef {{ name?: string, path?: string, middleware: MiddlewareHandler } | MiddlewareHandler } Middleware
  */
 
+/** @typedef {import("net").Server} BasicServer */
+
 /**
  * @template {BasicApplication} [A=ExpressApplication]
+ * @template {BasicServer} [S=import("http").Server]
  * @typedef {Object} Configuration
  * @property {boolean | string} [ipc]
  * @property {Host} [host]
@@ -222,8 +226,8 @@ const schema = require("./options.json");
  * @property {boolean} [setupExitSignals]
  * @property {boolean | ClientConfiguration} [client]
  * @property {Headers | ((req: Request, res: Response, context: DevMiddlewareContext<Request, Response>) => Headers)} [headers]
- * @property {(devServer: Server<A>) => void} [onListening]
- * @property {(middlewares: Middleware[], devServer: Server<A>) => Middleware[]} [setupMiddlewares]
+ * @property {(devServer: Server<A, S>) => void} [onListening]
+ * @property {(middlewares: Middleware[], devServer: Server<A, S>) => Middleware[]} [setupMiddlewares]
  */
 
 if (!process.env.WEBPACK_SERVE) {
@@ -302,11 +306,11 @@ function useFn(route, fn) {
 
 /**
  * @template {BasicApplication} [A=ExpressApplication]
- * @template {import("http").Server} [S=import("http").Server]
+ * @template {BasicServer} [S=HTTPServer]
  */
 class Server {
   /**
-   * @param {Configuration<A>} options
+   * @param {Configuration<A, S>} options
    * @param {Compiler | MultiCompiler} compiler
    */
   constructor(options = {}, compiler) {
@@ -1587,8 +1591,9 @@ class Server {
   }
 
   /**
+   * @template T
    * @private
-   * @returns {string}
+   * @returns {T}
    */
   getServerTransport() {
     let implementation;
@@ -1618,9 +1623,8 @@ class Server {
           try {
             // eslint-disable-next-line import/no-dynamic-require
             implementation = require(
-              /** @type {WebSocketServerConfiguration} */ (
-                this.options.webSocketServer
-              ).type,
+              /** @type {WebSocketServerConfiguration} */
+              (this.options.webSocketServer).type,
             );
           } catch (error) {
             implementationFound = false;
@@ -1628,9 +1632,9 @@ class Server {
         }
         break;
       case "function":
-        implementation = /** @type {WebSocketServerConfiguration} */ (
-          this.options.webSocketServer
-        ).type;
+        implementation =
+          /** @type {WebSocketServerConfiguration} */
+          (this.options.webSocketServer).type;
         break;
       default:
         implementationFound = false;
@@ -2486,9 +2490,8 @@ class Server {
    */
   createWebSocketServer() {
     /** @type {WebSocketServerImplementation | undefined | null} */
-    this.webSocketServer = new /** @type {any} */ (this.getServerTransport())(
-      this,
-    );
+    this.webSocketServer = new (this.getServerTransport())(this);
+
     /** @type {WebSocketServerImplementation} */
     (this.webSocketServer).implementation.on(
       "connection",

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -2096,12 +2096,30 @@ class Server {
      */
     let middlewares = [];
 
+    const isHTTP2 =
+      /** @type {ServerConfiguration} */ (this.options.server).type === "http2";
+
+    if (isHTTP2) {
+      // TODO patch for https://github.com/pillarjs/finalhandler/pull/45, need remove then will be resolved
+      middlewares.push({
+        name: "http2-status-message-patch",
+        middleware:
+          /** @type {NextHandleFunction} */
+          (_req, res, next) => {
+            Object.defineProperty(res, "statusMessage", {
+              get() {
+                return "";
+              },
+              set() {},
+            });
+
+            next();
+          },
+      });
+    }
+
     // compress is placed last and uses unshift so that it will be the first middleware used
-    if (
-      this.options.compress &&
-      /** @type {ServerConfiguration} */
-      (this.options.server).type !== "http2"
-    ) {
+    if (this.options.compress && !isHTTP2) {
       const compression = require("compression");
 
       middlewares.push({ name: "compression", middleware: compression() });

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -391,7 +391,7 @@ class Server {
     if (gatewayOrFamily === "v4" || gatewayOrFamily === "v6") {
       let host;
 
-      Object.values(os.networkInterfaces())
+      const networks = Object.values(os.networkInterfaces())
         .flatMap((networks) => networks ?? [])
         .filter((network) => {
           if (!network || !network.address) {
@@ -415,13 +415,15 @@ class Server {
           }
 
           return network.address;
-        })
-        .forEach((network) => {
-          host = network.address;
-          if (host.includes(":")) {
-            host = `[${host}]`;
-          }
         });
+
+      for (const network of networks) {
+        host = network.address;
+
+        if (host.includes(":")) {
+          host = `[${host}]`;
+        }
+      }
 
       return host;
     }
@@ -1366,7 +1368,7 @@ class Server {
        */
       const result = [];
 
-      options.open.forEach((item) => {
+      for (const item of options.open) {
         if (typeof item === "string") {
           result.push({ target: item, options: defaultOpenOptions });
 
@@ -1374,7 +1376,7 @@ class Server {
         }
 
         result.push(...getOpenItemsFromObject(item));
-      });
+      }
 
       /** @type {NormalizedOpen[]} */
       (options.open) = result;
@@ -1721,7 +1723,7 @@ class Server {
         /** @type {MultiCompiler} */
         (this.compiler).compilers || [this.compiler];
 
-      compilers.forEach((compiler) => {
+      for (const compiler of compilers) {
         this.addAdditionalEntries(compiler);
 
         const webpack = compiler.webpack || require("webpack");
@@ -1746,7 +1748,7 @@ class Server {
             plugin.apply(compiler);
           }
         }
-      });
+      }
 
       if (
         this.options.client &&
@@ -1803,15 +1805,18 @@ class Server {
 
     // Proxy WebSocket without the initial http request
     // https://github.com/chimurai/http-proxy-middleware#external-websocket-upgrade
-    /** @type {RequestHandler[]} */
-    (this.webSocketProxies).forEach((webSocketProxy) => {
+    const webSocketProxies =
+      /** @type {RequestHandler[]} */
+      (this.webSocketProxies);
+
+    for (const webSocketProxy of webSocketProxies) {
       /** @type {S} */
       (this.server).on(
         "upgrade",
         /** @type {RequestHandler & { upgrade: NonNullable<RequestHandler["upgrade"]> }} */
         (webSocketProxy).upgrade,
       );
-    }, this);
+    }
   }
 
   /**
@@ -2019,17 +2024,18 @@ class Server {
           '<!DOCTYPE html><html><head><meta charset="utf-8"/></head><body>',
         );
 
+        /**
+         * @type {StatsCompilation[]}
+         */
         const statsForPrint =
           typeof (/** @type {MultiStats} */ (stats).stats) !== "undefined"
-            ? /** @type {MultiStats} */ (stats).toJson().children
+            ? /** @type {NonNullable<StatsCompilation["children"]>} */
+              (/** @type {MultiStats} */ (stats).toJson().children)
             : [/** @type {Stats} */ (stats).toJson()];
 
         res.write(`<h1>Assets Report:</h1>`);
 
-        /**
-         * @type {StatsCompilation[]}
-         */
-        (statsForPrint).forEach((item, index) => {
+        for (const [index, item] of statsForPrint.entries()) {
           res.write("<div>");
 
           const name =
@@ -2044,10 +2050,11 @@ class Server {
           res.write("<ul>");
 
           const publicPath = item.publicPath === "auto" ? "" : item.publicPath;
+          const assets =
+            /** @type {NonNullable<StatsCompilation["assets"]>} */
+            (item.assets);
 
-          for (const asset of /** @type {NonNullable<StatsCompilation["assets"]>} */ (
-            item.assets
-          )) {
+          for (const asset of assets) {
             const assetName = asset.name;
             const assetURL = `${publicPath}${assetName}`;
 
@@ -2060,7 +2067,7 @@ class Server {
 
           res.write("</ul>");
           res.write("</div>");
-        });
+        }
 
         res.end("</body></html>");
       });
@@ -2075,11 +2082,11 @@ class Server {
     const watchFiles = /** @type {NormalizedStatic[]} */ (this.options.static);
 
     if (watchFiles.length > 0) {
-      watchFiles.forEach((staticOption) => {
-        if (staticOption.watch) {
-          this.watchFiles(staticOption.directory, staticOption.watch);
+      for (const item of watchFiles) {
+        if (item.watch) {
+          this.watchFiles(item.directory, item.watch);
         }
-      });
+      }
     }
   }
 
@@ -2091,9 +2098,9 @@ class Server {
     const watchFiles = /** @type {WatchFiles[]} */ (this.options.watchFiles);
 
     if (watchFiles.length > 0) {
-      watchFiles.forEach((item) => {
+      for (const item of watchFiles) {
         this.watchFiles(item.paths, item.options);
-      });
+      }
     }
   }
 
@@ -2290,10 +2297,13 @@ class Server {
       });
     }
 
-    if (/** @type {NormalizedStatic[]} */ (this.options.static).length > 0) {
+    const staticOptions =
       /** @type {NormalizedStatic[]} */
-      (this.options.static).forEach((staticOption) => {
-        staticOption.publicPath.forEach((publicPath) => {
+      (this.options.static);
+
+    if (staticOptions.length > 0) {
+      for (const staticOption of staticOptions) {
+        for (const publicPath of staticOption.publicPath) {
           middlewares.push({
             name: "express-static",
             path: publicPath,
@@ -2302,8 +2312,8 @@ class Server {
               staticOption.staticOptions,
             ),
           });
-        });
-      });
+        }
+      }
     }
 
     if (this.options.historyApiFallback) {
@@ -2345,10 +2355,9 @@ class Server {
           (this.middleware),
       });
 
-      if (/** @type {NormalizedStatic[]} */ (this.options.static).length > 0) {
-        /** @type {NormalizedStatic[]} */
-        (this.options.static).forEach((staticOption) => {
-          staticOption.publicPath.forEach((publicPath) => {
+      if (staticOptions.length > 0) {
+        for (const staticOption of staticOptions) {
+          for (const publicPath of staticOption.publicPath) {
             middlewares.push({
               name: "express-static",
               path: publicPath,
@@ -2357,17 +2366,16 @@ class Server {
                 staticOption.staticOptions,
               ),
             });
-          });
-        });
+          }
+        }
       }
     }
 
-    if (/** @type {NormalizedStatic[]} */ (this.options.static).length > 0) {
+    if (staticOptions.length > 0) {
       const serveIndex = require("serve-index");
 
-      /** @type {NormalizedStatic[]} */
-      (this.options.static).forEach((staticOption) => {
-        staticOption.publicPath.forEach((publicPath) => {
+      for (const staticOption of staticOptions) {
+        for (const publicPath of staticOption.publicPath) {
           if (staticOption.serveIndex) {
             middlewares.push({
               name: "serve-index",
@@ -2392,8 +2400,8 @@ class Server {
               },
             });
           }
-        });
-      });
+        }
+      }
     }
 
     // Register this middleware always as the last one so that it's only used as a
@@ -2421,7 +2429,7 @@ class Server {
       middlewares = this.options.setupMiddlewares(middlewares, this);
     }
 
-    middlewares.forEach((middleware) => {
+    for (const middleware of middlewares) {
       if (typeof middleware === "function") {
         /** @type {A} */
         (this.app).use(
@@ -2442,7 +2450,7 @@ class Server {
           (middleware.middleware),
         );
       }
-    });
+    }
   }
 
   /**
@@ -2962,6 +2970,8 @@ class Server {
        */
       const allHeaders = [];
 
+      allHeaders.push({ key: "X_TEST", value: "TEST" });
+
       if (!Array.isArray(headers)) {
         // eslint-disable-next-line guard-for-in
         for (const name in headers) {
@@ -2972,14 +2982,9 @@ class Server {
         headers = allHeaders;
       }
 
-      headers.forEach(
-        /**
-         * @param {{key: string, value: any}} header
-         */
-        (header) => {
-          res.setHeader(header.key, header.value);
-        },
-      );
+      for (const { key, value } of headers) {
+        res.setHeader(key, value);
+      }
     }
 
     next();

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -1106,15 +1106,13 @@ class Server {
       },
     };
 
+    const serverOptions = /** @type {ServerOptions} */ (options.server.options);
+
     if (
       options.server.type === "spdy" &&
-      typeof (/** @type {ServerOptions} */ (options.server.options).spdy) ===
-        "undefined"
+      typeof serverOptions.spdy === "undefined"
     ) {
-      /** @type {ServerOptions} */
-      (options.server.options).spdy = {
-        protocols: ["h2", "http/1.1"],
-      };
+      serverOptions.spdy = { protocols: ["h2", "http/1.1"] };
     }
 
     if (
@@ -1122,13 +1120,8 @@ class Server {
       options.server.type === "http2" ||
       options.server.type === "spdy"
     ) {
-      if (
-        typeof (
-          /** @type {ServerOptions} */ (options.server.options).requestCert
-        ) === "undefined"
-      ) {
-        /** @type {ServerOptions} */
-        (options.server.options).requestCert = false;
+      if (typeof serverOptions.requestCert === "undefined") {
+        serverOptions.requestCert = false;
       }
 
       const httpsProperties =
@@ -1136,19 +1129,13 @@ class Server {
         (["ca", "cert", "crl", "key", "pfx"]);
 
       for (const property of httpsProperties) {
-        if (
-          typeof (
-            /** @type {ServerOptions} */ (options.server.options)[property]
-          ) === "undefined"
-        ) {
+        if (typeof serverOptions[property] === "undefined") {
           // eslint-disable-next-line no-continue
           continue;
         }
 
         /** @type {any} */
-        const value =
-          /** @type {ServerOptions} */
-          (options.server.options)[property];
+        const value = serverOptions[property];
         /**
          * @param {string | Buffer | undefined} item
          * @returns {string | Buffer | undefined}
@@ -1176,17 +1163,14 @@ class Server {
         };
 
         /** @type {any} */
-        (options.server.options)[property] = Array.isArray(value)
+        (serverOptions)[property] = Array.isArray(value)
           ? value.map((item) => readFile(item))
           : readFile(value);
       }
 
       let fakeCert;
 
-      if (
-        !(/** @type {ServerOptions} */ (options.server.options).key) ||
-        !(/** @type {ServerOptions} */ (options.server.options).cert)
-      ) {
+      if (!serverOptions.key || !serverOptions.cert) {
         const certificateDir = Server.findCacheDir();
         const certificatePath = path.join(certificateDir, "server.pem");
         let certificateExists;
@@ -1299,14 +1283,8 @@ class Server {
         this.logger.info(`SSL certificate: ${certificatePath}`);
       }
 
-      /** @type {ServerOptions} */
-      (options.server.options).key =
-        /** @type {ServerOptions} */
-        (options.server.options).key || fakeCert;
-      /** @type {ServerOptions} */
-      (options.server.options).cert =
-        /** @type {ServerOptions} */
-        (options.server.options).cert || fakeCert;
+      serverOptions.key = serverOptions.key || fakeCert;
+      serverOptions.cert = serverOptions.cert || fakeCert;
     }
 
     if (typeof options.ipc === "boolean") {

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -200,7 +200,7 @@ const schema = require("./options.json");
  */
 
 /**
- * @template {BasicApplication} [T=ExpressApplication]
+ * @template {BasicApplication} [A=ExpressApplication]
  * @typedef {Object} Configuration
  * @property {boolean | string} [ipc]
  * @property {Host} [host]
@@ -215,15 +215,15 @@ const schema = require("./options.json");
  * @property {string | string[] | WatchFiles | Array<string | WatchFiles>} [watchFiles]
  * @property {boolean | string | Static | Array<string | Static>} [static]
  * @property {ServerType | ServerConfiguration} [server]
- * @property {() => Promise<T>} [app]
+ * @property {() => Promise<A>} [app]
  * @property {boolean | "sockjs" | "ws" | string | WebSocketServerConfiguration} [webSocketServer]
  * @property {ProxyConfigArray} [proxy]
  * @property {boolean | string | Open | Array<string | Open>} [open]
  * @property {boolean} [setupExitSignals]
  * @property {boolean | ClientConfiguration} [client]
  * @property {Headers | ((req: Request, res: Response, context: DevMiddlewareContext<Request, Response>) => Headers)} [headers]
- * @property {(devServer: Server<T>) => void} [onListening]
- * @property {(middlewares: Middleware[], devServer: Server<T>) => Middleware[]} [setupMiddlewares]
+ * @property {(devServer: Server<A>) => void} [onListening]
+ * @property {(middlewares: Middleware[], devServer: Server<A>) => Middleware[]} [setupMiddlewares]
  */
 
 if (!process.env.WEBPACK_SERVE) {
@@ -301,11 +301,12 @@ function useFn(route, fn) {
  */
 
 /**
- * @template {BasicApplication} [T=ExpressApplication]
+ * @template {BasicApplication} [A=ExpressApplication]
+ * @template {import("http").Server} [S=import("http").Server]
  */
 class Server {
   /**
-   * @param {Configuration<T>} options
+   * @param {Configuration<A>} options
    * @param {Compiler | MultiCompiler} compiler
    */
   constructor(options = {}, compiler) {
@@ -1804,7 +1805,7 @@ class Server {
     // https://github.com/chimurai/http-proxy-middleware#external-websocket-upgrade
     /** @type {RequestHandler[]} */
     (this.webSocketProxies).forEach((webSocketProxy) => {
-      /** @type {import("http").Server} */
+      /** @type {S} */
       (this.server).on(
         "upgrade",
         /** @type {RequestHandler & { upgrade: NonNullable<RequestHandler["upgrade"]> }} */
@@ -1818,7 +1819,7 @@ class Server {
    * @returns {Promise<void>}
    */
   async setupApp() {
-    /** @type {T | undefined}*/
+    /** @type {A | undefined}*/
     this.app =
       typeof this.options.app === "function"
         ? await this.options.app()
@@ -1877,13 +1878,14 @@ class Server {
    * @returns {void}
    */
   setupHostHeaderCheck() {
-    /** @type {T} */
+    /** @type {A} */
     (this.app).use((req, res, next) => {
+      const headerName = req.headers[":authority"] ? ":authority" : "host";
       if (
         this.checkHeader(
           /** @type {{ [key: string]: string | undefined }} */
           (req.headers),
-          "host",
+          headerName,
         )
       ) {
         next();
@@ -1916,7 +1918,7 @@ class Server {
   setupBuiltInRoutes() {
     const { app, middleware } = this;
 
-    /** @type {T} */
+    /** @type {A} */
     (app).use("/__webpack_dev_server__/sockjs.bundle.js", (req, res, next) => {
       if (req.method !== "GET" && req.method !== "HEAD") {
         next();
@@ -1958,7 +1960,7 @@ class Server {
       fs.createReadStream(clientPath).pipe(res);
     });
 
-    /** @type {T} */
+    /** @type {A} */
     (app).use("/webpack-dev-server/invalidate", (req, res, next) => {
       if (req.method !== "GET" && req.method !== "HEAD") {
         next();
@@ -1970,7 +1972,7 @@ class Server {
       res.end();
     });
 
-    /** @type {T} */
+    /** @type {A} */
     (app).use("/webpack-dev-server/open-editor", (req, res, next) => {
       if (req.method !== "GET" && req.method !== "HEAD") {
         next();
@@ -1996,7 +1998,7 @@ class Server {
       res.end();
     });
 
-    /** @type {T} */
+    /** @type {A} */
     (app).use("/webpack-dev-server", (req, res, next) => {
       if (req.method !== "GET" && req.method !== "HEAD") {
         next();
@@ -2070,9 +2072,10 @@ class Server {
    * @returns {void}
    */
   setupWatchStaticFiles() {
-    if (/** @type {NormalizedStatic[]} */ (this.options.static).length > 0) {
-      /** @type {NormalizedStatic[]} */
-      (this.options.static).forEach((staticOption) => {
+    const watchFiles = /** @type {NormalizedStatic[]} */ (this.options.static);
+
+    if (watchFiles.length > 0) {
+      watchFiles.forEach((staticOption) => {
         if (staticOption.watch) {
           this.watchFiles(staticOption.directory, staticOption.watch);
         }
@@ -2085,11 +2088,10 @@ class Server {
    * @returns {void}
    */
   setupWatchFiles() {
-    const { watchFiles } = this.options;
+    const watchFiles = /** @type {WatchFiles[]} */ (this.options.watchFiles);
 
-    if (/** @type {WatchFiles[]} */ (watchFiles).length > 0) {
-      /** @type {WatchFiles[]} */
-      (watchFiles).forEach((item) => {
+    if (watchFiles.length > 0) {
+      watchFiles.forEach((item) => {
         this.watchFiles(item.paths, item.options);
       });
     }
@@ -2106,7 +2108,11 @@ class Server {
     let middlewares = [];
 
     // compress is placed last and uses unshift so that it will be the first middleware used
-    if (this.options.compress) {
+    if (
+      this.options.compress &&
+      /** @type {ServerConfiguration} */
+      (this.options.server).type !== "http2"
+    ) {
       const compression = require("compression");
 
       middlewares.push({ name: "compression", middleware: compression() });
@@ -2417,20 +2423,20 @@ class Server {
 
     middlewares.forEach((middleware) => {
       if (typeof middleware === "function") {
-        /** @type {T} */
+        /** @type {A} */
         (this.app).use(
           /** @type {NextHandleFunction | HandleFunction} */
           (middleware),
         );
       } else if (typeof middleware.path !== "undefined") {
-        /** @type {T} */
+        /** @type {A} */
         (this.app).use(
           middleware.path,
           /** @type {SimpleHandleFunction | NextHandleFunction} */
           (middleware.middleware),
         );
       } else {
-        /** @type {T} */
+        /** @type {A} */
         (this.app).use(
           /** @type {NextHandleFunction | HandleFunction} */
           (middleware.middleware),
@@ -2450,13 +2456,16 @@ class Server {
 
     // eslint-disable-next-line import/no-dynamic-require
     const serverType = require(/** @type {string} */ (type));
-    /** @type {import("http").Server | import("http2").Http2SecureServer | undefined | null} */
+    /** @type {S | null | undefined}*/
     this.server =
       type === "http2"
-        ? serverType.createSecureServer(options, this.app)
+        ? serverType.createSecureServer(
+            { ...options, allowHTTP1: true },
+            this.app,
+          )
         : serverType.createServer(options, this.app);
 
-    /** @type {import("http").Server} */
+    /** @type {S} */
     (this.server).on(
       "connection",
       /**
@@ -2473,7 +2482,7 @@ class Server {
       },
     );
 
-    /** @type {import("http").Server} */
+    /** @type {S} */
     (this.server).on(
       "error",
       /**
@@ -2758,7 +2767,7 @@ class Server {
     if (this.options.ipc) {
       this.logger.info(
         `Project is running at: "${
-          /** @type {import("http").Server} */
+          /** @type {S} */
           (this.server).address()
         }"`,
       );
@@ -2769,7 +2778,7 @@ class Server {
       const { address, port } =
         /** @type {import("net").AddressInfo} */
         (
-          /** @type {import("http").Server} */
+          /** @type {S} */
           (this.server).address()
         );
       /**
@@ -3244,7 +3253,7 @@ class Server {
 
     await /** @type {Promise<void>} */ (
       new Promise((resolve) => {
-        /** @type {import("http").Server} */
+        /** @type {S} */
         (this.server).listen(listenOptions, () => {
           resolve();
         });
@@ -3330,7 +3339,7 @@ class Server {
     if (this.server) {
       await /** @type {Promise<void>} */ (
         new Promise((resolve) => {
-          /** @type {import("http").Server} */
+          /** @type {S} */
           (this.server).close(() => {
             this.server = null;
 

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -102,8 +102,12 @@ const schema = require("./options.json");
  */
 
 /**
+ * @typedef {"http" | "https" | "spdy" | "http2" | string} ServerType
+ */
+
+/**
  * @typedef {Object} ServerConfiguration
- * @property {"http" | "https" | "spdy" | string} [type]
+ * @property {ServerType} [type]
  * @property {ServerOptions} [options]
  */
 
@@ -210,8 +214,7 @@ const schema = require("./options.json");
  * @property {boolean | Record<string, never> | BonjourOptions} [bonjour]
  * @property {string | string[] | WatchFiles | Array<string | WatchFiles>} [watchFiles]
  * @property {boolean | string | Static | Array<string | Static>} [static]
- * @property {boolean | ServerOptions} [https]
- * @property {"http" | "https" | "spdy" | string | ServerConfiguration} [server]
+ * @property {ServerType | ServerConfiguration} [server]
  * @property {() => Promise<T>} [app]
  * @property {boolean | "sockjs" | "ws" | string | WebSocketServerConfiguration} [webSocketServer]
  * @property {ProxyConfigArray} [proxy]
@@ -1096,7 +1099,6 @@ class Server {
             ? /** @type {ServerConfiguration} */ (options.server).type || "http"
             : "http",
       options: {
-        .../** @type {ServerOptions} */ (options.https),
         .../** @type {ServerConfiguration} */ (options.server || {}).options,
       },
     };
@@ -1112,7 +1114,11 @@ class Server {
       };
     }
 
-    if (options.server.type === "https" || options.server.type === "spdy") {
+    if (
+      options.server.type === "https" ||
+      options.server.type === "http2" ||
+      options.server.type === "spdy"
+    ) {
       if (
         typeof (
           /** @type {ServerOptions} */ (options.server.options).requestCert
@@ -2438,16 +2444,17 @@ class Server {
    * @returns {void}
    */
   createServer() {
-    const { type, options } = /** @type {ServerConfiguration} */ (
-      this.options.server
-    );
+    const { type, options } =
+      /** @type {ServerConfiguration} */
+      (this.options.server);
 
-    /** @type {import("http").Server | undefined | null} */
     // eslint-disable-next-line import/no-dynamic-require
-    this.server = require(/** @type {string} */ (type)).createServer(
-      options,
-      this.app,
-    );
+    const serverType = require(/** @type {string} */ (type));
+    /** @type {import("http").Server | import("http2").Http2SecureServer | undefined | null} */
+    this.server =
+      type === "http2"
+        ? serverType.createSecureServer(options, this.app)
+        : serverType.createServer(options, this.app);
 
     /** @type {import("http").Server} */
     (this.server).on(

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -1371,8 +1371,8 @@ class Server {
       for (const item of options.open) {
         if (typeof item === "string") {
           result.push({ target: item, options: defaultOpenOptions });
-
-          return;
+          // eslint-disable-next-line no-continue
+          continue;
         }
 
         result.push(...getOpenItemsFromObject(item));

--- a/lib/options.json
+++ b/lib/options.json
@@ -526,10 +526,10 @@
       "description": "Allows to set server and options (by default 'http')."
     },
     "ServerType": {
-      "enum": ["http", "https", "spdy"]
+      "enum": ["http", "https", "spdy", "http2"]
     },
     "ServerEnum": {
-      "enum": ["http", "https", "spdy"],
+      "enum": ["http", "https", "spdy", "http2"],
       "cli": {
         "exclude": true
       }

--- a/test/__snapshots__/validate-options.test.js.snap.webpack5
+++ b/test/__snapshots__/validate-options.test.js.snap.webpack5
@@ -533,7 +533,7 @@ exports[`options validate should throw an error on the "server" option with '{"t
 exports[`options validate should throw an error on the "server" option with '{"type":"https","options":{"ca":true}}' value 1`] = `
 "ValidationError: Invalid options object. Dev Server has been initialized using an options object that does not match the API schema.
  - options.server should be one of these:
-   "http" | "https" | "spdy" | non-empty string | object { type?, options? }
+   "http" | "https" | "spdy" | "http2" | non-empty string | object { type?, options? }
    -> Allows to set server and options (by default 'http').
    -> Read more at https://webpack.js.org/configuration/dev-server/#devserverserver
    Details:
@@ -550,7 +550,7 @@ exports[`options validate should throw an error on the "server" option with '{"t
 exports[`options validate should throw an error on the "server" option with '{"type":"https","options":{"cert":true}}' value 1`] = `
 "ValidationError: Invalid options object. Dev Server has been initialized using an options object that does not match the API schema.
  - options.server should be one of these:
-   "http" | "https" | "spdy" | non-empty string | object { type?, options? }
+   "http" | "https" | "spdy" | "http2" | non-empty string | object { type?, options? }
    -> Allows to set server and options (by default 'http').
    -> Read more at https://webpack.js.org/configuration/dev-server/#devserverserver
    Details:
@@ -567,7 +567,7 @@ exports[`options validate should throw an error on the "server" option with '{"t
 exports[`options validate should throw an error on the "server" option with '{"type":"https","options":{"key":10}}' value 1`] = `
 "ValidationError: Invalid options object. Dev Server has been initialized using an options object that does not match the API schema.
  - options.server should be one of these:
-   "http" | "https" | "spdy" | non-empty string | object { type?, options? }
+   "http" | "https" | "spdy" | "http2" | non-empty string | object { type?, options? }
    -> Allows to set server and options (by default 'http').
    -> Read more at https://webpack.js.org/configuration/dev-server/#devserverserver
    Details:
@@ -590,7 +590,7 @@ exports[`options validate should throw an error on the "server" option with '{"t
 exports[`options validate should throw an error on the "server" option with '{"type":"https","options":{"pfx":10}}' value 1`] = `
 "ValidationError: Invalid options object. Dev Server has been initialized using an options object that does not match the API schema.
  - options.server should be one of these:
-   "http" | "https" | "spdy" | non-empty string | object { type?, options? }
+   "http" | "https" | "spdy" | "http2" | non-empty string | object { type?, options? }
    -> Allows to set server and options (by default 'http').
    -> Read more at https://webpack.js.org/configuration/dev-server/#devserverserver
    Details:

--- a/test/e2e/__snapshots__/app.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/app.test.js.snap.webpack5
@@ -28,6 +28,34 @@ exports[`app option should work using "connect (async)" application and "http" s
 "
 `;
 
+exports[`app option should work using "connect (async)" application and "http2" server should handle GET request to index route (/): console messages 1`] = `
+[
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
+  "[HMR] Waiting for update signal from WDS...",
+  "Hey.",
+]
+`;
+
+exports[`app option should work using "connect (async)" application and "http2" server should handle GET request to index route (/): page errors 1`] = `[]`;
+
+exports[`app option should work using "connect (async)" application and "http2" server should handle GET request to index route (/): response status 1`] = `200`;
+
+exports[`app option should work using "connect (async)" application and "http2" server should handle GET request to index route (/): response text 1`] = `
+"
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset='UTF-8'>
+    <title>webpack-dev-server</title>
+  </head>
+  <body>
+    <h1>webpack-dev-server is running...</h1>
+    <script type="text/javascript" charset="utf-8" src="/main.js"></script>
+  </body>
+</html>
+"
+`;
+
 exports[`app option should work using "connect (async)" application and "https" server should handle GET request to index route (/): console messages 1`] = `
 [
   "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
@@ -97,6 +125,34 @@ exports[`app option should work using "connect" application and "http" server sh
 exports[`app option should work using "connect" application and "http" server should handle GET request to index route (/): response status 1`] = `200`;
 
 exports[`app option should work using "connect" application and "http" server should handle GET request to index route (/): response text 1`] = `
+"
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset='UTF-8'>
+    <title>webpack-dev-server</title>
+  </head>
+  <body>
+    <h1>webpack-dev-server is running...</h1>
+    <script type="text/javascript" charset="utf-8" src="/main.js"></script>
+  </body>
+</html>
+"
+`;
+
+exports[`app option should work using "connect" application and "http2" server should handle GET request to index route (/): console messages 1`] = `
+[
+  "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
+  "[HMR] Waiting for update signal from WDS...",
+  "Hey.",
+]
+`;
+
+exports[`app option should work using "connect" application and "http2" server should handle GET request to index route (/): page errors 1`] = `[]`;
+
+exports[`app option should work using "connect" application and "http2" server should handle GET request to index route (/): response status 1`] = `200`;
+
+exports[`app option should work using "connect" application and "http2" server should handle GET request to index route (/): response text 1`] = `
 "
 <!DOCTYPE html>
 <html>

--- a/test/e2e/app.test.js
+++ b/test/e2e/app.test.js
@@ -13,21 +13,21 @@ const staticDirectory = path.resolve(
 );
 
 const apps = [
-  // ["express", () => require("express")()],
+  ["express", () => require("express")()],
   ["connect", () => require("connect")()],
-  // ["connect (async)", async () => require("express")()],
+  ["connect (async)", () => require("connect")()],
 ];
 
-const servers = [
-  // "http",
-  // "https",
-  // "spdy",
-  "http2",
-];
+const servers = ["http", "https", "spdy", "http2"];
 
 describe("app option", () => {
   for (const [appName, app] of apps) {
     for (const server of servers) {
+      if (appName === "express" && server === "http2") {
+        // eslint-disable-next-line no-continue
+        continue;
+      }
+
       let compiler;
       let devServer;
       let page;
@@ -87,9 +87,7 @@ describe("app option", () => {
             () => performance.getEntries()[0].nextHopProtocol,
           );
 
-          const isSpdy = server === "spdy";
-
-          if (isSpdy) {
+          if (server === "spdy" || server === "http2") {
             expect(HTTPVersion).toEqual("h2");
           } else {
             expect(HTTPVersion).toEqual("http/1.1");

--- a/test/e2e/app.test.js
+++ b/test/e2e/app.test.js
@@ -13,12 +13,17 @@ const staticDirectory = path.resolve(
 );
 
 const apps = [
-  ["express", () => require("express")()],
+  // ["express", () => require("express")()],
   ["connect", () => require("connect")()],
-  ["connect (async)", async () => require("express")()],
+  // ["connect (async)", async () => require("express")()],
 ];
 
-const servers = ["http", "https", "spdy"];
+const servers = [
+  // "http",
+  // "https",
+  // "spdy",
+  "http2",
+];
 
 describe("app option", () => {
   for (const [appName, app] of apps) {

--- a/test/fixtures/watch-files-config/webpack.config.js
+++ b/test/fixtures/watch-files-config/webpack.config.js
@@ -4,6 +4,7 @@ const HTMLGeneratorPlugin = require("../../helpers/html-generator-plugin");
 
 module.exports = {
   mode: "development",
+  devtool: false,
   context: __dirname,
   stats: "none",
   entry: "./foo.js",

--- a/types/lib/Server.d.ts
+++ b/types/lib/Server.d.ts
@@ -4,11 +4,11 @@ export = Server;
  * @property {typeof useFn} use
  */
 /**
- * @template {BasicApplication} [T=ExpressApplication]
+ * @template {BasicApplication} [A=ExpressApplication]
  * @template {import("http").Server} [S=import("http").Server]
  */
 declare class Server<
-  T extends BasicApplication = import("express").Application,
+  A extends BasicApplication = import("express").Application,
   S extends import("http").Server = import("http").Server<
     typeof import("http").IncomingMessage,
     typeof import("http").ServerResponse
@@ -1165,11 +1165,11 @@ declare class Server<
    */
   private static isWebTarget;
   /**
-   * @param {Configuration<T>} options
+   * @param {Configuration<A>} options
    * @param {Compiler | MultiCompiler} compiler
    */
   constructor(
-    options: Configuration<T> | undefined,
+    options: Configuration<A> | undefined,
     compiler: Compiler | MultiCompiler,
   );
   compiler: import("webpack").Compiler | import("webpack").MultiCompiler;
@@ -1177,7 +1177,7 @@ declare class Server<
    * @type {ReturnType<Compiler["getInfrastructureLogger"]>}
    * */
   logger: ReturnType<Compiler["getInfrastructureLogger"]>;
-  options: Configuration<T>;
+  options: Configuration<A>;
   /**
    * @type {FSWatcher[]}
    */
@@ -1241,8 +1241,8 @@ declare class Server<
    * @returns {Promise<void>}
    */
   private setupApp;
-  /** @type {T | undefined}*/
-  app: T | undefined;
+  /** @type {A | undefined}*/
+  app: A | undefined;
   /**
    * @private
    * @param {Stats | MultiStats} statsObj
@@ -1686,7 +1686,7 @@ type Middleware =
       middleware: MiddlewareHandler;
     }
   | MiddlewareHandler;
-type Configuration<T extends BasicApplication = import("express").Application> =
+type Configuration<A extends BasicApplication = import("express").Application> =
   {
     ipc?: string | boolean | undefined;
     host?: string | undefined;
@@ -1724,7 +1724,7 @@ type Configuration<T extends BasicApplication = import("express").Application> =
       | undefined;
     static?: string | boolean | Static | (string | Static)[] | undefined;
     server?: string | ServerConfiguration | undefined;
-    app?: (() => Promise<T>) | undefined;
+    app?: (() => Promise<A>) | undefined;
     webSocketServer?:
       | string
       | boolean
@@ -1742,9 +1742,9 @@ type Configuration<T extends BasicApplication = import("express").Application> =
           context: DevMiddlewareContext<Request, Response>,
         ) => Headers)
       | undefined;
-    onListening?: ((devServer: Server<T>) => void) | undefined;
+    onListening?: ((devServer: Server<A>) => void) | undefined;
     setupMiddlewares?:
-      | ((middlewares: Middleware[], devServer: Server<T>) => Middleware[])
+      | ((middlewares: Middleware[], devServer: Server<A>) => Middleware[])
       | undefined;
   };
 type BasicApplication = {

--- a/types/lib/Server.d.ts
+++ b/types/lib/Server.d.ts
@@ -1302,8 +1302,12 @@ declare class Server<
    * @returns {void}
    */
   private createServer;
-  /** @type {import("http").Server | undefined | null} */
-  server: import("http").Server | undefined | null;
+  /** @type {import("http").Server | import("http2").Http2SecureServer | undefined | null} */
+  server:
+    | import("http").Server
+    | import("http2").Http2SecureServer
+    | undefined
+    | null;
   /**
    * @private
    * @returns {void}
@@ -1449,6 +1453,7 @@ declare namespace Server {
     WatchFiles,
     Static,
     NormalizedStatic,
+    ServerType,
     ServerConfiguration,
     WebSocketServerConfiguration,
     ClientConnection,
@@ -1579,6 +1584,7 @@ type NormalizedStatic = {
   staticOptions: ServeStaticOptions;
   watch: false | WatchOptions;
 };
+type ServerType = "http" | "https" | "spdy" | "http2" | string;
 type ServerConfiguration = {
   type?: string | undefined;
   options?: ServerOptions | undefined;
@@ -1716,7 +1722,6 @@ type Configuration<T extends BasicApplication = import("express").Application> =
       | (string | WatchFiles)[]
       | undefined;
     static?: string | boolean | Static | (string | Static)[] | undefined;
-    https?: boolean | ServerOptions | undefined;
     server?: string | ServerConfiguration | undefined;
     app?: (() => Promise<T>) | undefined;
     webSocketServer?:

--- a/types/lib/Server.d.ts
+++ b/types/lib/Server.d.ts
@@ -5,11 +5,11 @@ export = Server;
  */
 /**
  * @template {BasicApplication} [A=ExpressApplication]
- * @template {import("http").Server} [S=import("http").Server]
+ * @template {BasicServer} [S=HTTPServer]
  */
 declare class Server<
   A extends BasicApplication = import("express").Application,
-  S extends import("http").Server = import("http").Server<
+  S extends BasicServer = import("http").Server<
     typeof import("http").IncomingMessage,
     typeof import("http").ServerResponse
   >,
@@ -1165,11 +1165,11 @@ declare class Server<
    */
   private static isWebTarget;
   /**
-   * @param {Configuration<A>} options
+   * @param {Configuration<A, S>} options
    * @param {Compiler | MultiCompiler} compiler
    */
   constructor(
-    options: Configuration<A> | undefined,
+    options: Configuration<A, S> | undefined,
     compiler: Compiler | MultiCompiler,
   );
   compiler: import("webpack").Compiler | import("webpack").MultiCompiler;
@@ -1177,7 +1177,7 @@ declare class Server<
    * @type {ReturnType<Compiler["getInfrastructureLogger"]>}
    * */
   logger: ReturnType<Compiler["getInfrastructureLogger"]>;
-  options: Configuration<A>;
+  options: Configuration<A, S>;
   /**
    * @type {FSWatcher[]}
    */
@@ -1222,8 +1222,9 @@ declare class Server<
    */
   private getClientTransport;
   /**
+   * @template T
    * @private
-   * @returns {string}
+   * @returns {T}
    */
   private getServerTransport;
   /**
@@ -1431,6 +1432,7 @@ declare namespace Server {
     IPv4,
     IPv6,
     Socket,
+    HTTPServer,
     IncomingMessage,
     ServerResponse,
     OpenOptions,
@@ -1472,6 +1474,7 @@ declare namespace Server {
     Headers,
     MiddlewareHandler,
     Middleware,
+    BasicServer,
     Configuration,
     BasicApplication,
   };
@@ -1502,6 +1505,7 @@ type ServeStaticOptions = import("serve-static").ServeStaticOptions;
 type IPv4 = import("ipaddr.js").IPv4;
 type IPv6 = import("ipaddr.js").IPv6;
 type Socket = import("net").Socket;
+type HTTPServer = import("http").Server;
 type IncomingMessage = import("http").IncomingMessage;
 type ServerResponse = import("http").ServerResponse;
 type OpenOptions = import("open").Options;
@@ -1686,67 +1690,69 @@ type Middleware =
       middleware: MiddlewareHandler;
     }
   | MiddlewareHandler;
-type Configuration<A extends BasicApplication = import("express").Application> =
-  {
-    ipc?: string | boolean | undefined;
-    host?: string | undefined;
-    port?: Port | undefined;
-    hot?: boolean | "only" | undefined;
-    liveReload?: boolean | undefined;
-    devMiddleware?:
-      | DevMiddlewareOptions<
-          import("express").Request<
-            import("express-serve-static-core").ParamsDictionary,
-            any,
-            any,
-            qs.ParsedQs,
-            Record<string, any>
-          >,
-          import("express").Response<any, Record<string, any>>
-        >
-      | undefined;
-    compress?: boolean | undefined;
-    allowedHosts?: string | string[] | undefined;
-    historyApiFallback?:
-      | boolean
-      | import("connect-history-api-fallback").Options
-      | undefined;
-    bonjour?:
-      | boolean
-      | Record<string, never>
-      | import("bonjour-service").Service
-      | undefined;
-    watchFiles?:
-      | string
-      | string[]
-      | WatchFiles
-      | (string | WatchFiles)[]
-      | undefined;
-    static?: string | boolean | Static | (string | Static)[] | undefined;
-    server?: string | ServerConfiguration | undefined;
-    app?: (() => Promise<A>) | undefined;
-    webSocketServer?:
-      | string
-      | boolean
-      | WebSocketServerConfiguration
-      | undefined;
-    proxy?: ProxyConfigArray | undefined;
-    open?: string | boolean | Open | (string | Open)[] | undefined;
-    setupExitSignals?: boolean | undefined;
-    client?: boolean | ClientConfiguration | undefined;
-    headers?:
-      | Headers
-      | ((
-          req: Request,
-          res: Response,
-          context: DevMiddlewareContext<Request, Response>,
-        ) => Headers)
-      | undefined;
-    onListening?: ((devServer: Server<A>) => void) | undefined;
-    setupMiddlewares?:
-      | ((middlewares: Middleware[], devServer: Server<A>) => Middleware[])
-      | undefined;
-  };
+type BasicServer = import("net").Server;
+type Configuration<
+  A extends BasicApplication = import("express").Application,
+  S extends BasicServer = import("http").Server<
+    typeof import("http").IncomingMessage,
+    typeof import("http").ServerResponse
+  >,
+> = {
+  ipc?: string | boolean | undefined;
+  host?: string | undefined;
+  port?: Port | undefined;
+  hot?: boolean | "only" | undefined;
+  liveReload?: boolean | undefined;
+  devMiddleware?:
+    | DevMiddlewareOptions<
+        import("express").Request<
+          import("express-serve-static-core").ParamsDictionary,
+          any,
+          any,
+          qs.ParsedQs,
+          Record<string, any>
+        >,
+        import("express").Response<any, Record<string, any>>
+      >
+    | undefined;
+  compress?: boolean | undefined;
+  allowedHosts?: string | string[] | undefined;
+  historyApiFallback?:
+    | boolean
+    | import("connect-history-api-fallback").Options
+    | undefined;
+  bonjour?:
+    | boolean
+    | Record<string, never>
+    | import("bonjour-service").Service
+    | undefined;
+  watchFiles?:
+    | string
+    | string[]
+    | WatchFiles
+    | (string | WatchFiles)[]
+    | undefined;
+  static?: string | boolean | Static | (string | Static)[] | undefined;
+  server?: string | ServerConfiguration | undefined;
+  app?: (() => Promise<A>) | undefined;
+  webSocketServer?: string | boolean | WebSocketServerConfiguration | undefined;
+  proxy?: ProxyConfigArray | undefined;
+  open?: string | boolean | Open | (string | Open)[] | undefined;
+  setupExitSignals?: boolean | undefined;
+  client?: boolean | ClientConfiguration | undefined;
+  headers?:
+    | Headers
+    | ((
+        req: Request,
+        res: Response,
+        context: DevMiddlewareContext<Request, Response>,
+      ) => Headers)
+    | undefined;
+  onListening?: ((devServer: Server<A, S>) => void) | undefined;
+  setupMiddlewares?:
+    | ((middlewares: Middleware[], devServer: Server<A, S>) => Middleware[])
+    | undefined;
+};
 type BasicApplication = {
   use: typeof useFn;
 };

--- a/types/lib/Server.d.ts
+++ b/types/lib/Server.d.ts
@@ -5,9 +5,14 @@ export = Server;
  */
 /**
  * @template {BasicApplication} [T=ExpressApplication]
+ * @template {import("http").Server} [S=import("http").Server]
  */
 declare class Server<
   T extends BasicApplication = import("express").Application,
+  S extends import("http").Server = import("http").Server<
+    typeof import("http").IncomingMessage,
+    typeof import("http").ServerResponse
+  >,
 > {
   static get schema(): {
     title: string;
@@ -1302,12 +1307,8 @@ declare class Server<
    * @returns {void}
    */
   private createServer;
-  /** @type {import("http").Server | import("http2").Http2SecureServer | undefined | null} */
-  server:
-    | import("http").Server
-    | import("http2").Http2SecureServer
-    | undefined
-    | null;
+  /** @type {S | null | undefined}*/
+  server: S | null | undefined;
   /**
    * @private
    * @returns {void}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [ ] This is a **bugfix**
- [x] This is a **feature**
- [ ] This is a **code refactor**
- [x] This is a **test update**
- [ ] This is a **docs update**
- [x] This is a **metadata update**

### For Bugs and Features; did you add new tests?

Yes

### Motivation / Use-Case

Allow to use `http2` with `connect`, `express` still doesn't support http2

### Breaking Changes

No

### Additional Info

No