### PR TITLE
refactor: use methods to get client entries

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -793,9 +793,7 @@ class Server {
         webSocketURLStr = searchParams.toString();
       }
 
-      additionalEntries.push(
-        `${this.getClientEntry()}?${webSocketURLStr}`,
-      );
+      additionalEntries.push(`${this.getClientEntry()}?${webSocketURLStr}`);
     }
 
     const clientHotEntry = this.getClientHotEntry();
@@ -1676,15 +1674,14 @@ class Server {
   }
 
   /**
-   * @private
    * @returns {string}
    */
+  // eslint-disable-next-line class-methods-use-this
   getClientEntry() {
     return require.resolve("../client/index.js");
   }
 
   /**
-   * @private
    * @returns {string | void}
    */
   getClientHotEntry() {

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -794,14 +794,13 @@ class Server {
       }
 
       additionalEntries.push(
-        `${require.resolve("../client/index.js")}?${webSocketURLStr}`,
+        `${this.getClientEntry()}?${webSocketURLStr}`,
       );
     }
 
-    if (this.options.hot === "only") {
-      additionalEntries.push(require.resolve("webpack/hot/only-dev-server"));
-    } else if (this.options.hot) {
-      additionalEntries.push(require.resolve("webpack/hot/dev-server"));
+    const clientHotEntry = this.getClientHotEntry();
+    if (clientHotEntry) {
+      additionalEntries.push(clientHotEntry);
     }
 
     const webpack = compiler.webpack || require("webpack");
@@ -1674,6 +1673,26 @@ class Server {
     }
 
     return implementation;
+  }
+
+  /**
+   * @private
+   * @returns {string}
+   */
+  getClientEntry() {
+    return require.resolve("../client/index.js");
+  }
+
+  /**
+   * @private
+   * @returns {string | void}
+   */
+  getClientHotEntry() {
+    if (this.options.hot === "only") {
+      return require.resolve("webpack/hot/only-dev-server");
+    } else if (this.options.hot) {
+      return require.resolve("webpack/hot/dev-server");
+    }
   }
 
   /**

--- a/test/e2e/__snapshots__/client.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/client.test.js.snap.webpack5
@@ -12,6 +12,8 @@ exports[`client option default behaviour responds with a 200 status code for /ws
 
 exports[`client option default behaviour responds with a 200 status code for /ws path: response status 1`] = `200`;
 
+exports[`client option override client entry should disable client entry: response status 1`] = `200`;
+
 exports[`client option should respect path option responds with a 200 status code for /foo/test/bar path: console messages 1`] = `[]`;
 
 exports[`client option should respect path option responds with a 200 status code for /foo/test/bar path: page errors 1`] = `[]`;

--- a/test/fixtures/custom-client/CustomClientEntry.js
+++ b/test/fixtures/custom-client/CustomClientEntry.js
@@ -1,0 +1,3 @@
+"use strict";
+
+console.log("custom client entry");

--- a/test/fixtures/custom-client/CustomClientHotEntry.js
+++ b/test/fixtures/custom-client/CustomClientHotEntry.js
@@ -1,0 +1,3 @@
+"use strict";
+
+console.log("custom client hot entry");

--- a/types/lib/Server.d.ts
+++ b/types/lib/Server.d.ts
@@ -1232,6 +1232,16 @@ declare class Server<
   private getServerTransport;
   /**
    * @private
+   * @returns {string}
+   */
+  private getClientEntry;
+  /**
+   * @private
+   * @returns {string | void}
+   */
+  private getClientHotEntry;
+  /**
+   * @private
    * @returns {void}
    */
   private setupProgressPlugin;

--- a/types/lib/Server.d.ts
+++ b/types/lib/Server.d.ts
@@ -1231,15 +1231,13 @@ declare class Server<
    */
   private getServerTransport;
   /**
-   * @private
    * @returns {string}
    */
-  private getClientEntry;
+  getClientEntry(): string;
   /**
-   * @private
    * @returns {string | void}
    */
-  private getClientHotEntry;
+  getClientHotEntry(): string | void;
   /**
    * @private
    * @returns {void}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [ ] This is a **bugfix**
- [ ] This is a **feature**
- [x] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

A test case was added in `test/e2e/client.test.js` to test that the override can take effect correctly.

### Motivation / Use-Case

Use methods to get client entries, so that users can introduce custom client entries instead by overriding these methods.

### Breaking Changes

No breaking changes

### Additional Info
