### PR TITLE
chore: update http-proxy-middleware

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "express": "^4.21.0",
         "graceful-fs": "^4.2.6",
         "html-entities": "^2.4.0",
-        "http-proxy-middleware": "^2.0.3",
+        "http-proxy-middleware": "^2.0.7",
         "ipaddr.js": "^2.1.0",
         "launch-editor": "^2.6.1",
         "open": "^10.0.3",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "express": "^4.21.0",
     "graceful-fs": "^4.2.6",
     "html-entities": "^2.4.0",
-    "http-proxy-middleware": "^2.0.3",
+    "http-proxy-middleware": "^2.0.7",
     "ipaddr.js": "^2.1.0",
     "launch-editor": "^2.6.1",
     "open": "^10.0.3",


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [x] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

N/A, since this is a dependency upgrade

### Motivation / Use-Case

There is a security vulnerability in this package and this PR addresses it.

> Versions of the package http-proxy-middleware before 2.0.7, from 3.0.0 and before 3.0.3 are vulnerable to Denial of Service (DoS) due to an UnhandledPromiseRejection error thrown by micromatch. An attacker could kill the Node.js process and crash the server by making requests to certain paths.

### Breaking Changes

There shouldn't be any, this is a minor dependency upgrade. 