### PR TITLE
fix: take the first network found instead of the last one

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -437,8 +437,9 @@ class Server {
           return network.address;
         });
 
-      for (const network of networks) {
-        host = network.address;
+      if (networks.length > 0) {
+        // Take the first network found
+        host = networks[0].address;
 
         if (host.includes(":")) {
           host = `[${host}]`;

--- a/test/cli/host-option.test.js
+++ b/test/cli/host-option.test.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const os = require("os");
 const { testBin, normalizeStderr } = require("../helpers/test-bin");
 const port = require("../ports-map")["cli-host"];
 const Server = require("../../lib/Server");
@@ -114,6 +115,127 @@ describe('"host" CLI option', () => {
 
     expect(exitCode).toEqual(0);
     expect(normalizeStderr(stderr)).toMatchSnapshot("stderr");
+  });
+
+  it('should work using "--host local-ip" take the first network found', async () => {
+    const { exitCode, stderr } = await testBin([
+      "--port",
+      port,
+      "--host",
+      "local-ip",
+    ]);
+
+    expect(exitCode).toEqual(0);
+    jest.spyOn(os, "networkInterfaces").mockImplementation(() => {
+      return {
+        lo: [
+          {
+            address: "127.0.0.1",
+            netmask: "255.0.0.0",
+            family: "IPv4",
+            mac: "00:00:00:00:00:00",
+            internal: true,
+            cidr: "127.0.0.1/8",
+          },
+          {
+            address: "::1",
+            netmask: "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+            family: "IPv6",
+            mac: "00:00:00:00:00:00",
+            internal: true,
+            cidr: "::1/128",
+            scopeid: 0,
+          },
+        ],
+        enp6s0: [
+          {
+            address: "192.168.1.15",
+            netmask: "255.255.255.0",
+            family: "IPv4",
+            mac: "50:eb:f6:97:9f:6f",
+            internal: false,
+            cidr: "192.168.1.15/24",
+          },
+          {
+            address: "2a01:cb0c:1623:6800:4ff8:723c:1a4b:fe5d",
+            netmask: "ffff:ffff:ffff:ffff::",
+            family: "IPv6",
+            mac: "50:eb:f6:97:9f:6f",
+            internal: false,
+            cidr: "2a01:cb0c:1623:6800:4ff8:723c:1a4b:fe5d/64",
+            scopeid: 0,
+          },
+          {
+            address: "2a01:cb0c:1623:6800:9acc:408c:ee87:27cf",
+            netmask: "ffff:ffff:ffff:ffff::",
+            family: "IPv6",
+            mac: "50:eb:f6:97:9f:6f",
+            internal: false,
+            cidr: "2a01:cb0c:1623:6800:9acc:408c:ee87:27cf/64",
+            scopeid: 0,
+          },
+          {
+            address: "fe80::bf2a:e5e2:8f9:4336",
+            netmask: "ffff:ffff:ffff:ffff::",
+            family: "IPv6",
+            mac: "50:eb:f6:97:9f:6f",
+            internal: false,
+            cidr: "fe80::bf2a:e5e2:8f9:4336/64",
+            scopeid: 2,
+          },
+        ],
+        "br-9bb0264f9b1c": [
+          {
+            address: "172.19.0.1",
+            netmask: "255.255.0.0",
+            family: "IPv4",
+            mac: "02:42:e4:c8:6e:5f",
+            internal: false,
+            cidr: "172.19.0.1/16",
+          },
+          {
+            address: "fe80::42:e4ff:fec8:6e5f",
+            netmask: "ffff:ffff:ffff:ffff::",
+            family: "IPv6",
+            mac: "02:42:e4:c8:6e:5f",
+            internal: false,
+            cidr: "fe80::42:e4ff:fec8:6e5f/64",
+            scopeid: 4,
+          },
+        ],
+        "br-a52e5d90701f": [
+          {
+            address: "172.18.0.1",
+            netmask: "255.255.0.0",
+            family: "IPv4",
+            mac: "02:42:f6:7e:a2:45",
+            internal: false,
+            cidr: "172.18.0.1/16",
+          },
+          {
+            address: "fe80::42:f6ff:fe7e:a245",
+            netmask: "ffff:ffff:ffff:ffff::",
+            family: "IPv6",
+            mac: "02:42:f6:7e:a2:45",
+            internal: false,
+            cidr: "fe80::42:f6ff:fe7e:a245/64",
+            scopeid: 5,
+          },
+        ],
+        docker0: [
+          {
+            address: "172.17.0.1",
+            netmask: "255.255.0.0",
+            family: "IPv4",
+            mac: "02:42:3e:89:61:cf",
+            internal: false,
+            cidr: "172.17.0.1/16",
+          },
+        ],
+      };
+    });
+    expect(stderr.indexOf("172.17.0.1") === -1);
+    expect(stderr.indexOf("192.168.1.15") > -1);
   });
 
   it('should work using "--host local-ipv4"', async () => {


### PR DESCRIPTION
Take the first network found instead of the last one that may be the docker bridge. This restores the same behavior as 5.0.4, this fixes a regression introduced in 5.1.0 where the default-gateway dependency was dropped.

- [x] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

I tried to include a test and run it with
`npm run test:only test/cli/hot-option.test.js`
but I can't make it run on my machine, it's just blocking at
RUNS  test/cli/hot-option.test.js
no idea why.
I also have lots of failing tests and other files blocking like this when I'm testing on my machine.
Hopefully the CI may execute the test, finger crossed.

### Motivation / Use-Case

On version 5.0.4 with `--host local-ip` on Ubuntu, it returned
`https://192.168.1.15:8080`
On 5.1.0 and 5.2.0 it returns
`https://172.17.0.1:8080` that is the docker bridge, not so useful.

The new code introduced in #5255 was taking the last network of the networks array.
The change in this PR take the first one in networks array.

### Breaking Changes

No breaking change, this fixes a regression introduced in 5.1.0 where the default-gateway dependency was dropped.

### Additional Info


```js
console.log(networks)
[
  {
    address: '192.168.1.15',
    netmask: '255.255.255.0',
    family: 'IPv4',
    mac: '50:eb:f6:97:9f:6f',
    internal: false,
    cidr: '192.168.1.15/24'
  },
  {
    address: '172.19.0.1',
    netmask: '255.255.0.0',
    family: 'IPv4',
    mac: '02:42:e4:c8:6e:5f',
    internal: false,
    cidr: '172.19.0.1/16'
  },
  {
    address: '172.18.0.1',
    netmask: '255.255.0.0',
    family: 'IPv4',
    mac: '02:42:f6:7e:a2:45',
    internal: false,
    cidr: '172.18.0.1/16'
  },
  {
    address: '172.17.0.1',
    netmask: '255.255.0.0',
    family: 'IPv4',
    mac: '02:42:3e:89:61:cf',
    internal: false,
    cidr: '172.17.0.1/16'
  }
]
```
