### PR TITLE
fix: do not crush when error is null for runtime errors

### DIFF
--- a/client-src/overlay.js
+++ b/client-src/overlay.js
@@ -664,10 +664,16 @@ const createOverlay = (options) => {
       if (!error && !message) {
         return;
       }
+
       // if error stack indicates a React error boundary caught the error, do not show overlay.
-      if (error.stack && error.stack.includes("invokeGuardedCallbackDev")) {
+      if (
+        error &&
+        error.stack &&
+        error.stack.includes("invokeGuardedCallbackDev")
+      ) {
         return;
       }
+
       handleError(error, message);
     });
 

--- a/test/client/ReactErrorBoundary.test.js
+++ b/test/client/ReactErrorBoundary.test.js
@@ -4,7 +4,7 @@
 
 "use strict";
 
-const { createOverlay } = require("../../../client-src/overlay");
+const { createOverlay } = require("../../client-src/overlay");
 
 describe("createOverlay", () => {
   const originalDocument = global.document;
@@ -101,6 +101,29 @@ describe("createOverlay", () => {
       messages: [
         {
           message: regularError.message,
+          stack: expect.anything(),
+        },
+      ],
+    });
+    showOverlayMock.mockRestore();
+  });
+
+  it("should show overlay for normal uncaught errors (when null is thrown)", () => {
+    const options = { trustedTypesPolicyName: null, catchRuntimeError: true };
+    const overlay = createOverlay(options);
+    const showOverlayMock = jest.spyOn(overlay, "send");
+
+    const errorEvent = new ErrorEvent("error", {
+      error: null,
+      message: "error",
+    });
+    window.dispatchEvent(errorEvent);
+
+    expect(showOverlayMock).toHaveBeenCalledWith({
+      type: "RUNTIME_ERROR",
+      messages: [
+        {
+          message: "error",
           stack: expect.anything(),
         },
       ],


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
  Please do remove this header to acknowledge this message.

  Please place an x, no spaces, in all [ ] that apply
-->

- [x] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [x] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

Yes

### Motivation / Use-Case

fixes https://github.com/webpack/webpack-dev-server/pull/5431#issuecomment-2759854857

### Breaking Changes

No

### Additional Info

No