### PR TITLE
fix: "Overlay enabled" false positive

### DIFF
--- a/client-src/index.js
+++ b/client-src/index.js
@@ -183,7 +183,7 @@ if (parsedResourceQuery.overlay) {
 
     decodeOverlayOptions(options.overlay);
   }
-  enabledFeatures.Overlay = true;
+  enabledFeatures.Overlay = options.overlay !== false;
 }
 
 if (parsedResourceQuery.logging) {


### PR DESCRIPTION
When `client.overlay` is set to `false` the resource query string will be contain `overlay=false` ([relevant code](https://github.com/webpack/webpack-dev-server/blob/1e6c003efaadb41189087f784d3be09e43a4bbea/lib/Server.js#L764-L778)). This PR fixes the `enabledFeatures` logic to handle cases when `overlay=false`


- [x] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

No

### Motivation / Use-Case

Fixes misleading console logs

### Breaking Changes

No

### Additional Info
