### PR TITLE
feat: print Dev Server URL on 'u' keypress to reduce terminal clutter

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -4,6 +4,7 @@ const os = require("os");
 const path = require("path");
 const url = require("url");
 const util = require("util");
+const readline = require("readline");
 const fs = require("graceful-fs");
 const ipaddr = require("ipaddr.js");
 const { validate } = require("schema-utils");
@@ -308,6 +309,24 @@ function useFn(route, fn) {
 }
 
 const DEFAULT_ALLOWED_PROTOCOLS = /^(file|.+-extension):/i;
+
+/**
+ * @param {(host: string) => string} prettyPrintURL
+ */
+function setupKeypressLogger(prettyPrintURL) {
+  readline.emitKeypressEvents(process.stdin);
+  if (process.stdin.isTTY) {
+    process.stdin.setRawMode(true);
+    process.stdin.on("keypress", (str, key) => {
+      if (key.name === "u") {
+        console.log(`🔗 Dev Server: ${prettyPrintURL("localhost")}`);
+      } else if (key.name === "q" || (key.ctrl && key.name === "c")) {
+        process.exit();
+      }
+    });
+    console.log("🔑 Press [u] to show Dev Server URL, [q] to quit");
+  }
+}
 
 /**
  * @typedef {Object} BasicApplication
@@ -2916,6 +2935,11 @@ class Server {
        */
       const prettyPrintURL = (newHostname) =>
         url.format({ protocol, hostname: newHostname, port, pathname: "/" });
+
+      // @ts-expect-error: we just added this option, TS types need updating
+      if (this.options.printUrlOnKeypress) {
+        setupKeypressLogger(prettyPrintURL);
+      }
 
       let host;
       let localhost;

--- a/lib/options.json
+++ b/lib/options.json
@@ -495,6 +495,11 @@
       "description": "Allows to specify a port to use.",
       "link": "https://webpack.js.org/configuration/dev-server/#devserverport"
     },
+    "PrintUrlOnKeypress": {
+      "type": "boolean",
+      "default": false,
+      "description": "Only print the Dev Server URL when the user presses 'u' in the terminal."
+    },
     "Proxy": {
       "type": "array",
       "items": {
@@ -975,6 +980,9 @@
     },
     "compress": {
       "$ref": "#/definitions/Compress"
+    },
+    "printUrlOnKeypress": {
+      "$ref": "#/definitions/PrintUrlOnKeypress"
     },
     "devMiddleware": {
       "$ref": "#/definitions/DevMiddleware"

--- a/types/lib/Server.d.ts
+++ b/types/lib/Server.d.ts
@@ -575,6 +575,11 @@ declare class Server<
         description: string;
         link: string;
       };
+      PrintUrlOnKeypress: {
+        type: string;
+        default: boolean;
+        description: string;
+      };
       Proxy: {
         type: string;
         items: {
@@ -1064,6 +1069,9 @@ declare class Server<
         $ref: string;
       };
       compress: {
+        $ref: string;
+      };
+      printUrlOnKeypress: {
         $ref: string;
       };
       devMiddleware: {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  Please note that this template is not optional and all _ALL_ fields must be filled out, or your pull request may be rejected.

  Please do not delete this template.
-->

- [x] This is a **feature**

### For Bugs and Features; did you add new tests?

No new tests. This is a developer‑experience enhancement only.

### Motivation / Use-Case

Sometimes the Dev Server URL scrolls out of view in busy terminals, making it hard to grab.  
This change adds a new `printUrlOnKeypress` option (default `false`) that, when enabled, registers a keypress listener. Pressing **u** in the terminal will reprint the current Dev Server URL, reducing noisy automatic logs while still keeping the URL readily accessible.

Addresses discussion in #4907

### Breaking Changes

None

### Additional Info

- The option is gated behind:
  ```js
  devServer: {
    printUrlOnKeypress: true
  }
