### PR TITLE
fix: progress indicator

### DIFF
--- a/client-src/progress.js
+++ b/client-src/progress.js
@@ -52,6 +52,7 @@ export function defineProgressElement() {
             position: fixed;
             right: 5%;
             top: 5%;
+            pointer-events: none;
             transition: opacity .25s ease-in-out;
             z-index: 2147483645;
         }
@@ -116,6 +117,7 @@ export function defineProgressElement() {
             position: fixed;
             top: 0;
             left: 0;
+            pointer-events: none;
             height: 4px;
             width: 100vw;
             z-index: 2147483645;


### PR DESCRIPTION
- [x] This is a **bugfix**
- [ ] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?

No, this is only a CSS addition to the progress indicator setting `pointer-events: none;` this prevents the element from sitting on top of the DOM and blocking users from being able to click on that region of their screen.

### Motivation / Use-Case

With the progress indicator enabled, the `HTMLElement` persists in the DOM and is overlaying a large portion preventing users from clicking that region even if the element is invisible.

### Breaking Changes

N/A

### Additional Info
