### PR TITLE
feat: add logging for blocked updates when beforeunload is cance

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -3,6 +3,7 @@
   "language": "en,en-gb",
   "words": [
     "apos",
+    "beforeunload",
     "camelcase",
     "tapable",
     "sockjs",

--- a/client-src/index.js
+++ b/client-src/index.js
@@ -287,6 +287,7 @@ const overlay =
  */
 const reloadApp = ({ hot, liveReload }, currentStatus) => {
   if (currentStatus.isUnloading) {
+    log.info("Reload prevented.");
     return;
   }
 

--- a/examples/client/beforeunload/hmr-fallback/README.md
+++ b/examples/client/beforeunload/hmr-fallback/README.md
@@ -1,0 +1,39 @@
+# client.beforeunload Example
+
+This example reproduces a bug where the `isUnloading` flag gets stuck after canceling the "Leave site?" dialog, blocking HMR/Live Reload.
+
+## Bug Description
+
+When a user cancels the native confirmation dialog triggered by a `beforeunload` event listener, webpack-dev-server's internal `isUnloading` state remains `true`. This causes all subsequent HMR and live reloads to be ignored until manual refresh.
+
+## Configuration
+
+```js
+module.exports = {
+  devServer: {
+    hot: true,
+    liveReload: false, // Intentionally configured to cause HMR fallback
+  },
+};
+```
+
+## How to Reproduce the Bug
+
+### Prerequisites
+
+- Enable "Slow 3G" in browser DevTools Network tab (to make the issue more visible)
+- Open browser console to see webpack-dev-server logs
+
+### Steps
+
+1. Run `npx webpack serve` and open `http://localhost:8080/`
+2. Click **"Add Beforeunload Event"** button
+3. Click **"Reload Page"** button (or press F5/Ctrl+R)
+4. When "Leave site?" dialog appears, click **"Cancel"**
+5. Edit `app.js` file (make any change to trigger rebuild)
+6. **Bug**: Page does not update despite file changes
+
+### Expected vs Actual Behavior
+
+**Expected**: After canceling dialog, file changes should still trigger page updates  
+**Actual**: Page updates are completely blocked until manual refresh

--- a/examples/client/beforeunload/hmr-fallback/app.js
+++ b/examples/client/beforeunload/hmr-fallback/app.js
@@ -1,0 +1,79 @@
+"use strict";
+
+const target = document.querySelector("#target");
+
+// Beforeunload event handler
+function beforeunloadHandler(event) {
+  console.log("[webpack-dev-server] beforeunload event triggered");
+  event.preventDefault();
+  event.returnValue = "";
+  return "";
+}
+
+let isEventRegistered = false;
+
+// Create add event button
+const addEventButton = document.createElement("button");
+addEventButton.textContent = "Add Beforeunload Event";
+addEventButton.style.cssText =
+  "padding: 10px 20px; margin: 10px; font-size: 16px; cursor: pointer; background-color: #28a745; color: white; border: none; border-radius: 4px;";
+addEventButton.addEventListener("click", function () {
+  if (!isEventRegistered) {
+    window.addEventListener("beforeunload", beforeunloadHandler);
+    isEventRegistered = true;
+    updateStatus();
+    console.log("[webpack-dev-server] beforeunload event added");
+  }
+});
+
+// Create remove event button
+const removeEventButton = document.createElement("button");
+removeEventButton.textContent = "Remove Beforeunload Event";
+removeEventButton.style.cssText =
+  "padding: 10px 20px; margin: 10px; font-size: 16px; cursor: pointer; background-color: #dc3545; color: white; border: none; border-radius: 4px;";
+removeEventButton.addEventListener("click", function () {
+  if (isEventRegistered) {
+    window.removeEventListener("beforeunload", beforeunloadHandler);
+    isEventRegistered = false;
+    updateStatus();
+    console.log("[webpack-dev-server] beforeunload event removed");
+  }
+});
+
+// Create reload button
+const reloadButton = document.createElement("button");
+reloadButton.textContent = "Reload Page";
+reloadButton.style.cssText =
+  "padding: 10px 20px; margin: 10px; font-size: 16px; cursor: pointer; background-color: #007bff; color: white; border: none; border-radius: 4px;";
+reloadButton.addEventListener("click", function () {
+  console.log("[webpack-dev-server] page reload triggered");
+  window.location.reload();
+});
+
+// Create status display
+const statusDisplay = document.createElement("div");
+statusDisplay.style.cssText =
+  "margin: 10px; padding: 10px; border: 2px solid #ccc; border-radius: 4px; font-weight: bold;";
+
+function updateStatus() {
+  statusDisplay.textContent = isEventRegistered
+    ? "Status: Beforeunload event is ACTIVE - Page exit will be blocked"
+    : "Status: Beforeunload event is INACTIVE - Page exit will not be blocked";
+  statusDisplay.style.backgroundColor = isEventRegistered
+    ? "#d4edda"
+    : "#f8d7da";
+  statusDisplay.style.borderColor = isEventRegistered ? "#28a745" : "#dc3545";
+}
+
+target.classList.add("pass");
+target.innerHTML = "Beforeunload Event Controller";
+target.appendChild(document.createElement("br"));
+target.appendChild(document.createElement("br"));
+target.appendChild(statusDisplay);
+target.appendChild(document.createElement("br"));
+target.appendChild(addEventButton);
+target.appendChild(removeEventButton);
+target.appendChild(reloadButton);
+
+// Initialize status
+updateStatus();

--- a/examples/client/beforeunload/hmr-fallback/webpack.config.js
+++ b/examples/client/beforeunload/hmr-fallback/webpack.config.js
@@ -1,0 +1,14 @@
+"use strict";
+
+// our setup function adds behind-the-scenes bits to the config that all of our
+// examples need
+const { setup } = require("../../../util");
+
+module.exports = setup({
+  context: __dirname,
+  entry: "./app.js",
+  devServer: {
+    hot: true,
+    liveReload: false,
+  },
+});

--- a/examples/client/beforeunload/live-reload/README.md
+++ b/examples/client/beforeunload/live-reload/README.md
@@ -1,0 +1,39 @@
+# client.beforeunload Example
+
+This example reproduces a bug where the `isUnloading` flag gets stuck after canceling the "Leave site?" dialog, blocking Live Reload updates.
+
+## Bug Description
+
+When a user cancels the native confirmation dialog triggered by a `beforeunload` event listener, webpack-dev-server's internal `isUnloading` state remains `true`. This causes all subsequent Live Reload updates to be ignored until manual refresh.
+
+## Configuration
+
+```js
+module.exports = {
+  devServer: {
+    hot: false,
+    liveReload: true, // Test Live Reload scenario
+  },
+};
+```
+
+## How to Reproduce the Bug
+
+### Prerequisites
+
+- Enable "Slow 3G" in browser DevTools Network tab (to make the issue more visible)
+- Open browser console to see webpack-dev-server logs
+
+### Steps
+
+1. Run `npx webpack serve` and open `http://localhost:8080/`
+2. Click **"Add Beforeunload Event"** button
+3. Click **"Reload Page"** button (or press F5/Ctrl+R)
+4. When "Leave site?" dialog appears, click **"Cancel"**
+5. Edit `app.js` file (make any change to trigger rebuild)
+6. **Bug**: Page does not update despite file changes
+
+### Expected vs Actual Behavior
+
+**Expected**: After canceling dialog, file changes should still trigger Live Reload updates  
+**Actual**: Live Reload updates are completely blocked until manual refresh

--- a/examples/client/beforeunload/live-reload/app.js
+++ b/examples/client/beforeunload/live-reload/app.js
@@ -1,0 +1,79 @@
+"use strict";
+
+const target = document.querySelector("#target");
+
+// Beforeunload event handler
+function beforeunloadHandler(event) {
+  console.log("[webpack-dev-server] beforeunload event triggered");
+  event.preventDefault();
+  event.returnValue = "";
+  return "";
+}
+
+let isEventRegistered = false;
+
+// Create add event button
+const addEventButton = document.createElement("button");
+addEventButton.textContent = "Add Beforeunload Event";
+addEventButton.style.cssText =
+  "padding: 10px 20px; margin: 10px; font-size: 16px; cursor: pointer; background-color: #28a745; color: white; border: none; border-radius: 4px;";
+addEventButton.addEventListener("click", function () {
+  if (!isEventRegistered) {
+    window.addEventListener("beforeunload", beforeunloadHandler);
+    isEventRegistered = true;
+    updateStatus();
+    console.log("[webpack-dev-server] beforeunload event added");
+  }
+});
+
+// Create remove event button
+const removeEventButton = document.createElement("button");
+removeEventButton.textContent = "Remove Beforeunload Event";
+removeEventButton.style.cssText =
+  "padding: 10px 20px; margin: 10px; font-size: 16px; cursor: pointer; background-color: #dc3545; color: white; border: none; border-radius: 4px;";
+removeEventButton.addEventListener("click", function () {
+  if (isEventRegistered) {
+    window.removeEventListener("beforeunload", beforeunloadHandler);
+    isEventRegistered = false;
+    updateStatus();
+    console.log("[webpack-dev-server] beforeunload event removed");
+  }
+});
+
+// Create reload button
+const reloadButton = document.createElement("button");
+reloadButton.textContent = "Reload Page";
+reloadButton.style.cssText =
+  "padding: 10px 20px; margin: 10px; font-size: 16px; cursor: pointer; background-color: #007bff; color: white; border: none; border-radius: 4px;";
+reloadButton.addEventListener("click", function () {
+  console.log("[webpack-dev-server] page reload triggered");
+  window.location.reload();
+});
+
+// Create status display
+const statusDisplay = document.createElement("div");
+statusDisplay.style.cssText =
+  "margin: 10px; padding: 10px; border: 2px solid #ccc; border-radius: 4px; font-weight: bold;";
+
+function updateStatus() {
+  statusDisplay.textContent = isEventRegistered
+    ? "Status: Beforeunload event is ACTIVE - Page exit will be blocked"
+    : "Status: Beforeunload event is INACTIVE - Page exit will not be blocked";
+  statusDisplay.style.backgroundColor = isEventRegistered
+    ? "#d4edda"
+    : "#f8d7da";
+  statusDisplay.style.borderColor = isEventRegistered ? "#28a745" : "#dc3545";
+}
+
+target.classList.add("pass");
+target.innerHTML = "Beforeunload Event Controller";
+target.appendChild(document.createElement("br"));
+target.appendChild(document.createElement("br"));
+target.appendChild(statusDisplay);
+target.appendChild(document.createElement("br"));
+target.appendChild(addEventButton);
+target.appendChild(removeEventButton);
+target.appendChild(reloadButton);
+
+// Initialize status
+updateStatus();

--- a/examples/client/beforeunload/live-reload/webpack.config.js
+++ b/examples/client/beforeunload/live-reload/webpack.config.js
@@ -1,0 +1,14 @@
+"use strict";
+
+// our setup function adds behind-the-scenes bits to the config that all of our
+// examples need
+const { setup } = require("../../../util");
+
+module.exports = setup({
+  context: __dirname,
+  entry: "./app.js",
+  devServer: {
+    hot: false,
+    liveReload: true,
+  },
+});


### PR DESCRIPTION
- [ ] This is a **bugfix**
- [x] This is a **feature**
- [ ] This is a **code refactor**
- [ ] This is a **test update**
- [ ] This is a **docs update**
- [ ] This is a **metadata update**

### For Bugs and Features; did you add new tests?
I have added a new example to manually reproduce this bug and verify the logging behavior.

### Motivation / Use-Case
This PR addresses a bug where the `webpack-dev-server` client ignores subsequent HMR (Hot Module Replacement) and live reload updates after a user cancels the `beforeunload` confirmation dialog.

This issue occurs when the internal `isUnloading` state gets stuck as `true`, which **can negatively impact the development experience** in specific scenarios:

**Common Case - Form Navigation Prevention:**
When users try to navigate away from pages with unsaved form data, browsers show native confirmation dialogs (e.g., "Leave site? Changes you made may not be saved"). If users cancel these dialogs to stay on the page, HMR functionality becomes blocked for subsequent updates.

**Secondary Case - Development Tools:**
Users of tools like LocatorJS also experience this issue. These tools, which open VSCode from the browser to help developers navigate to components, trigger the `beforeunload` event every time they're used, causing HMR to stop working.

**Personal Experience:**
I encountered this issue firsthand and spent considerable time diagnosing it. The problem was eventually resolved by changing the tool's behavior from `_self` to `_blank` to avoid triggering `beforeunload`, but the debugging process was challenging due to the lack of clear logging.

Most users may not be aware of this problem due to the lack of visible logging, which makes it a **silent development workflow disruption**.

**This PR adds informative logging to make this blocking behavior visible to developers, helping them understand when and why their updates are being ignored.**

Fixes #5571

### What This PR Includes
1. **Reproduction Example** - A reliable way to reproduce this bug and verify the logging behavior
2. **Enhanced Logging** - Added `log.info` messages to improve debugging visibility, helping developers understand when HMR/live reload updates are being blocked

### Proposed Solutions for Discussion
**While this PR focuses on improving debugging visibility through logging, I've also identified several potential solutions to address the root cause.** I'd welcome feedback from maintainers on whether any of these approaches would be worth implementing.

I initially explored using various browser events to handle this issue, but couldn't identify an appropriate event that reliably indicates when the unload process is truly cancelled. I also considered using `setTimeout`, but determining the right timing seemed ambiguous.

These solutions were proposed with consideration for the discussion in [#841](https://github.com/webpack/webpack-dev-server/pull/841).

#### **Proposal 1: Add Configuration Option**
```javascript
// webpack.config.js
module.exports = {
  devServer: {
    beforeunload: 'ignore' // or false
  }
};
```
**Benefits:** Gives users direct control to disable this feature when it disrupts their workflow.
**Use case:** Ideal for developers who frequently encounter this issue with specific tools or workflows.

#### **Proposal 2: Automatic State Reset**
After the `isUnloading` state blocks a reload once, immediately reset the state to `false` to ensure subsequent updates are handled correctly.
**Benefits:** Prevents the state from getting permanently stuck.
**Considerations:** While consecutive updates are rare, this approach needs careful handling to avoid potential issues.

#### **Proposal 3: Conditional Activation**
Enable the `beforeunload` listener only when the `liveReload` option is `true`, since HMR workflows typically don't require full page reloads.
**Benefits:** Reduces interference with HMR-focused development workflows.
**Considerations:** Could be problematic when HMR fails and falls back to full page reload.

### Next Steps
- **Future Work:** If maintainers have thoughts on the proposed solutions or other good directions, I'd be eager to give it a try and implement them
- **Implementation:** This can be done either as a follow-up PR or by extending the current one

### Testing the Fix
To test this PR:
1. Run the included reproduction example
2. Trigger a `beforeunload` event and cancel it
4. Observe the new log messages in the console
5. Verify that subsequent HMR updates are properly logged when blocked