### PR TITLE
fix: always allow localhost in cross-origin no-cors requests

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -3145,6 +3145,10 @@ class Server {
     }
 
     // always allow localhost host, for convenience
+    if (value === "localhost" || value.endsWith(".localhost")) {
+      return true;
+    }
+
     // allow if value is in allowedHosts
     if (Array.isArray(allowedHosts) && allowedHosts.length > 0) {
       for (const allowedHost of allowedHosts) {
@@ -3232,14 +3236,11 @@ class Server {
     // an IPv6-address in URLs,
     // these are removed from the hostname in url.parse(),
     // so we have the pure IPv6-address in hostname.
-    // For convenience, always allow localhost (hostname === 'localhost')
-    // and its subdomains (hostname.endsWith(".localhost")).
+    // Note: localhost is already handled by isHostAllowed() above.
     // allow hostname of listening address  (hostname === this.options.host)
     const isValidHostname = validateHost
       ? ipaddr.IPv4.isValid(hostname) ||
         ipaddr.IPv6.isValid(hostname) ||
-        hostname === "localhost" ||
-        hostname.endsWith(".localhost") ||
         hostname === this.options.host
       : false;
 

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -3144,7 +3144,7 @@ class Server {
       return true;
     }
 
-    // always allow localhost host, for convenience
+    // always allow localhost and its subdomains (via ".localhost"), for convenience
     if (value === "localhost" || value.endsWith(".localhost")) {
       return true;
     }

--- a/test/e2e/cross-origin-request.test.js
+++ b/test/e2e/cross-origin-request.test.js
@@ -11,7 +11,7 @@ describe("cross-origin requests", () => {
   const htmlServerPort = port2;
   const htmlServerHost = "127.0.0.1";
 
-  it("should return 403 for cross-origin no-cors non-module script tag requests", async () => {
+  it("should return 200 for cross-origin no-cors non-module script tag requests to localhost", async () => {
     const compiler = webpack(config);
     const devServerOptions = {
       port: devServerPort,
@@ -54,7 +54,7 @@ describe("cross-origin requests", () => {
 
       const response = await scriptTagRequest;
 
-      expect(response.status()).toBe(403);
+      expect(response.status()).toBe(200);
     } finally {
       await browser.close();
       await server.stop();


### PR DESCRIPTION
Implement the intended behavior to always allow localhost host for development convenience. The isHostAllowed method had a comment stating localhost should always be allowed, but the code did not implement this check.

This fixes the issue where no-cors cross-site requests to localhost were incorrectly blocked with 403 Forbidden. Now localhost is always allowed regardless of allowedHosts configuration, matching the intended behavior for development environments.

Fixes the cross-origin-header-check middleware blocking legitimate localhost requests from blob URLs and other cross-origin contexts.

Fixes #5603
