### PR TITLE
feat: use new URL instead of url.parse

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -3059,12 +3059,17 @@ class Server {
     if (!header) return null;
     try {
       // If the header does not have a scheme, prepend // so URL can parse it
-      const url = new URL(/^(.+:)?\/\//.test(header) ? header : `//${header}`);
-      let hostname = url.hostname;
+      const parseUrl = new URL(
+        /^(.+:)?\/\//.test(header) ? header : `//${header}`,
+        "http://localhost/",
+      );
+
+      let hostname = parseUrl.hostname;
       // Normalize IPv6: remove brackets if present
       if (hostname.startsWith("[") && hostname.endsWith("]")) {
         hostname = hostname.slice(1, -1);
       }
+
       return hostname;
     } catch {
       return null;

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -3051,6 +3051,27 @@ class Server {
   }
 
   /**
+   * Extracts and normalizes the hostname from a header, removing brackets for IPv6.
+   * @param {string} header header value
+   * @returns {string|null} hostname or null
+   */
+  #parseHostnameFromHeader = function (header) {
+    if (!header) return null;
+    try {
+      // If the header does not have a scheme, prepend // so URL can parse it
+      const url = new URL(/^(.+:)?\/\//.test(header) ? header : `//${header}`);
+      let hostname = url.hostname;
+      // Normalize IPv6: remove brackets if present
+      if (hostname.startsWith("[") && hostname.endsWith("]")) {
+        hostname = hostname.slice(1, -1);
+      }
+      return hostname;
+    } catch {
+      return null;
+    }
+  };
+
+  /**
    * @private
    * @param {{ [key: string]: string | undefined }} headers headers
    * @param {string} headerToCheck header to check
@@ -3074,15 +3095,7 @@ class Server {
       return true;
     }
 
-    // use the node url-parser to retrieve the hostname from the host-header.
-    // TODO resolve me in the next major release
-    // eslint-disable-next-line n/no-deprecated-api
-    const { hostname } = url.parse(
-      // if header doesn't have scheme, add // for parsing.
-      /^(.+:)?\/\//.test(header) ? header : `//${header}`,
-      false,
-      true,
-    );
+    const hostname = this.#parseHostnameFromHeader(header);
 
     if (hostname === null) {
       return false;
@@ -3096,8 +3109,7 @@ class Server {
     // A note on IPv6 addresses:
     // header will always contain the brackets denoting
     // an IPv6-address in URLs,
-    // these are removed from the hostname in url.parse(),
-    // so we have the pure IPv6-address in hostname.
+    // these aren't removed from the hostname in new URL(),
     // For convenience, always allow localhost (hostname === 'localhost')
     // and its subdomains (hostname.endsWith(".localhost")).
     // allow hostname of listening address  (hostname === this.options.host)
@@ -3132,9 +3144,7 @@ class Server {
       return true;
     }
 
-    // TODO resolve me in the next major release
-    // eslint-disable-next-line n/no-deprecated-api
-    const origin = url.parse(originHeader, false, true).hostname;
+    const origin = this.#parseHostnameFromHeader(originHeader);
 
     if (origin === null) {
       return false;
@@ -3154,13 +3164,7 @@ class Server {
       return true;
     }
 
-    // eslint-disable-next-line n/no-deprecated-api
-    const host = url.parse(
-      // if hostHeader doesn't have scheme, add // for parsing.
-      /^(.+:)?\/\//.test(hostHeader) ? hostHeader : `//${hostHeader}`,
-      false,
-      true,
-    ).hostname;
+    const host = this.#parseHostnameFromHeader(hostHeader);
 
     if (host === null) {
       return false;

--- a/types/lib/Server.d.ts
+++ b/types/lib/Server.d.ts
@@ -1409,6 +1409,7 @@ declare class Server<
    * @param {((err?: Error) => void)=} callback callback
    */
   stopCallback(callback?: ((err?: Error) => void) | undefined): void;
+  #private;
 }
 declare namespace Server {
   export {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

An important change, IPv6 hostnames now return with square brackets (`[]`) (for new URL()), so they need to be formatted for `ipaddr` to correctly validate whether it’s an IPv6 URL. Additionally, the hostname also needs to be formatted in the IPv6 case, because right now, when an IPv6 hostname is passed in `host`, users are not including the square brackets. We could change this behavior, what do you think?

Also, it seems this will make retrieving the hostname faster.

<img width="969" height="218" alt="imagen" src="https://github.com/user-attachments/assets/4568b7c2-a2b7-4095-8631-3658f995b688" />
**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->
