### PR TITLE
Fix WebSocketClient onMessage event naming

### DIFF
--- a/client-src/clients/WebSocketClient.js
+++ b/client-src/clients/WebSocketClient.js
@@ -35,8 +35,8 @@ export default class WebSocketClient {
    * @param {(...args: EXPECTED_ANY[]) => void} fn function
    */
   onMessage(fn) {
-    this.client.onmessage = (err) => {
-      fn(err.data);
+    this.client.onmessage = (event) => {
+      fn(event.data);
     };
   }
 }


### PR DESCRIPTION
**Summary**

This PR improves code clarity in `WebSocketClient` by renaming the `onmessage` callback parameter from `err` to `event`.

The previous name was misleading, as the parameter represents a `MessageEvent`, not an error. This change aligns the variable name with the actual WebSocket API and improves readability and maintainability without altering runtime behavior.


**What kind of change does this PR introduce?**

Refactor (non-functional, clarity improvement)


**Did you add tests for your changes?**

No. This change is a naming refactor only and does not affect logic or behavior.


**Does this PR introduce a breaking change?**

No. This change is purely internal and does not impact the public API or runtime behavior.


**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

No documentation changes are required.
