### PR TITLE
fix: correct src typo in getCurrentScriptSource test

### DIFF
--- a/test/client/utils/getCurrentScriptSource.test.js
+++ b/test/client/utils/getCurrentScriptSource.test.js
@@ -75,7 +75,7 @@ describe("'getCurrentScriptSource' function", () => {
     expect(getCurrentScriptSource()).toBe("bar");
   });
 
-  it("should fail when no scripts with the 'scr' attribute", () => {
+  it("should fail when no scripts with the 'src' attribute", () => {
     const elements = ["foo", "bar"].map(() => document.createElement("script"));
 
     Object.defineProperty(document, "scripts", {


### PR DESCRIPTION
### What this PR does

- Fixes a typo in a test description (`scr` → `src`)

### Notes

- No behavior changes
- Test logic unchanged
