### PR TITLE
feat: use compiler.platform to determine the target

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -560,42 +560,9 @@ class Server {
    * @returns {boolean} true when target is `web`, otherwise false
    */
   static isWebTarget(compiler) {
-    if (compiler.platform && compiler.platform.web) {
-      return compiler.platform.web;
-    }
-
-    // TODO improve for the next major version and keep only `webTargets` to fallback for old versions
-    if (
-      compiler.options.externalsPresets &&
-      compiler.options.externalsPresets.web
-    ) {
-      return true;
-    }
-
-    if (
-      compiler.options.resolve.conditionNames &&
-      compiler.options.resolve.conditionNames.includes("browser")
-    ) {
-      return true;
-    }
-
-    const webTargets = [
-      "web",
-      "webworker",
-      "electron-preload",
-      "electron-renderer",
-      "nwjs",
-      "node-webkit",
-
-      undefined,
-      null,
-    ];
-
-    if (Array.isArray(compiler.options.target)) {
-      return compiler.options.target.some((r) => webTargets.includes(r));
-    }
-
-    return webTargets.includes(/** @type {string} */ (compiler.options.target));
+    return (
+      compiler.platform?.web || compiler.options.externalsPresets?.web || false
+    );
   }
 
   /**
@@ -813,18 +780,9 @@ class Server {
         /** @type {MultiCompiler} */
         (this.compiler).compilers.find(
           (config) =>
-            (config.options.externalsPresets &&
-              config.options.externalsPresets.web) ||
-            [
-              "web",
-              "webworker",
-              "electron-preload",
-              "electron-renderer",
-              "node-webkit",
-
-              undefined,
-              null,
-            ].includes(/** @type {string} */ (config.options.target)),
+            config.options.externalsPresets?.web ||
+            config.platform?.web ||
+            false,
         );
 
       if (compilerWithWebPreset) {

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -560,9 +560,7 @@ class Server {
    * @returns {boolean} true when target is `web`, otherwise false
    */
   static isWebTarget(compiler) {
-    return (
-      compiler.platform?.web || compiler.options.externalsPresets?.web || false
-    );
+    return compiler.platform?.web || false;
   }
 
   /**
@@ -778,12 +776,7 @@ class Server {
       // Configuration with `web` preset
       const compilerWithWebPreset =
         /** @type {MultiCompiler} */
-        (this.compiler).compilers.find(
-          (config) =>
-            config.options.externalsPresets?.web ||
-            config.platform?.web ||
-            false,
-        );
+        (this.compiler).compilers.find((config) => Server.isWebTarget(config));
 
       if (compilerWithWebPreset) {
         return compilerWithWebPreset.options;

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -560,7 +560,7 @@ class Server {
    * @returns {boolean} true when target is `web`, otherwise false
    */
   static isWebTarget(compiler) {
-    return compiler.platform?.web || false;
+    return compiler.platform.web || false;
   }
 
   /**

--- a/migration-v6.md
+++ b/migration-v6.md
@@ -37,9 +37,9 @@ This document serves as a migration guide for `webpack-dev-server@6.0.0`.
   };
   ```
 
-- Now, webpack-dev-server adds WebSocket communication only when the `target` is set to a web-compatible environment or when `externalsPresets` includes `web`.
+- Now, webpack-dev-server adds WebSocket communication only when the `target` is set to a web-compatible environment. Previously, it also injected WebSocket communication if `resolve` contained a `conditionNames` entry with `browser` or if `externalsPresets.web` existed.
 
-Previously, it also injected WebSocket communication if `resolve` contained a `conditionNames` entry with `browser`.
+- When retrieving the configuration in a multi-compiler setup, it will look for one that has a target compatible with a web environment. If it doesn’t find one, it will fall back to the first compiler found by webpack.
 
 ## Deprecations
 

--- a/migration-v6.md
+++ b/migration-v6.md
@@ -37,6 +37,10 @@ This document serves as a migration guide for `webpack-dev-server@6.0.0`.
   };
   ```
 
+- Now, webpack-dev-server adds WebSocket communication only when the `target` is set to a web-compatible environment or when `externalsPresets` includes `web`.
+
+Previously, it also injected WebSocket communication if `resolve` contained a `conditionNames` entry with `browser`.
+
 ## Deprecations
 
 - The static methods `internalIP` and `internalIPSync` were removed. Use `findIp` instead.

--- a/package-lock.json
+++ b/package-lock.json
@@ -19791,9 +19791,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
-      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

The use of `compiler.platform` is available starting from webpack 5.92.0 ([https://github.com/webpack/webpack/commit/e11fb128a24222e2fce1ad10e55b140c2a64a2ff](https://github.com/webpack/webpack/commit/e11fb128a24222e2fce1ad10e55b140c2a64a2ff)).

The logic that added WebSocket communication when a `conditionNames` entry included `browser` has been removed. However, I’m not sure whether we also want to remove the behavior related to `externalsPresets`. Do we want to remove that as well?

If you want to know where it determines whether the web is available for a specific target, take a look here (https://github.com/webpack/webpack/blob/c835794b7fcd9f1e2f6750ae94c95aadf23a63dd/lib/config/target.js#L101)
**What kind of change does this PR introduce?**

refactor, and feat

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->
