### PR TITLE
fix: treat loopback aliases as equivalent in isSameOrigin

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -3091,10 +3091,15 @@ class Server {
       return true;
     }
 
-    // Treat all loopback aliases as equivalent, localhost may resolve to
+    // Treat all loopback aliases as equivalent: localhost may resolve to
     // 127.0.0.1 or ::1 depending on the OS, causing a false mismatch.
+    // Only widen when allowedHosts is "auto" (default) or already permits a
+    // loopback alias, so an explicit allow-list excluding loopback is honored.
     const loopbacks = new Set(["localhost", "127.0.0.1", "::1"]);
-    if (loopbacks.has(origin) && loopbacks.has(host)) {
+    const loopbackPermitted =
+      this.options.allowedHosts === "auto" ||
+      [...loopbacks].some((alias) => this.isHostAllowed(alias));
+    if (loopbacks.has(origin) && loopbacks.has(host) && loopbackPermitted) {
       return true;
     }
 

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -3091,6 +3091,13 @@ class Server {
       return true;
     }
 
+    // Treat all loopback aliases as equivalent, localhost may resolve to
+    // 127.0.0.1 or ::1 depending on the OS, causing a false mismatch.
+    const loopbacks = new Set(["localhost", "127.0.0.1", "::1"]);
+    if (loopbacks.has(origin) && loopbacks.has(host)) {
+      return true;
+    }
+
     return origin === host;
   }
 

--- a/test/e2e/__snapshots__/allowed-hosts.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/allowed-hosts.test.js.snap.webpack5
@@ -1,3 +1,15 @@
+exports[`allowed hosts > check host headers > should NOT allow websocket connection when origin is a non-loopback address mismatching host (loopback fix must not widen trust) 1`] = `
+200
+`;
+
+exports[`allowed hosts > check host headers > should NOT allow websocket connection when origin is a non-loopback address mismatching host (loopback fix must not widen trust) 2`] = `
+[]
+`;
+
+exports[`allowed hosts > check host headers > should NOT allow websocket connection when origin is a non-loopback address mismatching host (loopback fix must not widen trust) 3`] = `
+[]
+`;
+
 exports[`allowed hosts > check host headers > should allow hosts in allowedHosts 1`] = `
 200
 `;
@@ -19,6 +31,42 @@ exports[`allowed hosts > check host headers > should allow hosts that pass a wil
 `;
 
 exports[`allowed hosts > check host headers > should allow hosts that pass a wildcard in allowedHosts 3`] = `
+[]
+`;
+
+exports[`allowed hosts > check host headers > should allow websocket connection when host is 'localhost' but resolves to '127.0.0.1' (loopback alias mismatch) 1`] = `
+200
+`;
+
+exports[`allowed hosts > check host headers > should allow websocket connection when host is 'localhost' but resolves to '127.0.0.1' (loopback alias mismatch) 2`] = `
+[]
+`;
+
+exports[`allowed hosts > check host headers > should allow websocket connection when host is 'localhost' but resolves to '127.0.0.1' (loopback alias mismatch) 3`] = `
+[]
+`;
+
+exports[`allowed hosts > check host headers > should allow websocket connection when host is 'localhost' but resolves to '::1' (loopback alias mismatch) 1`] = `
+200
+`;
+
+exports[`allowed hosts > check host headers > should allow websocket connection when host is 'localhost' but resolves to '::1' (loopback alias mismatch) 2`] = `
+[]
+`;
+
+exports[`allowed hosts > check host headers > should allow websocket connection when host is 'localhost' but resolves to '::1' (loopback alias mismatch) 3`] = `
+[]
+`;
+
+exports[`allowed hosts > check host headers > should allow websocket connection when origin is '127.0.0.1' but host is 'localhost' (reverse loopback alias mismatch) 1`] = `
+200
+`;
+
+exports[`allowed hosts > check host headers > should allow websocket connection when origin is '127.0.0.1' but host is 'localhost' (reverse loopback alias mismatch) 2`] = `
+[]
+`;
+
+exports[`allowed hosts > check host headers > should allow websocket connection when origin is '127.0.0.1' but host is 'localhost' (reverse loopback alias mismatch) 3`] = `
 []
 `;
 
@@ -82,7 +130,7 @@ exports[`allowed hosts > check host headers > should always allow value of the \
 []
 `;
 
-exports[`allowed hosts > should connect web socket client using "0.0.0.0" host to web socket server with the "auto" value ("ws") 1`] = `
+exports[`allowed hosts > should connect web socket client using \"0.0.0.0\" host to web socket server with the \"auto\" value (\"ws\") 1`] = `
 [
   "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
@@ -90,11 +138,11 @@ exports[`allowed hosts > should connect web socket client using "0.0.0.0" host t
 ]
 `;
 
-exports[`allowed hosts > should connect web socket client using "0.0.0.0" host to web socket server with the "auto" value ("ws") 2`] = `
+exports[`allowed hosts > should connect web socket client using \"0.0.0.0\" host to web socket server with the \"auto\" value (\"ws\") 2`] = `
 []
 `;
 
-exports[`allowed hosts > should connect web socket client using "127.0.0.1" host to web socket server by default ("ws") 1`] = `
+exports[`allowed hosts > should connect web socket client using \"127.0.0.1\" host to web socket server by default (\"ws\") 1`] = `
 [
   "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
@@ -102,11 +150,11 @@ exports[`allowed hosts > should connect web socket client using "127.0.0.1" host
 ]
 `;
 
-exports[`allowed hosts > should connect web socket client using "127.0.0.1" host to web socket server by default ("ws") 2`] = `
+exports[`allowed hosts > should connect web socket client using \"127.0.0.1\" host to web socket server by default (\"ws\") 2`] = `
 []
 `;
 
-exports[`allowed hosts > should connect web socket client using "127.0.0.1" host to web socket server with the "auto" value ("ws") 1`] = `
+exports[`allowed hosts > should connect web socket client using \"127.0.0.1\" host to web socket server with the \"auto\" value (\"ws\") 1`] = `
 [
   "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
@@ -114,11 +162,11 @@ exports[`allowed hosts > should connect web socket client using "127.0.0.1" host
 ]
 `;
 
-exports[`allowed hosts > should connect web socket client using "127.0.0.1" host to web socket server with the "auto" value ("ws") 2`] = `
+exports[`allowed hosts > should connect web socket client using \"127.0.0.1\" host to web socket server with the \"auto\" value (\"ws\") 2`] = `
 []
 `;
 
-exports[`allowed hosts > should connect web socket client using "[::1] host to web socket server with the "auto" value ("ws") 1`] = `
+exports[`allowed hosts > should connect web socket client using \"[::1] host to web socket server with the \"auto\" value (\"ws\") 1`] = `
 [
   "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
@@ -126,11 +174,11 @@ exports[`allowed hosts > should connect web socket client using "[::1] host to w
 ]
 `;
 
-exports[`allowed hosts > should connect web socket client using "[::1] host to web socket server with the "auto" value ("ws") 2`] = `
+exports[`allowed hosts > should connect web socket client using \"[::1] host to web socket server with the \"auto\" value (\"ws\") 2`] = `
 []
 `;
 
-exports[`allowed hosts > should connect web socket client using "chrome-extension:" protocol to web socket server with the "auto" value ("ws") 1`] = `
+exports[`allowed hosts > should connect web socket client using \"chrome-extension:\" protocol to web socket server with the \"auto\" value (\"ws\") 1`] = `
 [
   "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
@@ -138,11 +186,11 @@ exports[`allowed hosts > should connect web socket client using "chrome-extensio
 ]
 `;
 
-exports[`allowed hosts > should connect web socket client using "chrome-extension:" protocol to web socket server with the "auto" value ("ws") 2`] = `
+exports[`allowed hosts > should connect web socket client using \"chrome-extension:\" protocol to web socket server with the \"auto\" value (\"ws\") 2`] = `
 []
 `;
 
-exports[`allowed hosts > should connect web socket client using "file:" protocol to web socket server with the "auto" value ("ws") 1`] = `
+exports[`allowed hosts > should connect web socket client using \"file:\" protocol to web socket server with the \"auto\" value (\"ws\") 1`] = `
 [
   "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
@@ -150,11 +198,11 @@ exports[`allowed hosts > should connect web socket client using "file:" protocol
 ]
 `;
 
-exports[`allowed hosts > should connect web socket client using "file:" protocol to web socket server with the "auto" value ("ws") 2`] = `
+exports[`allowed hosts > should connect web socket client using \"file:\" protocol to web socket server with the \"auto\" value (\"ws\") 2`] = `
 []
 `;
 
-exports[`allowed hosts > should connect web socket client using "localhost" host to web socket server by default ("ws") 1`] = `
+exports[`allowed hosts > should connect web socket client using \"localhost\" host to web socket server by default (\"ws\") 1`] = `
 [
   "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
@@ -162,11 +210,11 @@ exports[`allowed hosts > should connect web socket client using "localhost" host
 ]
 `;
 
-exports[`allowed hosts > should connect web socket client using "localhost" host to web socket server by default ("ws") 2`] = `
+exports[`allowed hosts > should connect web socket client using \"localhost\" host to web socket server by default (\"ws\") 2`] = `
 []
 `;
 
-exports[`allowed hosts > should connect web socket client using custom hostname to web socket server with the "all" value ("ws") 1`] = `
+exports[`allowed hosts > should connect web socket client using custom hostname to web socket server with the \"all\" value (\"ws\") 1`] = `
 [
   "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
@@ -174,11 +222,11 @@ exports[`allowed hosts > should connect web socket client using custom hostname 
 ]
 `;
 
-exports[`allowed hosts > should connect web socket client using custom hostname to web socket server with the "all" value ("ws") 2`] = `
+exports[`allowed hosts > should connect web socket client using custom hostname to web socket server with the \"all\" value (\"ws\") 2`] = `
 []
 `;
 
-exports[`allowed hosts > should connect web socket client using custom hostname to web socket server with the "all" value in array ("ws") 1`] = `
+exports[`allowed hosts > should connect web socket client using custom hostname to web socket server with the \"all\" value in array (\"ws\") 1`] = `
 [
   "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
@@ -186,11 +234,11 @@ exports[`allowed hosts > should connect web socket client using custom hostname 
 ]
 `;
 
-exports[`allowed hosts > should connect web socket client using custom hostname to web socket server with the "all" value in array ("ws") 2`] = `
+exports[`allowed hosts > should connect web socket client using custom hostname to web socket server with the \"all\" value in array (\"ws\") 2`] = `
 []
 `;
 
-exports[`allowed hosts > should connect web socket client using custom hostname to web socket server with the custom hostname value ("ws") 1`] = `
+exports[`allowed hosts > should connect web socket client using custom hostname to web socket server with the custom hostname value (\"ws\") 1`] = `
 [
   "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
@@ -198,11 +246,11 @@ exports[`allowed hosts > should connect web socket client using custom hostname 
 ]
 `;
 
-exports[`allowed hosts > should connect web socket client using custom hostname to web socket server with the custom hostname value ("ws") 2`] = `
+exports[`allowed hosts > should connect web socket client using custom hostname to web socket server with the custom hostname value (\"ws\") 2`] = `
 []
 `;
 
-exports[`allowed hosts > should connect web socket client using custom hostname to web socket server with the custom hostname value starting with dot ("ws") 1`] = `
+exports[`allowed hosts > should connect web socket client using custom hostname to web socket server with the custom hostname value starting with dot (\"ws\") 1`] = `
 [
   "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
@@ -210,11 +258,11 @@ exports[`allowed hosts > should connect web socket client using custom hostname 
 ]
 `;
 
-exports[`allowed hosts > should connect web socket client using custom hostname to web socket server with the custom hostname value starting with dot ("ws") 2`] = `
+exports[`allowed hosts > should connect web socket client using custom hostname to web socket server with the custom hostname value starting with dot (\"ws\") 2`] = `
 []
 `;
 
-exports[`allowed hosts > should connect web socket client using custom hostname to web socket server with the multiple custom hostname values ("ws") 1`] = `
+exports[`allowed hosts > should connect web socket client using custom hostname to web socket server with the multiple custom hostname values (\"ws\") 1`] = `
 [
   "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
@@ -222,11 +270,11 @@ exports[`allowed hosts > should connect web socket client using custom hostname 
 ]
 `;
 
-exports[`allowed hosts > should connect web socket client using custom hostname to web socket server with the multiple custom hostname values ("ws") 2`] = `
+exports[`allowed hosts > should connect web socket client using custom hostname to web socket server with the multiple custom hostname values (\"ws\") 2`] = `
 []
 `;
 
-exports[`allowed hosts > should connect web socket client using custom sub hostname to web socket server with the custom hostname value ("ws") 1`] = `
+exports[`allowed hosts > should connect web socket client using custom sub hostname to web socket server with the custom hostname value (\"ws\") 1`] = `
 [
   "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
@@ -234,11 +282,11 @@ exports[`allowed hosts > should connect web socket client using custom sub hostn
 ]
 `;
 
-exports[`allowed hosts > should connect web socket client using custom sub hostname to web socket server with the custom hostname value ("ws") 2`] = `
+exports[`allowed hosts > should connect web socket client using custom sub hostname to web socket server with the custom hostname value (\"ws\") 2`] = `
 []
 `;
 
-exports[`allowed hosts > should connect web socket client using localhost to web socket server with the "auto" value ("ws") 1`] = `
+exports[`allowed hosts > should connect web socket client using localhost to web socket server with the \"auto\" value (\"ws\") 1`] = `
 [
   "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
@@ -246,11 +294,11 @@ exports[`allowed hosts > should connect web socket client using localhost to web
 ]
 `;
 
-exports[`allowed hosts > should connect web socket client using localhost to web socket server with the "auto" value ("ws") 2`] = `
+exports[`allowed hosts > should connect web socket client using localhost to web socket server with the \"auto\" value (\"ws\") 2`] = `
 []
 `;
 
-exports[`allowed hosts > should connect web socket client using origin header containing an IP address with the custom hostname value ("ws") 1`] = `
+exports[`allowed hosts > should connect web socket client using origin header containing an IP address with the custom hostname value (\"ws\") 1`] = `
 [
   "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
@@ -258,25 +306,25 @@ exports[`allowed hosts > should connect web socket client using origin header co
 ]
 `;
 
-exports[`allowed hosts > should connect web socket client using origin header containing an IP address with the custom hostname value ("ws") 2`] = `
+exports[`allowed hosts > should connect web socket client using origin header containing an IP address with the custom hostname value (\"ws\") 2`] = `
 []
 `;
 
-exports[`allowed hosts > should disconnect web client using localhost to web socket server with the "auto" value ("ws") 1`] = `
+exports[`allowed hosts > should disconnect web client using localhost to web socket server with the \"auto\" value (\"ws\") 1`] = `
 "<html><head><meta name="color-scheme" content="light dark"></head><body><pre style="word-wrap: break-word; white-space: pre-wrap;">Invalid Host header</pre></body></html>"
 `;
 
-exports[`allowed hosts > should disconnect web client using localhost to web socket server with the "auto" value ("ws") 2`] = `
+exports[`allowed hosts > should disconnect web client using localhost to web socket server with the \"auto\" value (\"ws\") 2`] = `
 [
   "Failed to load resource: the server responded with a status of 403 (Forbidden)",
 ]
 `;
 
-exports[`allowed hosts > should disconnect web client using localhost to web socket server with the "auto" value ("ws") 3`] = `
+exports[`allowed hosts > should disconnect web client using localhost to web socket server with the \"auto\" value (\"ws\") 3`] = `
 []
 `;
 
-exports[`allowed hosts > should disconnect web client using origin header containing an IP address with the "auto" value ("ws") 1`] = `
+exports[`allowed hosts > should disconnect web client using origin header containing an IP address with the \"auto\" value (\"ws\") 1`] = `
 [
   "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
@@ -287,11 +335,11 @@ exports[`allowed hosts > should disconnect web client using origin header contai
 ]
 `;
 
-exports[`allowed hosts > should disconnect web client using origin header containing an IP address with the "auto" value ("ws") 2`] = `
+exports[`allowed hosts > should disconnect web client using origin header containing an IP address with the \"auto\" value (\"ws\") 2`] = `
 []
 `;
 
-exports[`allowed hosts > should disconnect web socket client using custom hostname from web socket server with the "auto" value based on the "host" header ("ws") 1`] = `
+exports[`allowed hosts > should disconnect web socket client using custom hostname from web socket server with the \"auto\" value based on the \"host\" header (\"ws\") 1`] = `
 [
   "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
@@ -302,11 +350,11 @@ exports[`allowed hosts > should disconnect web socket client using custom hostna
 ]
 `;
 
-exports[`allowed hosts > should disconnect web socket client using custom hostname from web socket server with the "auto" value based on the "host" header ("ws") 2`] = `
+exports[`allowed hosts > should disconnect web socket client using custom hostname from web socket server with the \"auto\" value based on the \"host\" header (\"ws\") 2`] = `
 []
 `;
 
-exports[`allowed hosts > should disconnect web socket client using custom hostname from web socket server with the "auto" value based on the "host" header when "server: 'https'" is enabled ("ws") 1`] = `
+exports[`allowed hosts > should disconnect web socket client using custom hostname from web socket server with the \"auto\" value based on the \"host\" header when \"server: 'https'\" is enabled (\"ws\") 1`] = `
 [
   "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
@@ -317,11 +365,11 @@ exports[`allowed hosts > should disconnect web socket client using custom hostna
 ]
 `;
 
-exports[`allowed hosts > should disconnect web socket client using custom hostname from web socket server with the "auto" value based on the "host" header when "server: 'https'" is enabled ("ws") 2`] = `
+exports[`allowed hosts > should disconnect web socket client using custom hostname from web socket server with the \"auto\" value based on the \"host\" header when \"server: 'https'\" is enabled (\"ws\") 2`] = `
 []
 `;
 
-exports[`allowed hosts > should disconnect web socket client using custom hostname from web socket server with the "auto" value based on the "origin" header ("ws") 1`] = `
+exports[`allowed hosts > should disconnect web socket client using custom hostname from web socket server with the \"auto\" value based on the \"origin\" header (\"ws\") 1`] = `
 [
   "[webpack-dev-server] Server started: Hot Module Replacement enabled, Live Reloading enabled, Progress disabled, Overlay enabled.",
   "[HMR] Waiting for update signal from WDS...",
@@ -332,6 +380,6 @@ exports[`allowed hosts > should disconnect web socket client using custom hostna
 ]
 `;
 
-exports[`allowed hosts > should disconnect web socket client using custom hostname from web socket server with the "auto" value based on the "origin" header ("ws") 2`] = `
+exports[`allowed hosts > should disconnect web socket client using custom hostname from web socket server with the \"auto\" value based on the \"origin\" header (\"ws\") 2`] = `
 []
 `;

--- a/test/e2e/__snapshots__/allowed-hosts.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/allowed-hosts.test.js.snap.webpack5
@@ -1,3 +1,15 @@
+exports[`allowed hosts > check host headers > should NOT allow websocket connection when allowedHosts is restrictive and excludes every loopback alias 1`] = `
+200
+`;
+
+exports[`allowed hosts > check host headers > should NOT allow websocket connection when allowedHosts is restrictive and excludes every loopback alias 2`] = `
+[]
+`;
+
+exports[`allowed hosts > check host headers > should NOT allow websocket connection when allowedHosts is restrictive and excludes every loopback alias 3`] = `
+[]
+`;
+
 exports[`allowed hosts > check host headers > should NOT allow websocket connection when origin is a non-loopback address mismatching host (loopback fix must not widen trust) 1`] = `
 200
 `;

--- a/test/e2e/allowed-hosts.test.js
+++ b/test/e2e/allowed-hosts.test.js
@@ -1850,5 +1850,176 @@ describe("allowed hosts", () => {
 
       t.assert.snapshot(pageErrors);
     });
+
+    it("should allow websocket connection when host is 'localhost' but resolves to '127.0.0.1' (loopback alias mismatch)", async (t) => {
+      const options = {
+        allowedHosts: "auto",
+        host: "localhost",
+        port: port1,
+      };
+
+      server = new Server(options, compiler);
+
+      await server.start();
+
+      ({ page, browser } = await runBrowser());
+
+      page
+        .on("console", (message) => {
+          consoleMessages.push(message);
+        })
+        .on("pageerror", (error) => {
+          pageErrors.push(error);
+        });
+
+      // Simulate: browser opens from localhost, but OS resolved
+      // 'localhost' to '127.0.0.1' so host header is the IP
+      const headersLocalhostOriginIPv4Host = {
+        host: "127.0.0.1",
+        origin: "http://localhost",
+      };
+
+      if (!server.isSameOrigin(headersLocalhostOriginIPv4Host)) {
+        throw new Error(
+          "isSameOrigin should treat localhost and 127.0.0.1 as equivalent loopback addresses",
+        );
+      }
+
+      const response = await page.goto(`http://localhost:${port1}/main.js`, {
+        waitUntil: "networkidle0",
+      });
+
+      t.assert.snapshot(response.status());
+      t.assert.snapshot(consoleMessages.map((message) => message.text()));
+      t.assert.snapshot(pageErrors);
+    });
+
+    it("should allow websocket connection when host is 'localhost' but resolves to '::1' (loopback alias mismatch)", async (t) => {
+      const options = {
+        allowedHosts: "auto",
+        host: "localhost",
+        port: port1,
+      };
+
+      server = new Server(options, compiler);
+
+      await server.start();
+
+      ({ page, browser } = await runBrowser());
+
+      page
+        .on("console", (message) => {
+          consoleMessages.push(message);
+        })
+        .on("pageerror", (error) => {
+          pageErrors.push(error);
+        });
+
+      // Simulate: browser opens from localhost, but OS resolved
+      // 'localhost' to '::1' (IPv6) so host header is the IPv6 address
+      const headersLocalhostOriginIPv6Host = {
+        host: "::1",
+        origin: "http://localhost",
+      };
+
+      if (!server.isSameOrigin(headersLocalhostOriginIPv6Host)) {
+        throw new Error(
+          "isSameOrigin should treat localhost and ::1 as equivalent loopback addresses",
+        );
+      }
+
+      const response = await page.goto(`http://localhost:${port1}/main.js`, {
+        waitUntil: "networkidle0",
+      });
+
+      t.assert.snapshot(response.status());
+      t.assert.snapshot(consoleMessages.map((message) => message.text()));
+      t.assert.snapshot(pageErrors);
+    });
+
+    it("should allow websocket connection when origin is '127.0.0.1' but host is 'localhost' (reverse loopback alias mismatch)", async (t) => {
+      const options = {
+        allowedHosts: "auto",
+        host: "127.0.0.1",
+        port: port1,
+      };
+
+      server = new Server(options, compiler);
+
+      await server.start();
+
+      ({ page, browser } = await runBrowser());
+
+      page
+        .on("console", (message) => {
+          consoleMessages.push(message);
+        })
+        .on("pageerror", (error) => {
+          pageErrors.push(error);
+        });
+
+      // Reverse of above: server bound to 127.0.0.1, but browser
+      // sent origin header using 'localhost' name
+      const headersIPv4OriginLocalhostHost = {
+        host: "localhost",
+        origin: "http://127.0.0.1",
+      };
+
+      if (!server.isSameOrigin(headersIPv4OriginLocalhostHost)) {
+        throw new Error(
+          "isSameOrigin should treat 127.0.0.1 and localhost as equivalent loopback addresses",
+        );
+      }
+
+      const response = await page.goto(`http://127.0.0.1:${port1}/main.js`, {
+        waitUntil: "networkidle0",
+      });
+
+      t.assert.snapshot(response.status());
+      t.assert.snapshot(consoleMessages.map((message) => message.text()));
+      t.assert.snapshot(pageErrors);
+    });
+
+    it("should NOT allow websocket connection when origin is a non-loopback address mismatching host (loopback fix must not widen trust)", async (t) => {
+      const options = {
+        allowedHosts: "auto",
+        host: "localhost",
+        port: port1,
+      };
+
+      server = new Server(options, compiler);
+
+      await server.start();
+
+      ({ page, browser } = await runBrowser());
+
+      page
+        .on("console", (message) => {
+          consoleMessages.push(message);
+        })
+        .on("pageerror", (error) => {
+          pageErrors.push(error);
+        });
+
+      // A real external origin must never pass as loopback equivalent.
+      const headersExternalOrigin = {
+        host: "localhost",
+        origin: "http://evil.example.com",
+      };
+
+      if (server.isSameOrigin(headersExternalOrigin)) {
+        throw new Error(
+          "isSameOrigin must NOT allow external origins to match loopback host",
+        );
+      }
+
+      const response = await page.goto(`http://localhost:${port1}/main.js`, {
+        waitUntil: "networkidle0",
+      });
+
+      t.assert.snapshot(response.status());
+      t.assert.snapshot(consoleMessages.map((message) => message.text()));
+      t.assert.snapshot(pageErrors);
+    });
   });
 });

--- a/test/e2e/allowed-hosts.test.js
+++ b/test/e2e/allowed-hosts.test.js
@@ -1982,6 +1982,49 @@ describe("allowed hosts", () => {
       t.assert.snapshot(pageErrors);
     });
 
+    it("should NOT allow websocket connection when allowedHosts is restrictive and excludes every loopback alias", async (t) => {
+      const options = {
+        // Explicit allow-list without any loopback alias: the loopback
+        // equivalence must NOT override the user's configuration.
+        allowedHosts: ["example.com"],
+        host: "localhost",
+        port: port1,
+      };
+
+      server = new Server(options, compiler);
+
+      await server.start();
+
+      ({ page, browser } = await runBrowser());
+
+      page
+        .on("console", (message) => {
+          consoleMessages.push(message);
+        })
+        .on("pageerror", (error) => {
+          pageErrors.push(error);
+        });
+
+      const headersLoopbackButNotAllowed = {
+        host: "127.0.0.1",
+        origin: "http://localhost",
+      };
+
+      if (server.isSameOrigin(headersLoopbackButNotAllowed)) {
+        throw new Error(
+          "isSameOrigin must respect explicit allowedHosts when no loopback alias is permitted",
+        );
+      }
+
+      const response = await page.goto(`http://localhost:${port1}/main.js`, {
+        waitUntil: "networkidle0",
+      });
+
+      t.assert.snapshot(response.status());
+      t.assert.snapshot(consoleMessages.map((message) => message.text()));
+      t.assert.snapshot(pageErrors);
+    });
+
     it("should NOT allow websocket connection when origin is a non-loopback address mismatching host (loopback fix must not widen trust)", async (t) => {
       const options = {
         allowedHosts: "auto",

--- a/test/e2e/allowed-hosts.test.js
+++ b/test/e2e/allowed-hosts.test.js
@@ -1915,10 +1915,12 @@ describe("allowed hosts", () => {
           pageErrors.push(error);
         });
 
-      // Simulate: browser opens from localhost, but OS resolved
-      // 'localhost' to '::1' (IPv6) so host header is the IPv6 address
+      // Simulate: page loaded via localhost, but a WS client built the
+      // connection URL using the IPv6 loopback, so the Host header is
+      // the bracketed IPv6 form (per RFC 3986/7230) while Origin keeps
+      // the original 'localhost'.
       const headersLocalhostOriginIPv6Host = {
-        host: "::1",
+        host: "[::1]",
         origin: "http://localhost",
       };
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

This is a follow-up to webpack/webpack-cli#4715, where Alexander pointed out after merging. That PR fixed the webpack-cli templates by removing the hardcoded `host: "localhost"` that was causing WebSocket disconnection loops. But the root cause lives deeper, in webpack-dev-server itself.

When `host: 'localhost'` is configured, the OS decides at bind time whether `localhost` resolves to `127.0.0.1` (IPv4) or `::1` (IPv6). This is OS-dependent and not under the user's control, Windows 10/11 with modern network stacks commonly prioritizes IPv6, linux `127.0.0.1`

During the WebSocket handshake, `createWebSocketServer()` calls `isSameOrigin()` which compares the parsed `origin` header against the parsed `host` header. When the OS resolves `localhost` to `::1`, the browser sends:

```
origin: http://localhost
host:   ::1
```
The final line of `isSameOrigin()` is a strict string comparison:

```js
return origin === host; // "localhost" === "::1" → false
```
This causes the server to reject the WebSocket connection and send `Invalid Host/Origin header` back to the client, triggering an infinite reconnection loop visible in the browser console:

```
[webpack-dev-server] Invalid Host/Origin header
[webpack-dev-server] Disconnected!
[webpack-dev-server] Trying to reconnect...
```

This happens even though `localhost`, `127.0.0.1`, and `::1` are all loopback addresses and already individually trusted by `isValidHost()` earlier in the same handshake check.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
a fix when host is set to `localhost`
<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**
Four tests added to `test/e2e/allowed-hosts.test.js` inside the existing `describe("check host headers")` block, following the same direct `server.isSameOrigin()` call pattern as existing `isValidHost()` 
<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

No, and this fix does not widen the trust boundary in any way. Here is the exact reasoning:

- All three values are already individually trusted. `isValidHost()`, called earlier in the same WebSocket handshake, already passes `localhost`, `127.0.0.1`, and `::1` unconditionally. This fix only resolves the inconsistency when comparing two values that are both already trusted.

- Both sides must be loopback simultaneously. The condition uses `&&`, it only passes when *both* `origin` and `host` are in the loopback set. The `host` header comes from the server's own socket binding. An external attacker cannot control the server's `host` header to be `127.0.0.1` or `::1`.

- Browsers enforce origin strictly. A page served from `https://evil.com` will always send `Origin: https://evil.com`. No browser will send `Origin: http://localhost` for a cross-origin request from an external site, making spoofing of the loopback `origin` impossible.

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**
no need
<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**
no
<!-- If you have used AI, please state so here. Explain how you used it. 
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->