### PR TITLE
types: Restrict client property to false or ClientConfiguration

### DIFF
--- a/types/lib/Server.d.ts
+++ b/types/lib/Server.d.ts
@@ -1832,7 +1832,7 @@ type Configuration<
   proxy?: ProxyConfigArray | undefined;
   open?: (boolean | string | Open | Array<string | Open>) | undefined;
   setupExitSignals?: boolean | undefined;
-  client?: (boolean | ClientConfiguration) | undefined;
+  client?: (false | ClientConfiguration) | undefined;
   headers?:
     | (
         | Headers


### PR DESCRIPTION

`client: true` is never documented nor supported. It is confusing to support `client: true` in types.

Schema here:

https://github.com/webpack/webpack-dev-server/blob/df073c53a8cefb54210b43813fa6ee60364a554e/lib/options.json#L50-L85

Docs here:

https://webpack.js.org/configuration/dev-server/#devserverclient
