### PR TITLE
fix: allow undefined for Server constructor options argument

### DIFF
--- a/.changeset/server-options-undefined-type.md
+++ b/.changeset/server-options-undefined-type.md
@@ -1,0 +1,10 @@
+---
+"webpack-dev-server": patch
+---
+
+fix: allow `undefined` for the `Server` constructor `options` argument
+
+The constructor type was narrowed to `Configuration<A, S>` in 5.2.3, which broke
+passing `config.devServer` (typed as `DevServerConfiguration | undefined`) without
+a non-null assertion or fallback. The `options` argument is now `Configuration<A, S> | undefined`
+again and defaults to an empty object, restoring the previous behaviour.

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -325,11 +325,14 @@ const DEFAULT_ALLOWED_PROTOCOLS = /^(file|.+-extension):/i;
  */
 class Server {
   /**
-   * @param {Configuration<A, S>} options options
+   * @param {Configuration<A, S> | undefined} options options
    * @param {Compiler | MultiCompiler} compiler compiler
    */
   constructor(options, compiler) {
-    validate(/** @type {Schema} */ (schema), options, {
+    /** @type {Configuration<A, S>} */
+    const normalizedOptions = options || {};
+
+    validate(/** @type {Schema} */ (schema), normalizedOptions, {
       name: "Dev Server",
       baseDataPath: "options",
     });
@@ -339,7 +342,7 @@ class Server {
      * @type {ReturnType<Compiler["getInfrastructureLogger"]>}
      */
     this.logger = this.compiler.getInfrastructureLogger("webpack-dev-server");
-    this.options = options;
+    this.options = normalizedOptions;
     /**
      * @type {FSWatcher[]}
      */

--- a/test/normalize-options.test.js
+++ b/test/normalize-options.test.js
@@ -640,4 +640,19 @@ describe("normalize options", () => {
       }
     });
   }
+
+  it("should default options to an empty object when omitted", async () => {
+    const webpackConfig = require("./fixtures/simple-config/webpack.config");
+
+    const compiler = webpack(webpackConfig);
+    const server = new Server(undefined, compiler);
+
+    expect(server.options).toEqual({});
+
+    try {
+      await server.start();
+    } finally {
+      await server.stop();
+    }
+  });
 });

--- a/types/lib/Server.d.ts
+++ b/types/lib/Server.d.ts
@@ -1173,10 +1173,13 @@ declare class Server<
    */
   private static isWebTarget;
   /**
-   * @param {Configuration<A, S>} options options
+   * @param {Configuration<A, S> | undefined} options options
    * @param {Compiler | MultiCompiler} compiler compiler
    */
-  constructor(options: Configuration<A, S>, compiler: Compiler | MultiCompiler);
+  constructor(
+    options: Configuration<A, S> | undefined,
+    compiler: Compiler | MultiCompiler,
+  );
   compiler: import("webpack").Compiler | import("webpack").MultiCompiler;
   /**
    * @type {ReturnType<Compiler["getInfrastructureLogger"]>}


### PR DESCRIPTION
### What kind of change does this PR introduce?

Bug fix.

### Did you add or update the examples?

No — this is a type/behaviour fix with no user-facing example.

### Summary

In 5.2.3 (#5535) the `Server` constructor `options` parameter type was narrowed from `Configuration<A, S> | undefined` to `Configuration<A, S>`. This is a breaking change in a patch release. Restores the original public contract and regenerates types via `npm run build:types`.

Closes #5685