### PR TITLE
fix: reject cross-site requests to open-editor and invalidate endpoints

### DIFF
--- a/.changeset/fix-cross-site-request-forgery.md
+++ b/.changeset/fix-cross-site-request-forgery.md
@@ -1,0 +1,5 @@
+---
+"webpack-dev-server": patch
+---
+
+Reject cross-site requests to the internal `open-editor` and `invalidate` endpoints. They performed state-changing actions (opening a file in the editor, forcing a recompilation) on any GET request, so a page the developer visited could trigger them. They now require a same-origin request, validated via `Sec-Fetch-Site` with an `Origin`/`Host` fallback.

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -2084,6 +2084,12 @@ class Server {
           return;
         }
 
+        if (!this.#isSameOriginRequest(req)) {
+          res.statusCode = 403;
+          res.end("Cross-Origin request blocked");
+          return;
+        }
+
         this.invalidate();
 
         res.end();
@@ -2102,6 +2108,12 @@ class Server {
       middleware: async (req, res, next) => {
         if (req.method !== "GET" && req.method !== "HEAD") {
           next();
+          return;
+        }
+
+        if (!this.#isSameOriginRequest(req)) {
+          res.statusCode = 403;
+          res.end("Cross-Origin request blocked");
           return;
         }
 
@@ -3286,6 +3298,36 @@ class Server {
     }
 
     return origin === host;
+  }
+
+  /**
+   * Determines whether a request was initiated from the dev server's own
+   * origin, to reject cross-site request forgery on state-changing endpoints.
+   * @param {Request} req request
+   * @returns {boolean} true when the request can be trusted as same-origin
+   */
+  #isSameOriginRequest(req) {
+    const headers =
+      /** @type {{ [key: string]: string | undefined }} */
+      (req.headers);
+
+    const secFetchSite = headers["sec-fetch-site"];
+
+    // Prefer `Sec-Fetch-Site`: browsers send it even for same-origin GET
+    // `fetch`es (which omit `Origin`), and a cross-site page cannot forge it.
+    // `none` is a user-initiated navigation.
+    if (typeof secFetchSite === "string") {
+      return secFetchSite === "same-origin" || secFetchSite === "none";
+    }
+
+    // Without `Sec-Fetch-*` metadata (non-browser/legacy clients): a request
+    // with no `Origin` header was not initiated by another origin's script;
+    // otherwise fall back to the `Origin`/`Host` comparison.
+    if (typeof headers.origin !== "string") {
+      return true;
+    }
+
+    return this.isSameOrigin(headers);
   }
 
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "graceful-fs": "^4.2.11",
         "http-proxy-middleware": "^4.1.1",
         "ipaddr.js": "^2.3.0",
-        "launch-editor": "^2.13.2",
+        "launch-editor": "^2.14.1",
         "open": "^11.0.0",
         "p-retry": "^8.0.0",
         "schema-utils": "^4.3.3",
@@ -12648,13 +12648,13 @@
       }
     },
     "node_modules/launch-editor": {
-      "version": "2.13.2",
-      "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.13.2.tgz",
-      "integrity": "sha512-4VVDnbOpLXy/s8rdRCSXb+zfMeFR0WlJWpET1iA9CQdlZDfwyLjUuGQzXU4VeOoey6AicSAluWan7Etga6Kcmg==",
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.14.1.tgz",
+      "integrity": "sha512-QWBrQsMpH7gPr965dsKD/3cKWiNoTjpATQf++Xq63N6sKRGMwlVXz41O1IZTMfZQgBctD/K5Zt06+/I6pP6+HA==",
       "license": "MIT",
       "dependencies": {
         "picocolors": "^1.1.1",
-        "shell-quote": "^1.8.3"
+        "shell-quote": "^1.8.4"
       }
     },
     "node_modules/less": {
@@ -17148,9 +17148,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.9.0.tgz",
+      "integrity": "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "graceful-fs": "^4.2.11",
     "http-proxy-middleware": "^4.1.1",
     "ipaddr.js": "^2.3.0",
-    "launch-editor": "^2.13.2",
+    "launch-editor": "^2.14.1",
     "open": "^11.0.0",
     "p-retry": "^8.0.0",
     "schema-utils": "^4.3.3",

--- a/test/e2e/cross-origin-request.test.js
+++ b/test/e2e/cross-origin-request.test.js
@@ -1,5 +1,5 @@
 import http from "node:http";
-import { afterEach, describe, it } from "node:test";
+import { afterEach, beforeEach, describe, it } from "node:test";
 import { expect } from "expect";
 import webpack from "webpack";
 import Server from "../../lib/Server.js";
@@ -367,5 +367,177 @@ describe("cross-origin resource policy header", () => {
 
     expect(res.status).toBe(200);
     expect(res.headers["cross-origin-resource-policy"]).toBeUndefined();
+  });
+});
+
+// State-changing internal endpoints must reject cross-site requests so a page
+// the developer visits cannot trigger them (CSRF).
+describe("cross-site request forgery on state-changing endpoints", () => {
+  const devServerPort = port1;
+
+  let server;
+
+  beforeEach(async () => {
+    const compiler = webpack(config);
+    server = new Server(
+      { port: devServerPort, allowedHosts: "auto" },
+      compiler,
+    );
+
+    await server.start();
+  });
+
+  afterEach(async () => {
+    if (server) {
+      await server.stop();
+      // Allow the port to be fully released before the next test
+      await new Promise((resolve) => {
+        setTimeout(resolve, 100);
+      });
+      server = null;
+    }
+  });
+
+  function request(path, headers = {}) {
+    return new Promise((resolve, reject) => {
+      const req = http.get(
+        `http://localhost:${devServerPort}${path}`,
+        { headers },
+        (res) => {
+          let body = "";
+          res.on("data", (chunk) => {
+            body += chunk;
+          });
+          res.on("end", () => {
+            resolve({ status: res.statusCode, body });
+          });
+        },
+      );
+      req.on("error", reject);
+    });
+  }
+
+  for (const endpoint of [
+    "/webpack-dev-server/invalidate",
+    "/webpack-dev-server/open-editor",
+  ]) {
+    it(`should block cross-site requests to ${endpoint}`, async () => {
+      const res = await request(endpoint, {
+        "sec-fetch-mode": "cors",
+        "sec-fetch-site": "cross-site",
+      });
+
+      expect(res.status).toBe(403);
+    });
+
+    it(`should allow same-origin requests to ${endpoint}`, async () => {
+      const res = await request(endpoint, {
+        "sec-fetch-mode": "cors",
+        "sec-fetch-site": "same-origin",
+      });
+
+      expect(res.status).toBe(200);
+    });
+
+    it(`should allow user-initiated navigations to ${endpoint}`, async () => {
+      const res = await request(endpoint, { "sec-fetch-site": "none" });
+
+      expect(res.status).toBe(200);
+    });
+  }
+
+  it("should block requests with a cross-origin Origin and no Sec-Fetch metadata", async () => {
+    const res = await request("/webpack-dev-server/invalidate", {
+      origin: "http://evil.example",
+    });
+
+    expect(res.status).toBe(403);
+  });
+
+  it("should allow requests without Sec-Fetch metadata or Origin (e.g. curl)", async () => {
+    const res = await request("/webpack-dev-server/invalidate");
+
+    expect(res.status).toBe(200);
+  });
+});
+
+// Same as above, but driven by a real browser so the cross-site requests carry
+// browser-generated `Sec-Fetch-*` metadata (and the same-origin GET `fetch`
+// omits the `Origin` header, exactly like the overlay client).
+describe("cross-site request forgery on state-changing endpoints (browser)", () => {
+  const devServerPort = port1;
+  const htmlServerPort = port2;
+  const htmlServerHost = "127.0.0.1";
+
+  const openEditorUrl = `http://localhost:${devServerPort}/webpack-dev-server/open-editor`;
+  const invalidateUrl = `http://localhost:${devServerPort}/webpack-dev-server/invalidate`;
+
+  let server;
+  let htmlServer;
+  let page;
+  let browser;
+
+  beforeEach(async () => {
+    const compiler = webpack(config);
+    server = new Server(
+      { port: devServerPort, allowedHosts: "auto" },
+      compiler,
+    );
+
+    await server.start();
+
+    htmlServer = http.createServer((req, res) => {
+      res.writeHead(200, { "Content-Type": "text/html" });
+      res.end("<!doctype html><html><body></body></html>");
+    });
+
+    await new Promise((resolve) => {
+      htmlServer.listen(htmlServerPort, htmlServerHost, resolve);
+    });
+
+    ({ page, browser } = await runBrowser());
+  });
+
+  afterEach(async () => {
+    await browser.close();
+    htmlServer.close();
+    await server.stop();
+  });
+
+  it("should block a cross-site iframe navigation to /open-editor", async () => {
+    await page.goto(`http://${htmlServerHost}:${htmlServerPort}/`);
+
+    const responsePromise = page.waitForResponse(openEditorUrl);
+    await page.evaluate((url) => {
+      const iframe = document.createElement("iframe");
+      iframe.src = url;
+      document.body.append(iframe);
+    }, openEditorUrl);
+
+    expect((await responsePromise).status()).toBe(403);
+  });
+
+  it("should block a cross-site iframe navigation to /invalidate", async () => {
+    await page.goto(`http://${htmlServerHost}:${htmlServerPort}/`);
+
+    const responsePromise = page.waitForResponse(invalidateUrl);
+    await page.evaluate((url) => {
+      const iframe = document.createElement("iframe");
+      iframe.src = url;
+      document.body.append(iframe);
+    }, invalidateUrl);
+
+    expect((await responsePromise).status()).toBe(403);
+  });
+
+  it("should allow the same-origin overlay fetch to /open-editor", async () => {
+    await page.goto(`http://localhost:${devServerPort}/`);
+
+    const responsePromise = page.waitForResponse(openEditorUrl);
+    await page.evaluate(() => {
+      fetch("/webpack-dev-server/open-editor").catch(() => {});
+    });
+
+    expect((await responsePromise).status()).toBe(200);
   });
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

Basically, this only protects against external websites calling those endpoints. It doesn't protect against Node.js scripts or `curl`, since in those cases the headers can be freely modified.

In contrast, when a request is made with `fetch()` from a web page, Chrome automatically sends the `Sec-Fetch-Site` header and doesn't let the page override it, even if an attacker tries. The same applies to the `Origin` header—it can't be spoofed by JavaScript running in the browser.

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it. 
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->