### PR TITLE
chore: remove unused @types/node-forge

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webpack-dev-server",
-  "version": "5.2.5",
+  "version": "6.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webpack-dev-server",
-      "version": "5.2.5",
+      "version": "6.0.0",
       "license": "MIT",
       "dependencies": {
         "@types/bonjour": "^3.5.13",
@@ -53,7 +53,6 @@
         "@types/compression": "^1.7.2",
         "@types/graceful-fs": "^4.1.9",
         "@types/node": "^24.0.14",
-        "@types/node-forge": "^1.3.1",
         "@types/picomatch": "^4.0.2",
         "@types/trusted-types": "^2.0.7",
         "acorn": "^8.14.0",
@@ -4865,16 +4864,6 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
-      }
-    },
-    "node_modules/@types/node-forge": {
-      "version": "1.3.14",
-      "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.14.tgz",
-      "integrity": "sha512-mhVF2BnD4BO+jtOp7z1CdzaK4mbuK0LLQYAvdOLqHTavxFNq4zA1EmYkpnFjP8HOUzedfQkRnp0E2ulSAYSzAw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/@types/picomatch": {

--- a/package.json
+++ b/package.json
@@ -99,7 +99,6 @@
     "@types/compression": "^1.7.2",
     "@types/graceful-fs": "^4.1.9",
     "@types/node": "^24.0.14",
-    "@types/node-forge": "^1.3.1",
     "@types/picomatch": "^4.0.2",
     "@types/trusted-types": "^2.0.7",
     "acorn": "^8.14.0",


### PR DESCRIPTION
**Summary**

Removes the unused `@types/node-forge` development dependency.

It was originally needed by `selfsigned` v2, which depended on `node-forge`.
`selfsigned` v5 removed both `node-forge` and its type dependency in favor of
`@peculiar/x509` and `pkijs`. No source files or generated types resolve
`node-forge` anymore.

For context:

- [`@types/node-forge` was added alongside `selfsigned` v2](https://github.com/webpack/webpack-dev-server/commit/d67b1a96ec3364470b2168c1cf3bac2ce2ad8fa0).
- [`selfsigned` v5 removed its `node-forge` dependency](https://github.com/webpack/webpack-dev-server/commit/9704dc52e3f696ae1446428c25882745e9b65cbb).

No changeset is included because this is a maintenance-only change with no
user-facing impact.

**What kind of change does this PR introduce?**

chore

**Did you add tests for your changes?**

No. This change only removes an unused type-only development dependency.

Validated with:

- `npm run lint:types`
- `npm run lint:types-client`

**Does this PR introduce a breaking change?**

No.

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

No documentation updates are needed.

**Use of AI**

AI assistance was used to trace the dependency history, inspect the current
dependency tree and type resolution, and draft this PR description. The
resulting change and validation commands were reviewed before submission.