### PR TITLE
fix: honor client reconnect, overlay and URL configuration

### DIFF
--- a/.changeset/honor-client-configuration.md
+++ b/.changeset/honor-client-configuration.md
@@ -1,0 +1,5 @@
+---
+"webpack-dev-server": patch
+---
+
+Honor reconnect limits before the first connection, preserve socket URL credentials and query values, filter mixed overlay messages, and recognize visual progress modes in client configuration.

--- a/client-src/index.js
+++ b/client-src/index.js
@@ -34,7 +34,7 @@ import sendMessage from "./utils/sendMessage.js";
  * @typedef {object} Options
  * @property {boolean} hot true when hot enabled, otherwise false
  * @property {boolean} liveReload true when live reload enabled, otherwise false
- * @property {boolean} progress true when need to show progress, otherwise false
+ * @property {boolean | "linear" | "circular"} progress progress display mode
  * @property {boolean | OverlayOptions} overlay overlay options
  * @property {LogLevel=} logging logging level
  * @property {number=} reconnect count of allowed reconnection
@@ -129,10 +129,13 @@ const parseURL = (resourceQuery) => {
     const searchParams = resourceQuery.slice(1).split("&");
 
     for (let i = 0; i < searchParams.length; i++) {
-      const pair = searchParams[i].split("=");
+      const parameter = searchParams[i].replace(/\+/g, " ");
+      const separator = parameter.indexOf("=");
+      const key = separator === -1 ? parameter : parameter.slice(0, separator);
+      const value = separator === -1 ? "" : parameter.slice(separator + 1);
 
       /** @type {EXPECTED_ANY} */
-      (result)[pair[0]] = decodeURIComponent(pair[1]);
+      (result)[decodeURIComponent(key)] = decodeURIComponent(value);
     }
   } else {
     // Else, get the url from the <script> this file was called with.
@@ -189,8 +192,15 @@ if (parsedResourceQuery["live-reload"] === "true") {
   enabledFeatures["Live Reloading"] = true;
 }
 
-if (parsedResourceQuery.progress === "true") {
-  options.progress = true;
+if (
+  parsedResourceQuery.progress === "true" ||
+  parsedResourceQuery.progress === "linear" ||
+  parsedResourceQuery.progress === "circular"
+) {
+  options.progress =
+    parsedResourceQuery.progress === "true"
+      ? true
+      : parsedResourceQuery.progress;
   enabledFeatures.Progress = true;
 }
 
@@ -440,7 +450,7 @@ const onSocketMessage = {
     options.reconnect = value;
   },
   /**
-   * @param {boolean} value progress value
+   * @param {boolean | "linear" | "circular"} value progress value
    */
   progress(value) {
     options.progress = value;
@@ -534,7 +544,7 @@ const onSocketMessage = {
         overlay.send({
           type: "BUILD_ERROR",
           level: "warning",
-          messages: warnings,
+          messages: warningsToDisplay,
         });
       }
     }
@@ -578,7 +588,7 @@ const onSocketMessage = {
         overlay.send({
           type: "BUILD_ERROR",
           level: "error",
-          messages: errors,
+          messages: errorsToDisplay,
         });
       }
     }
@@ -710,16 +720,30 @@ const createSocketURL = (parsedURL) => {
 
   let socketURLAuth = "";
 
+  /**
+   * @param {string} value credential
+   * @returns {string} decoded credential
+   */
+  const decodeAuth = (value) => {
+    if (!parsedURL.fromCurrentScript) return value;
+    try {
+      return decodeURIComponent(value);
+    } catch {
+      // URL accepts literal percent signs that are not valid escape sequences.
+      return value;
+    }
+  };
+
   // `new URL(urlString, [baseURLstring])` doesn't have `auth` property
   // Parse authentication credentials in case we need them
   if (parsedURL.username) {
-    socketURLAuth = parsedURL.username;
+    socketURLAuth = decodeAuth(parsedURL.username);
 
     // Since HTTP basic authentication does not allow empty username,
     // we only include password if the username is not empty.
     if (parsedURL.password) {
       // Result: <username>:<password>
-      socketURLAuth = socketURLAuth.concat(":", parsedURL.password);
+      socketURLAuth = socketURLAuth.concat(":", decodeAuth(parsedURL.password));
     }
   }
 

--- a/client-src/index.js
+++ b/client-src/index.js
@@ -134,8 +134,12 @@ const parseURL = (resourceQuery) => {
       const key = separator === -1 ? parameter : parameter.slice(0, separator);
       const value = separator === -1 ? "" : parameter.slice(separator + 1);
 
-      /** @type {EXPECTED_ANY} */
-      (result)[decodeURIComponent(key)] = decodeURIComponent(value);
+      try {
+        /** @type {EXPECTED_ANY} */
+        (result)[decodeURIComponent(key)] = decodeURIComponent(value);
+      } catch {
+        // Ignore malformed percent escapes without preventing client startup.
+      }
     }
   } else {
     // Else, get the url from the <script> this file was called with.

--- a/client-src/socket.js
+++ b/client-src/socket.js
@@ -39,6 +39,10 @@ let timeout;
  * @param {number=} reconnect count of reconnections
  */
 function socket(url, handlers, reconnect) {
+  if (typeof reconnect !== "undefined") {
+    maxRetries = reconnect;
+  }
+
   client = new Client(url);
 
   client.onOpen(() => {
@@ -46,10 +50,6 @@ function socket(url, handlers, reconnect) {
 
     if (timeout) {
       clearTimeout(timeout);
-    }
-
-    if (typeof reconnect !== "undefined") {
-      maxRetries = reconnect;
     }
   });
 

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -197,8 +197,8 @@ function loadWebpackPeer() {
 /**
  * @typedef {object} ClientConfiguration
  * @property {"log" | "info" | "warn" | "error" | "none" | "verbose"=} logging logging
- * @property {(boolean | { warnings?: OverlayMessageOptions, errors?: OverlayMessageOptions, runtimeErrors?: OverlayMessageOptions })=} overlay overlay
- * @property {boolean=} progress progress
+ * @property {(boolean | { warnings?: OverlayMessageOptions, errors?: OverlayMessageOptions, runtimeErrors?: OverlayMessageOptions, trustedTypesPolicyName?: string })=} overlay overlay
+ * @property {(boolean | "linear" | "circular")=} progress progress
  * @property {(boolean | number)=} reconnect reconnect
  * @property {("ws" | string)=} webSocketTransport web socket transport
  * @property {(string | WebSocketURL)=} webSocketURL web socket URL

--- a/test/client/index.test.js
+++ b/test/client/index.test.js
@@ -212,6 +212,18 @@ describe("index", () => {
     });
   });
 
+  it("should ignore malformed resource query parameters", async () => {
+    socket.mockReset();
+    log.setLogLevel.mockReset();
+    globalThis.__resourceQuery = "?%ZZ=x&logging=warn&overlay=%ZZ";
+
+    const indexUrl = import.meta.resolve("../../client-src/index.js");
+    await import(`${indexUrl}?t=${Date.now()}-${Math.random()}`);
+
+    expect(socket).toHaveBeenCalledTimes(1);
+    expect(log.setLogLevel).toHaveBeenCalledWith("warn");
+  });
+
   it("should parse overlay options from resource query", async () => {
     // Re-evaluate client-src/index.js fresh after mutating __resourceQuery so
     // top-level option parsing runs again.

--- a/test/client/index.test.js
+++ b/test/client/index.test.js
@@ -191,6 +191,27 @@ describe("index", () => {
     });
   });
 
+  it("should send only overlay messages accepted by a filter", () => {
+    onSocketMessage.overlay({
+      warnings: (warning) => warning === "visible warning",
+      errors: (error) => error === "visible error",
+    });
+
+    onSocketMessage.warnings(["hidden warning", "visible warning"]);
+    expect(overlay.send).toHaveBeenLastCalledWith({
+      type: "BUILD_ERROR",
+      level: "warning",
+      messages: ["visible warning"],
+    });
+
+    onSocketMessage.errors(["hidden error", "visible error"]);
+    expect(overlay.send).toHaveBeenLastCalledWith({
+      type: "BUILD_ERROR",
+      level: "error",
+      messages: ["visible error"],
+    });
+  });
+
   it("should parse overlay options from resource query", async () => {
     // Re-evaluate client-src/index.js fresh after mutating __resourceQuery so
     // top-level option parsing runs again.

--- a/test/client/socket-helper.test.js
+++ b/test/client/socket-helper.test.js
@@ -121,4 +121,31 @@ describe("socket", () => {
     expect(typeof initializedInstance.onMessage).toBe("function");
     expect(typeof initializedInstance.onOpen).toBe("function");
   });
+
+  it("should honor a zero reconnect limit before the initial connection opens", async () => {
+    const MockClient = createMockClient();
+    const webSocketClientMock = mock.module(
+      "../../client-src/clients/WebSocketClient.js",
+      {
+        defaultExport: MockClient,
+      },
+    );
+
+    try {
+      const freshSocket = (
+        await import(
+          `../../client-src/socket.js?t=${Date.now()}-${Math.random()}`
+        )
+      ).default;
+      const close = fn();
+
+      freshSocket("my.url", { close }, 0);
+      MockClient.mock.instances[0].onClose.mock.calls[0][0]();
+
+      expect(close).toHaveBeenCalledTimes(1);
+      expect(MockClient.mock.calls).toHaveLength(1);
+    } finally {
+      webSocketClientMock.restore();
+    }
+  });
 });

--- a/test/client/utils/createSocketURL.test.js
+++ b/test/client/utils/createSocketURL.test.js
@@ -20,6 +20,16 @@ describe("'createSocketURL' function", () => {
     ["?protocol=http:", "https://example.com", "ws://example.com/ws"],
     ["?hostname=example.com", "http://example.com", "ws://example.com/ws"],
     [
+      "?%68%6f%73%74%6e%61%6d%65=example.com&username=first+last&password=a%3Db%2Bc",
+      "http://example.com",
+      "ws://first%20last:a%3Db%2Bc@example.com/ws",
+    ],
+    [
+      "?hostname=example.com&username=user&password=a=b",
+      "http://example.com",
+      "ws://user:a%3Db@example.com/ws",
+    ],
+    [
       "?username=username&password=password",
       "http://example.com",
       "ws://username:password@example.com/ws",
@@ -91,6 +101,11 @@ describe("'createSocketURL' function", () => {
       null,
       "http://user:password@localhost:8080/",
       "ws://user:password@localhost:8080/ws",
+    ],
+    [
+      null,
+      "http://user%40name:p%3Dword@localhost/",
+      "ws://user%40name:p%3Dword@localhost/ws",
     ],
     [null, "https://localhost:8080", "wss://localhost:8080/ws"],
     [null, "http://127.0.0.1", "ws://127.0.0.1/ws"],

--- a/test/e2e/__snapshots__/api.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/api.test.js.snap.webpack5
@@ -46,7 +46,6 @@ exports[`API > Server.checkHostHeader > should allow URLs with scheme for checki
   "WebSocket connection to 'ws://test.host:8157/ws' failed: Error in connection establishment: net::ERR_NAME_NOT_RESOLVED",
   "[webpack-dev-server] JSHandle@object",
   "[webpack-dev-server] Disconnected!",
-  "[webpack-dev-server] Trying to reconnect...",
 ]
 `;
 

--- a/test/e2e/api.test.js
+++ b/test/e2e/api.test.js
@@ -927,11 +927,15 @@ describe("API", () => {
         session.on("Network.webSocketCreated", (test) => {
           webSocketRequests.push(test);
         });
+        const webSocketClosed = new Promise((resolve) => {
+          session.once("Network.webSocketClosed", resolve);
+        });
 
         try {
           const response = await page.goto(`http://localhost:${port}/`, {
             waitUntil: "networkidle0",
           });
+          await webSocketClosed;
 
           if (!server.isValidHost(headers, "origin")) {
             throw new Error("Validation didn't fail");

--- a/test/e2e/api.test.js
+++ b/test/e2e/api.test.js
@@ -937,18 +937,11 @@ describe("API", () => {
             throw new Error("Validation didn't fail");
           }
 
-          await new Promise((resolve) => {
-            const interval = setInterval(() => {
-              const needFinish = consoleMessages.filter((message) =>
-                /Trying to reconnect/.test(message.text()),
-              );
-
-              if (needFinish.length > 0) {
-                clearInterval(interval);
-                resolve();
-              }
-            }, 100);
-          });
+          expect(
+            consoleMessages.some((message) =>
+              /Trying to reconnect/.test(message.text()),
+            ),
+          ).toBe(false);
 
           t.assert.snapshot(webSocketRequests[0].url);
 

--- a/types/lib/Server.d.ts
+++ b/types/lib/Server.d.ts
@@ -248,13 +248,14 @@ export type ClientConfiguration = {
             warnings?: OverlayMessageOptions;
             errors?: OverlayMessageOptions;
             runtimeErrors?: OverlayMessageOptions;
+            trustedTypesPolicyName?: string;
           }
       )
     | undefined;
   /**
    * progress
    */
-  progress?: boolean | undefined;
+  progress?: (boolean | "linear" | "circular") | undefined;
   /**
    * reconnect
    */


### PR DESCRIPTION
## Summary

- Apply reconnect limits before the first successful connection, including zero/false.
- Send only matching errors and warnings to the overlay when a predicate filters a mixed batch.
- Preserve embedded equals signs, plus/space semantics, encoded query keys, and current-script credentials.
- Recognize linear/circular progress modes and declare the already-supported public progress and Trusted Types options.

The existing API-origin test now asserts that `reconnect: false` produces no retry and its snapshot reflects the intended behavior. Focused regressions also cover the initial zero-retry path, mixed overlay predicates, query parsing, and credential encoding.

## Compatibility

No package, engine, peer, or public API removals. Disabled reconnects now remain disabled on initial failure; filtered messages stay hidden; socket credentials produce correctly encoded URLs.

## Verification

- Package build passes
- Client index tests: 14 passed
- Socket helper tests: 4 passed
- Socket URL tests: 47 passed
- Focused API-origin browser test passes with local Chrome
- Full lint suite passes: ESLint, Prettier, TypeScript (server/client), and spelling
- Changeset validation and `git diff --check` pass

Type: fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added linear and circular progress indicator options.
  * Added support for configuring a Trusted Types policy for the client overlay.
* **Bug Fixes**
  * Improved reconnection-limit handling, including disabling retries when set to zero.
  * Preserved and correctly decoded credentials in socket URLs.
  * Improved query-parameter parsing, including malformed and valueless parameters.
  * Ensured overlay notifications display only messages approved by configured filters.
* **Documentation**
  * Updated client configuration types and inline documentation for the new options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->