### PR TITLE
fix: preserve overlay lifecycle and keyboard access

### DIFF
--- a/.changeset/overlay-lifecycle.md
+++ b/.changeset/overlay-lifecycle.md
@@ -1,0 +1,5 @@
+---
+"webpack-dev-server": patch
+---
+
+Keep overlay dismissal and Trusted Types working across rebuilds, discard stale queued renders, encode editor filenames, and provide keyboard-accessible error controls with restored focus.

--- a/client-src/overlay.js
+++ b/client-src/overlay.js
@@ -5,50 +5,6 @@ import ansiHTML from "ansi-html-community";
 
 /** @typedef {import("./index.js").EXPECTED_ANY} EXPECTED_ANY */
 
-/**
- * @type {(input: string, position: number) => number | undefined}
- */
-// @ts-expect-error
-const getCodePoint = String.prototype.codePointAt
-  ? // @ts-expect-error
-    (input, position) => input.codePointAt(position)
-  : (input, position) =>
-      (input.charCodeAt(position) - 0xd800) * 0x400 +
-      input.charCodeAt(position + 1) -
-      0xdc00 +
-      0x10000;
-
-/**
- * @param {string} macroText macro text
- * @param {RegExp} macroRegExp macro reg exp
- * @param {(input: string) => string} macroReplacer macro replacer
- * @returns {string} result
- */
-const replaceUsingRegExp = (macroText, macroRegExp, macroReplacer) => {
-  macroRegExp.lastIndex = 0;
-  let replaceMatch = macroRegExp.exec(macroText);
-  let replaceResult;
-  if (replaceMatch) {
-    replaceResult = "";
-    let replaceLastIndex = 0;
-    do {
-      if (replaceLastIndex !== replaceMatch.index) {
-        replaceResult += macroText.slice(replaceLastIndex, replaceMatch.index);
-      }
-      const replaceInput = replaceMatch[0];
-      replaceResult += macroReplacer(replaceInput);
-      replaceLastIndex = replaceMatch.index + replaceInput.length;
-    } while ((replaceMatch = macroRegExp.exec(macroText)));
-
-    if (replaceLastIndex !== macroText.length) {
-      replaceResult += macroText.slice(replaceLastIndex);
-    }
-  } else {
-    replaceResult = macroText;
-  }
-  return replaceResult;
-};
-
 const references = {
   "<": "&lt;",
   ">": "&gt;",
@@ -66,15 +22,10 @@ function encode(text) {
     return "";
   }
 
-  return replaceUsingRegExp(text, /[<>'"&]/g, (input) => {
-    let result = references[/** @type {keyof typeof references} */ (input)];
-    if (!result) {
-      const code =
-        input.length > 1 ? getCodePoint(input, 0) : input.charCodeAt(0);
-      result = `&#${code};`;
-    }
-    return result;
-  });
+  return text.replace(
+    /[<>'"&]/g,
+    (input) => references[/** @type {keyof typeof references} */ (input)],
+  );
 }
 
 /**
@@ -450,8 +401,10 @@ const createOverlay = (options) => {
   let containerElement;
   /** @type {HTMLDivElement | null | undefined} */
   let headerElement;
-  /** @type {((element: HTMLDivElement) => void)[]} */
-  let onLoadQueue = [];
+  /** @type {((element: HTMLDivElement) => void) | undefined} */
+  let onLoad;
+  /** @type {Element | null | undefined} */
+  let previousActiveElement;
   /** @type {Omit<TrustedTypePolicy, "createScript" | "createScriptURL"> | undefined} */
   let overlayTrustedTypesPolicy;
 
@@ -474,7 +427,7 @@ const createOverlay = (options) => {
    */
   function createContainer(trustedTypesPolicyName) {
     // Enable Trusted Types if they are available in the current browser.
-    if (window.trustedTypes) {
+    if (window.trustedTypes && !overlayTrustedTypesPolicy) {
       overlayTrustedTypesPolicy = window.trustedTypes.createPolicy(
         trustedTypesPolicyName || "webpack-dev-server#overlay",
         {
@@ -485,8 +438,13 @@ const createOverlay = (options) => {
 
     iframeContainerElement = document.createElement("iframe");
     iframeContainerElement.id = "webpack-dev-server-client-overlay";
+    iframeContainerElement.title = "Webpack development server errors";
     iframeContainerElement.src = "about:blank";
     applyStyle(iframeContainerElement, iframeStyle);
+
+    previousActiveElement = document.activeElement;
+    // eslint-disable-next-line no-use-before-define
+    window.addEventListener("keydown", handleEscapeKey);
 
     iframeContainerElement.onload = () => {
       const contentElement =
@@ -531,10 +489,21 @@ const createOverlay = (options) => {
         (iframeContainerElement).contentDocument
       ).body.appendChild(contentElement);
 
-      onLoadQueue.forEach((onLoad) => {
-        onLoad(/** @type {HTMLDivElement} */ (contentElement));
-      });
-      onLoadQueue = [];
+      const iframeDocument = /** @type {Document} */ (
+        /** @type {HTMLIFrameElement} */ (iframeContainerElement)
+          .contentDocument
+      );
+      iframeDocument.documentElement.lang =
+        document.documentElement.lang || "en";
+      // eslint-disable-next-line no-use-before-define
+      iframeDocument.addEventListener("keydown", handleEscapeKey);
+
+      if (onLoad) {
+        onLoad(contentElement);
+        onLoad = undefined;
+      }
+
+      closeButtonElement.focus();
 
       /** @type {HTMLIFrameElement} */
       (iframeContainerElement).onload = null;
@@ -559,7 +528,8 @@ const createOverlay = (options) => {
       return;
     }
 
-    onLoadQueue.push(callback);
+    // Each callback renders the complete current message list.
+    onLoad = callback;
 
     if (iframeContainerElement) {
       return;
@@ -578,10 +548,24 @@ const createOverlay = (options) => {
     }
 
     // Clean up and reset internal state.
+    iframeContainerElement.onload = null;
+    iframeContainerElement.contentDocument?.removeEventListener(
+      "keydown",
+      // eslint-disable-next-line no-use-before-define
+      handleEscapeKey,
+    );
+    const restoreFocus = document.activeElement === iframeContainerElement;
     document.body.removeChild(iframeContainerElement);
 
     iframeContainerElement = null;
     containerElement = null;
+    headerElement = null;
+    onLoad = undefined;
+
+    if (restoreFocus && previousActiveElement instanceof HTMLElement) {
+      previousActiveElement.focus();
+    }
+    previousActiveElement = null;
   }
 
   // Compilation with errors (e.g. syntax error or missing modules).
@@ -608,19 +592,29 @@ const createOverlay = (options) => {
           padding: "1rem 1rem 1.5rem 1rem",
         });
 
-        const typeElement = document.createElement("div");
+        const canOpen = typeof message !== "string" && message.moduleIdentifier;
+        const typeElement = document.createElement(canOpen ? "button" : "div");
         const { header, body } = formatProblem(type, message);
 
         typeElement.innerText = header;
         applyStyle(typeElement, msgTypeStyle);
 
-        if (typeof message !== "string" && message.moduleIdentifier) {
-          applyStyle(typeElement, { cursor: "pointer" });
+        if (canOpen) {
+          typeElement.setAttribute("type", "button");
+          applyStyle(typeElement, {
+            cursor: "pointer",
+            background: "none",
+            border: "none",
+            padding: "0",
+            textAlign: "left",
+            display: "block",
+            lineHeight: "inherit",
+          });
           // element.dataset not supported in IE
           typeElement.setAttribute("data-can-open", "true");
           typeElement.addEventListener("click", () => {
             fetch(
-              `/webpack-dev-server/open-editor?fileName=${message.moduleIdentifier}`,
+              `/webpack-dev-server/open-editor?fileName=${encodeURIComponent(canOpen)}`,
             );
           });
         }

--- a/test/client/overlay-lifecycle.test.js
+++ b/test/client/overlay-lifecycle.test.js
@@ -1,0 +1,97 @@
+import "../helpers/jsdom-setup.js";
+
+import { afterEach, describe, it } from "node:test";
+import { expect } from "expect";
+import { fn } from "jest-mock";
+import { createOverlay } from "../../client-src/overlay.js";
+
+const buildError = (messages) => ({
+  type: "BUILD_ERROR",
+  level: "error",
+  messages,
+});
+
+const loadOverlay = () => {
+  const iframe = document.querySelector("#webpack-dev-server-client-overlay");
+
+  expect(iframe).not.toBeNull();
+  iframe.onload();
+
+  return iframe;
+};
+
+describe("overlay lifecycle", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    globalThis.fetch = originalFetch;
+    delete globalThis.trustedTypes;
+  });
+
+  it("renders only the latest complete message list while loading", () => {
+    const overlay = createOverlay({});
+
+    overlay.send(buildError(["first error"]));
+    overlay.send(buildError(["second error"]));
+
+    const iframe = loadOverlay();
+    const text = iframe.contentDocument.body.textContent;
+
+    expect(text).toContain("first error");
+    expect(text).toContain("second error");
+    expect(text.match(/first error/g)).toHaveLength(1);
+    expect(text.match(/second error/g)).toHaveLength(1);
+
+    overlay.send({ type: "DISMISS" });
+  });
+
+  it("discards a pending render when dismissed and supports reopening", () => {
+    const overlay = createOverlay({});
+
+    overlay.send(buildError(["stale error"]));
+    const staleIframe = document.querySelector(
+      "#webpack-dev-server-client-overlay",
+    );
+
+    overlay.send({ type: "DISMISS" });
+    expect(staleIframe.onload).toBeNull();
+    expect(document.body.contains(staleIframe)).toBe(false);
+
+    overlay.send(buildError(["current error"]));
+    const iframe = loadOverlay();
+    expect(iframe.contentDocument.body.textContent).toContain("current error");
+
+    iframe.contentDocument.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Escape" }),
+    );
+    expect(document.body.contains(iframe)).toBe(false);
+  });
+
+  it("reuses its Trusted Types policy and encodes editor paths", () => {
+    const createPolicy = fn(() => ({ createHTML: (value) => value }));
+    globalThis.trustedTypes = { createPolicy };
+    const fetchMock = fn(() => Promise.resolve());
+    globalThis.fetch = fetchMock;
+    const overlay = createOverlay({ trustedTypesPolicyName: "overlay-policy" });
+    const message = {
+      message: "broken",
+      moduleIdentifier: "src/a&b.js",
+    };
+
+    overlay.send(buildError([message]));
+    let iframe = loadOverlay();
+    iframe.contentDocument.querySelector("[data-can-open]").click();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/webpack-dev-server/open-editor?fileName=src%2Fa%26b.js",
+    );
+
+    overlay.send({ type: "DISMISS" });
+    overlay.send(buildError([message]));
+    iframe = loadOverlay();
+
+    expect(createPolicy).toHaveBeenCalledTimes(1);
+    overlay.send({ type: "DISMISS" });
+  });
+});

--- a/test/e2e/__snapshots__/overlay.test.js.snap.webpack5
+++ b/test/e2e/__snapshots__/overlay.test.js.snap.webpack5
@@ -45,6 +45,7 @@ exports[`overlay > should not show initially, then show on an error and allow to
 
   <iframe
     id="webpack-dev-server-client-overlay"
+    title="Webpack development server errors"
     src="about:blank"
     style="
       position: fixed;
@@ -123,7 +124,8 @@ exports[`overlay > should not show initially, then show on an error and allow to
           padding: 1rem 1rem 1.5rem;
         "
       >
-        <div
+        <button
+          type="button"
           data-can-open="true"
           style="
             color: rgb(232, 59, 70);
@@ -131,10 +133,19 @@ exports[`overlay > should not show initially, then show on an error and allow to
             margin-bottom: 1rem;
             font-family: sans-serif;
             cursor: pointer;
+            background: none;
+            border-width: medium;
+            border-style: none;
+            border-color: currentcolor;
+            border-image: none;
+            padding: 0px;
+            text-align: left;
+            display: block;
+            line-height: inherit;
           "
         >
           ERROR in ./foo.js 1:1
-        </div>
+        </button>
         <div
           style="
             line-height: 1.5;
@@ -177,6 +188,7 @@ exports[`overlay > should not show initially, then show on an error, then hide o
 
   <iframe
     id="webpack-dev-server-client-overlay"
+    title="Webpack development server errors"
     src="about:blank"
     style="
       position: fixed;
@@ -255,7 +267,8 @@ exports[`overlay > should not show initially, then show on an error, then hide o
           padding: 1rem 1rem 1.5rem;
         "
       >
-        <div
+        <button
+          type="button"
           data-can-open="true"
           style="
             color: rgb(232, 59, 70);
@@ -263,10 +276,19 @@ exports[`overlay > should not show initially, then show on an error, then hide o
             margin-bottom: 1rem;
             font-family: sans-serif;
             cursor: pointer;
+            background: none;
+            border-width: medium;
+            border-style: none;
+            border-color: currentcolor;
+            border-image: none;
+            padding: 0px;
+            text-align: left;
+            display: block;
+            line-height: inherit;
           "
         >
           ERROR in ./foo.js 1:1
-        </div>
+        </button>
         <div
           style="
             line-height: 1.5;
@@ -309,6 +331,7 @@ exports[`overlay > should not show initially, then show on an error, then show o
 
   <iframe
     id="webpack-dev-server-client-overlay"
+    title="Webpack development server errors"
     src="about:blank"
     style="
       position: fixed;
@@ -387,7 +410,8 @@ exports[`overlay > should not show initially, then show on an error, then show o
           padding: 1rem 1rem 1.5rem;
         "
       >
-        <div
+        <button
+          type="button"
           data-can-open="true"
           style="
             color: rgb(232, 59, 70);
@@ -395,10 +419,19 @@ exports[`overlay > should not show initially, then show on an error, then show o
             margin-bottom: 1rem;
             font-family: sans-serif;
             cursor: pointer;
+            background: none;
+            border-width: medium;
+            border-style: none;
+            border-color: currentcolor;
+            border-image: none;
+            padding: 0px;
+            text-align: left;
+            display: block;
+            line-height: inherit;
           "
         >
           ERROR in ./foo.js 1:1
-        </div>
+        </button>
         <div
           style="
             line-height: 1.5;
@@ -425,6 +458,7 @@ exports[`overlay > should not show initially, then show on an error, then show o
 
   <iframe
     id="webpack-dev-server-client-overlay"
+    title="Webpack development server errors"
     src="about:blank"
     style="
       position: fixed;
@@ -503,7 +537,8 @@ exports[`overlay > should not show initially, then show on an error, then show o
           padding: 1rem 1rem 1.5rem;
         "
       >
-        <div
+        <button
+          type="button"
           data-can-open="true"
           style="
             color: rgb(232, 59, 70);
@@ -511,10 +546,19 @@ exports[`overlay > should not show initially, then show on an error, then show o
             margin-bottom: 1rem;
             font-family: sans-serif;
             cursor: pointer;
+            background: none;
+            border-width: medium;
+            border-style: none;
+            border-color: currentcolor;
+            border-image: none;
+            padding: 0px;
+            text-align: left;
+            display: block;
+            line-height: inherit;
           "
         >
           ERROR in ./foo.js 1:1
-        </div>
+        </button>
         <div
           style="
             line-height: 1.5;
@@ -557,6 +601,7 @@ exports[`overlay > should show a warning after invalidation 1`] = `
 
   <iframe
     id="webpack-dev-server-client-overlay"
+    title="Webpack development server errors"
     src="about:blank"
     style="
       position: fixed;
@@ -668,6 +713,7 @@ exports[`overlay > should show a warning and error for initial compilation 1`] =
 
   <iframe
     id="webpack-dev-server-client-overlay"
+    title="Webpack development server errors"
     src="about:blank"
     style="
       position: fixed;
@@ -887,6 +933,7 @@ exports[`overlay > should show a warning and error for initial compilation and p
 
   <iframe
     id="webpack-dev-server-client-overlay"
+    title="Webpack development server errors"
     src="about:blank"
     style="
       position: fixed;
@@ -1025,6 +1072,7 @@ exports[`overlay > should show a warning and hide them after closing connection 
 
   <iframe
     id="webpack-dev-server-client-overlay"
+    title="Webpack development server errors"
     src="about:blank"
     style="
       position: fixed;
@@ -1144,6 +1192,7 @@ exports[`overlay > should show a warning for initial compilation 1`] = `
 
   <iframe
     id="webpack-dev-server-client-overlay"
+    title="Webpack development server errors"
     src="about:blank"
     style="
       position: fixed;
@@ -1255,6 +1304,7 @@ exports[`overlay > should show a warning when \"client.overlay.errors\" is \"tru
 
   <iframe
     id="webpack-dev-server-client-overlay"
+    title="Webpack development server errors"
     src="about:blank"
     style="
       position: fixed;
@@ -1366,6 +1416,7 @@ exports[`overlay > should show a warning when \"client.overlay.warnings\" is \"t
 
   <iframe
     id="webpack-dev-server-client-overlay"
+    title="Webpack development server errors"
     src="about:blank"
     style="
       position: fixed;
@@ -1477,6 +1528,7 @@ exports[`overlay > should show a warning when \"client.overlay\" is \"true\" 1`]
 
   <iframe
     id="webpack-dev-server-client-overlay"
+    title="Webpack development server errors"
     src="about:blank"
     style="
       position: fixed;
@@ -1588,6 +1640,7 @@ exports[`overlay > should show an ansi formatted error for initial compilation 1
 
   <iframe
     id="webpack-dev-server-client-overlay"
+    title="Webpack development server errors"
     src="about:blank"
     style="
       position: fixed;
@@ -1710,6 +1763,7 @@ exports[`overlay > should show an error after invalidation 1`] = `
 
   <iframe
     id="webpack-dev-server-client-overlay"
+    title="Webpack development server errors"
     src="about:blank"
     style="
       position: fixed;
@@ -1821,6 +1875,7 @@ exports[`overlay > should show an error for initial compilation 1`] = `
 
   <iframe
     id="webpack-dev-server-client-overlay"
+    title="Webpack development server errors"
     src="about:blank"
     style="
       position: fixed;
@@ -1932,6 +1987,7 @@ exports[`overlay > should show an error when \"client.overlay.errors\" is \"true
 
   <iframe
     id="webpack-dev-server-client-overlay"
+    title="Webpack development server errors"
     src="about:blank"
     style="
       position: fixed;
@@ -2043,6 +2099,7 @@ exports[`overlay > should show an error when \"client.overlay.warnings\" is \"tr
 
   <iframe
     id="webpack-dev-server-client-overlay"
+    title="Webpack development server errors"
     src="about:blank"
     style="
       position: fixed;
@@ -2154,6 +2211,7 @@ exports[`overlay > should show an error when \"client.overlay\" is \"true\" 1`] 
 
   <iframe
     id="webpack-dev-server-client-overlay"
+    title="Webpack development server errors"
     src="about:blank"
     style="
       position: fixed;
@@ -2440,6 +2498,7 @@ exports[`overlay > should show error when it is not filtered 1`] = `
 
   <iframe
     id="webpack-dev-server-client-overlay"
+    title="Webpack development server errors"
     src="about:blank"
     style="
       position: fixed;
@@ -2551,6 +2610,7 @@ exports[`overlay > should show overlay when Trusted Types are enabled 1`] = `
 
   <iframe
     id="webpack-dev-server-client-overlay"
+    title="Webpack development server errors"
     src="about:blank"
     style="
       position: fixed;
@@ -2662,6 +2722,7 @@ exports[`overlay > should show overlay when Trusted Types are enabled and the \"
 
   <iframe
     id="webpack-dev-server-client-overlay"
+    title="Webpack development server errors"
     src="about:blank"
     style="
       position: fixed;
@@ -2773,6 +2834,7 @@ exports[`overlay > should show overlay when \"Content-Security-Policy\" is \"def
 
   <iframe
     id="webpack-dev-server-client-overlay"
+    title="Webpack development server errors"
     src="about:blank"
     style="
       position: fixed;
@@ -2884,6 +2946,7 @@ exports[`overlay > should show warning when it is not filtered 1`] = `
 
   <iframe
     id="webpack-dev-server-client-overlay"
+    title="Webpack development server errors"
     src="about:blank"
     style="
       position: fixed;


### PR DESCRIPTION
## Summary

- Re-register Escape handling after dismissal and handle keyboard events inside the iframe.
- Focus the dismiss button and restore previous focus when the overlay owned it.
- Label the iframe, propagate the document language, and use a native keyboard-operable button for editor links.
- Render only the latest complete pending message list and discard callbacks when dismissed before load.
- Reuse the Trusted Types policy across reopenings.
- Encode filenames in editor query parameters.
- Replace the custom HTML-escaping loop and unreachable Unicode branch with equivalent native replacement.

The existing DOM snapshots are updated for the intentional iframe title and button markup. New focused lifecycle tests cover queued/stale renders, reopening and iframe Escape handling, Trusted Types policy reuse, and encoded editor paths.

## Compatibility

No public API, engine, or dependency changes. Error-link markup becomes a button; iframe title/language and focus behavior are intentional accessibility improvements. Reserved filename characters now reach the editor intact.

## Verification

- Full overlay browser E2E suite: 35 passed
- Focused overlay lifecycle suite: 3 passed
- Package build passes
- Full lint suite passes: ESLint, Prettier, TypeScript (server/client), and spelling
- Changeset validation and `git diff --check` pass
- The syntax-error fixture is clean after the run

Type: fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Overlay state now persists correctly across rebuilds and can be reopened after dismissal.
  - Stale renders are discarded to prevent outdated errors from appearing.
  - Trusted Types behavior remains consistent across updates.
  - Editor filenames are safely encoded when opening files.

- **Accessibility**
  - Added a descriptive title and language metadata to the error overlay.
  - Error controls are now keyboard accessible, with focus restored after dismissal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->