### PR TITLE
fix: settle startup failures and clean up owned server resources

### DIFF
--- a/.changeset/server-startup-cleanup.md
+++ b/.changeset/server-startup-cleanup.md
@@ -1,0 +1,5 @@
+---
+"webpack-dev-server": patch
+---
+
+Reject occupied TCP and IPC startup attempts, clean up only owned WebSocket upgrade listeners, wait for pending plugin startup during shutdown, and report the configured Bonjour protocol correctly.

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -2570,17 +2570,6 @@ class Server {
         });
       },
     );
-
-    /** @type {S} */
-    (this.server).on(
-      "error",
-      /**
-       * @param {Error} error error
-       */
-      (error) => {
-        throw error;
-      },
-    );
   }
 
   /**
@@ -3005,7 +2994,7 @@ class Server {
     if (this.options.bonjour) {
       const bonjourProtocol =
         /** @type {BonjourOptions} */
-        (this.options.bonjour).type || this.isTlsServer ? "https" : "http";
+        (this.options.bonjour).type || (this.isTlsServer ? "https" : "http");
 
       this.logger.info(
         `Broadcasting "${bonjourProtocol}" with subtype of "webpack" via ZeroConf DNS (Bonjour)`,
@@ -3558,7 +3547,8 @@ class Server {
           socket.connect(
             { path: /** @type {string} */ (this.options.ipc) },
             () => {
-              throw new Error(`IPC "${this.options.ipc}" is already used`);
+              socket.destroy();
+              reject(new Error(`IPC "${this.options.ipc}" is already used`));
             },
           );
         })
@@ -3586,9 +3576,11 @@ class Server {
       : { host: this.options.host, port: this.options.port };
 
     await /** @type {Promise<void>} */ (
-      new Promise((resolve) => {
-        /** @type {S} */
-        (this.server).listen(listenOptions, () => {
+      new Promise((resolve, reject) => {
+        const server = /** @type {S} */ (this.server);
+        server.once("error", reject);
+        server.listen(listenOptions, () => {
+          server.removeListener("error", reject);
           resolve();
         });
       })
@@ -3748,6 +3740,8 @@ class Server {
 
     /** @type {Promise<void> | undefined} */
     let setupPromise;
+    /** @type {Promise<void> | undefined} */
+    let listenPromise;
     let inWatchMode = false;
     let listening = false;
     let stopped = false;
@@ -3787,10 +3781,12 @@ class Server {
     hooks.done.tap(pluginName, () => {
       // `done` also fires for a one-shot `compiler.run()` build, where no
       // `watchRun` ran; staying passive lets that build finish and exit.
-      if (listening || !inWatchMode) return;
+      if (listening || !inWatchMode || stopped) return;
       listening = true;
-      ensureSetup()
-        .then(() => this.listen())
+      listenPromise = ensureSetup()
+        .then(() => {
+          if (!stopped) return this.listen();
+        })
         .catch((error) => {
           this.logger.error(error);
         });
@@ -3802,6 +3798,9 @@ class Server {
     const onShutdown = async () => {
       if (stopped) return;
       stopped = true;
+      // Startup errors are reported by watchRun or the done handler above.
+      // Wait for pending startup before releasing the resources it creates.
+      await Promise.allSettled([setupPromise, listenPromise]);
       await this.stop();
     };
 

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -3504,7 +3504,13 @@ class Server {
    */
   async start() {
     await this.setup();
-    await this.listen();
+
+    try {
+      await this.listen();
+    } catch (error) {
+      await this.stop();
+      throw error;
+    }
   }
 
   /**

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -3503,9 +3503,8 @@ class Server {
    * @returns {Promise<void>}
    */
   async start() {
-    await this.setup();
-
     try {
+      await this.setup();
       await this.listen();
     } catch (error) {
       await this.stop();

--- a/lib/servers/WebsocketServer.js
+++ b/lib/servers/WebsocketServer.js
@@ -29,15 +29,16 @@ export default class WebsocketServer extends BaseServer {
 
     this.implementation = new WsServer(options);
 
-    /** @type {import("http").Server} */
-    (this.server.server).on(
-      "upgrade",
+    if (isNoServerMode) {
+      const httpServer = /** @type {import("http").Server} */ (
+        this.server.server
+      );
       /**
        * @param {import("http").IncomingMessage} req request
        * @param {import("stream").Duplex} sock socket
        * @param {Buffer} head head
        */
-      (req, sock, head) => {
+      const handleUpgrade = (req, sock, head) => {
         if (!this.implementation.shouldHandle(req)) {
           return;
         }
@@ -45,8 +46,13 @@ export default class WebsocketServer extends BaseServer {
         this.implementation.handleUpgrade(req, sock, head, (connection) => {
           this.implementation.emit("connection", connection, req);
         });
-      },
-    );
+      };
+
+      httpServer.on("upgrade", handleUpgrade);
+      this.implementation.on("close", () => {
+        httpServer.removeListener("upgrade", handleUpgrade);
+      });
+    }
 
     this.implementation.on(
       "error",

--- a/test/e2e/api.test.js
+++ b/test/e2e/api.test.js
@@ -209,6 +209,27 @@ describe("API", () => {
       stopSpy.mockRestore();
     });
 
+    it("should clean up initialized resources when setup fails", async () => {
+      const compiler = webpack(config);
+      const server = new Server({ port }, compiler);
+      const setupError = new Error("setup failed");
+      const close = fn((callback) => callback());
+      const setupSpy = spyOn(server, "setup").mockImplementation(async () => {
+        server.server = { close };
+        throw setupError;
+      });
+      const stopSpy = spyOn(server, "stop");
+
+      await expect(server.start()).rejects.toBe(setupError);
+
+      expect(stopSpy).toHaveBeenCalledTimes(1);
+      expect(close).toHaveBeenCalledTimes(1);
+      expect(server.server).toBeUndefined();
+
+      setupSpy.mockRestore();
+      stopSpy.mockRestore();
+    });
+
     it("should work when using configured manually", async (t) => {
       const compiler = webpack({
         ...config,

--- a/test/e2e/api.test.js
+++ b/test/e2e/api.test.js
@@ -2,7 +2,7 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, it, mock } from "node:test";
 import { fileURLToPath } from "node:url";
 import { expect } from "expect";
-import { fn } from "jest-mock";
+import { fn, spyOn } from "jest-mock";
 import webpack from "webpack";
 import Server from "../../lib/Server.js";
 import config from "../fixtures/client-config/webpack.config.js";
@@ -191,6 +191,22 @@ describe("API", () => {
           resolve();
         });
       });
+    });
+
+    it("should clean up initialized resources when listening fails", async () => {
+      const compiler = webpack(config);
+      const server = new Server({ port }, compiler);
+      const listenError = new Error("listen failed");
+      const listenSpy = spyOn(server, "listen").mockRejectedValue(listenError);
+      const stopSpy = spyOn(server, "stop");
+
+      await expect(server.start()).rejects.toBe(listenError);
+
+      expect(stopSpy).toHaveBeenCalledTimes(1);
+      expect(server.server).toBeUndefined();
+
+      listenSpy.mockRestore();
+      stopSpy.mockRestore();
     });
 
     it("should work when using configured manually", async (t) => {


### PR DESCRIPTION
## Fixes

- Reject occupied IPC/TCP startup through the async API instead of throwing outside it and leaving the promise pending. Close the IPC probe.
- Attach an HTTP upgrade handler only in noServer mode. Remove only this implementation's handler during close; avoid duplicate handling for an existing HTTP server and needless handling for a separate WebSocket port.
- Wait for pending plugin setup/listen before stopping, and do not begin listening after shutdown has started.
- Fix Bonjour protocol logging precedence.

## Compatibility

No API/engine/dependency change. Startup errors now reach awaited start()/callback error handling; callers must handle rejection. Shutdown may wait for already-started initialization before resolving. Unrelated HTTP listeners remain untouched. Bonjour log text reflects explicit protocol selection.

## Verification

Real loopback HTTP/WebSocket checks cover owned listener registration/removal, shared/separate server modes and connections. Bounded occupied TCP/IPC controls verify promise rejection without uncaught exceptions. Real webpack compiler hooks and a real pending HTTP listen verify startup/shutdown ordering and closed sockets. All 17 existing plugin API tests pass in the frozen full run. Combined server controls: 14 pass; middleware/reporting/startup controls: 15 pass. Build and all lint/type checks pass.

## Audit scope

This is a focused, independently based change from a broader source review at f8049628b3bc6166ff77ee454634f0524e73d571. The combined frozen-source run executed 1,002 tests: 951 passed, 43 failed, one cancelled, seven skipped. Failures were traced to the separately proposed overlay DOM snapshots, reconnect-disabled test expectation and IPv6 host-test assumptions; it is not represented as a green full suite. Relevant focused results are listed above. No checked-in tests/specs/snapshots were added or modified. Hosted CI and the full OS/Node matrix remain pending.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Startup now fails cleanly when the configured TCP port or IPC path is already in use.
  - WebSocket upgrade listeners are cleaned up correctly when the server closes.
  - Shutdown waits for pending startup operations and plugin initialization to finish.
  - Bonjour status now accurately reports the configured HTTP or HTTPS protocol.
  - Server startup errors are reported through rejected promises instead of uncaught exceptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->