### PR TITLE
fix: export and type the custom server extension class

### DIFF
--- a/.changeset/export-base-server.md
+++ b/.changeset/export-base-server.md
@@ -1,0 +1,5 @@
+---
+"webpack-dev-server": patch
+---
+
+Export the documented `BaseServer` extension class and accept its constructors in the public `webSocketServer.type` declaration.

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -138,7 +138,7 @@ function loadWebpackPeer() {
 
 /**
  * @typedef {object} WebSocketServerConfiguration
- * @property {("ws" | string | (() => WebSocketServerConfiguration))=} type type
+ * @property {("ws" | string | typeof import("./servers/BaseServer.js").default)=} type type
  * @property {Record<string, EXPECTED_ANY>=} options options
  */
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,12 @@
       "default": "./lib/Server.js"
     },
     "./client/*": "./client/*",
+    "./lib/servers/BaseServer.js": {
+      "types": "./types/lib/servers/BaseServer.d.ts",
+      "import": "./lib/servers/BaseServer.js",
+      "require": "./dist/servers/BaseServer.js",
+      "default": "./lib/servers/BaseServer.js"
+    },
     "./package.json": "./package.json"
   },
   "main": "./dist/Server.js",

--- a/scripts/finalize-cjs-build.mjs
+++ b/scripts/finalize-cjs-build.mjs
@@ -12,9 +12,8 @@ import { fileURLToPath } from "node:url";
 //    files in `dist/` as CommonJS regardless of the package's root
 //    `"type": "module"`.
 // 2. Babel emits the loader as `exports.default`. Append the `module.exports`
-//    unwrap so `require("webpack-dev-server")` returns the `Server` class
-//    directly (parity with the pre-ESM `module.exports = Server`), while
-//    `.default` keeps pointing at it for interop.
+//    unwrap so the public Server and BaseServer entrypoints return their
+//    classes directly, while `.default` keeps pointing at them for interop.
 
 const CJS_DIR = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -27,7 +26,9 @@ await writeFile(
   `${JSON.stringify({ type: "commonjs" }, null, 2)}\n`,
 );
 
-await appendFile(
-  path.join(CJS_DIR, "Server.js"),
-  "module.exports = exports.default;\nmodule.exports.default = exports.default;\n",
-);
+for (const entry of ["Server.js", "servers/BaseServer.js"]) {
+  await appendFile(
+    path.join(CJS_DIR, entry),
+    "module.exports = exports.default;\nmodule.exports.default = exports.default;\n",
+  );
+}

--- a/types/lib/Server.d.ts
+++ b/types/lib/Server.d.ts
@@ -157,7 +157,9 @@ export type WebSocketServerConfiguration = {
   /**
    * type
    */
-  type?: ("ws" | string | (() => WebSocketServerConfiguration)) | undefined;
+  type?:
+    | ("ws" | string | typeof import("./servers/BaseServer.js").default)
+    | undefined;
   /**
    * options
    */


### PR DESCRIPTION
## Fixes

- Export the documented webpack-dev-server/lib/servers/BaseServer.js extension point for ESM, CommonJS and TypeScript consumers.
- Unwrap the CommonJS class consistently with the main Server entrypoint, retaining .default interoperability.
- Type webSocketServer.type as a constructor extending BaseServer instead of a zero-argument callable returning a configuration object.

## Compatibility

Restores the documented extension path blocked by the v6 export map. No runtime/engine/dependency removal. The declaration now accepts the class actually instantiated at runtime; invalid callable factories may require correction to constructible classes.

## Verification

Unchanged v6 export map reproduces ERR_PACKAGE_PATH_NOT_EXPORTED. Real ESM and CommonJS subclasses construct successfully; CommonJS default interop is retained. Strict NodeNext TypeScript consumer accepts a custom subclass in webSocketServer configuration. Build and full lint/types/spelling/formatting pass.

## Audit scope

This is a focused, independently based change from a broader source review at f8049628b3bc6166ff77ee454634f0524e73d571. The combined frozen-source run executed 1,002 tests: 951 passed, 43 failed, one cancelled, seven skipped. Failures were traced to the separately proposed overlay DOM snapshots, reconnect-disabled test expectation and IPv6 host-test assumptions; it is not represented as a green full suite. Relevant focused results are listed above. No checked-in tests/specs/snapshots were added or modified. Hosted CI and the full OS/Node matrix remain pending.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Exported the `BaseServer` class as a public package entry point.
  - WebSocket server configuration now accepts custom server class constructors.
  - Added TypeScript declarations for the new public export.
  - Improved CommonJS imports so server classes are returned directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->