### PR TITLE
tests: stabilize tests & ci

### DIFF
--- a/test/e2e/overlay.test.js
+++ b/test/e2e/overlay.test.js
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { describe, it, mock } from "node:test";
+import { afterEach, describe, it, mock } from "node:test";
 import { fileURLToPath } from "node:url";
 import { expect } from "expect";
 import fs from "graceful-fs";
@@ -15,6 +15,11 @@ import portsMap from "../ports-map.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const port = portsMap.overlay;
+const pathToOverlayFixture = path.resolve(
+  __dirname,
+  "../fixtures/overlay-config/foo.js",
+);
+const overlayFixtureCode = fs.readFileSync(pathToOverlayFixture);
 
 class ErrorPlugin {
   constructor(message, skipCounter) {
@@ -75,6 +80,17 @@ const delay = (ms) =>
   });
 
 describe("overlay", () => {
+  // Several tests below break this fixture on purpose so that the compiler
+  // emits an error, then repair it once they are done. Repairing it here too
+  // means an assertion that fails in between cannot leave the fixture broken
+  // on disk, where it used to make every following test compile the broken
+  // file and turn a single mismatch into a cascade of failures.
+  afterEach(() => {
+    if (!fs.readFileSync(pathToOverlayFixture).equals(overlayFixtureCode)) {
+      fs.writeFileSync(pathToOverlayFixture, overlayFixtureCode);
+    }
+  });
+
   it("should show a warning for initial compilation", async (t) => {
     const compiler = webpack(config);
 
@@ -333,13 +349,7 @@ describe("overlay", () => {
         }),
       );
 
-      const pathToFile = path.resolve(
-        __dirname,
-        "../fixtures/overlay-config/foo.js",
-      );
-      const originalCode = fs.readFileSync(pathToFile);
-
-      fs.writeFileSync(pathToFile, "`;");
+      fs.writeFileSync(pathToOverlayFixture, "`;");
 
       await page.waitForSelector("#webpack-dev-server-client-overlay");
 
@@ -362,7 +372,7 @@ describe("overlay", () => {
         }),
       );
 
-      fs.writeFileSync(pathToFile, originalCode);
+      fs.writeFileSync(pathToOverlayFixture, overlayFixtureCode);
 
       await page.waitForSelector("#webpack-dev-server-client-overlay", {
         hidden: true,
@@ -409,13 +419,7 @@ describe("overlay", () => {
         }),
       );
 
-      const pathToFile = path.resolve(
-        __dirname,
-        "../fixtures/overlay-config/foo.js",
-      );
-      const originalCode = fs.readFileSync(pathToFile);
-
-      fs.writeFileSync(pathToFile, "`;");
+      fs.writeFileSync(pathToOverlayFixture, "`;");
 
       await page.waitForSelector("#webpack-dev-server-client-overlay");
 
@@ -438,7 +442,7 @@ describe("overlay", () => {
         }),
       );
 
-      fs.writeFileSync(pathToFile, "`;a");
+      fs.writeFileSync(pathToOverlayFixture, "`;a");
 
       await page.waitForSelector("#webpack-dev-server-client-overlay", {
         hidden: true,
@@ -462,7 +466,7 @@ describe("overlay", () => {
         }),
       );
 
-      fs.writeFileSync(pathToFile, originalCode);
+      fs.writeFileSync(pathToOverlayFixture, overlayFixtureCode);
 
       await page.waitForSelector("#webpack-dev-server-client-overlay", {
         hidden: true,
@@ -509,13 +513,7 @@ describe("overlay", () => {
         }),
       );
 
-      const pathToFile = path.resolve(
-        __dirname,
-        "../fixtures/overlay-config/foo.js",
-      );
-      const originalCode = fs.readFileSync(pathToFile);
-
-      fs.writeFileSync(pathToFile, "`;");
+      fs.writeFileSync(pathToOverlayFixture, "`;");
 
       await page.waitForSelector("#webpack-dev-server-client-overlay");
 
@@ -560,7 +558,7 @@ describe("overlay", () => {
         }),
       );
 
-      fs.writeFileSync(pathToFile, originalCode);
+      fs.writeFileSync(pathToOverlayFixture, overlayFixtureCode);
     } finally {
       await browser.close();
       await server.stop();
@@ -588,13 +586,7 @@ describe("overlay", () => {
         waitUntil: "networkidle0",
       });
 
-      const pathToFile = path.resolve(
-        __dirname,
-        "../fixtures/overlay-config/foo.js",
-      );
-      const originalCode = fs.readFileSync(pathToFile);
-
-      fs.writeFileSync(pathToFile, "`;");
+      fs.writeFileSync(pathToOverlayFixture, "`;");
 
       await page.waitForSelector("#webpack-dev-server-client-overlay");
 
@@ -610,7 +602,7 @@ describe("overlay", () => {
         expect(mockLaunchEditorCb).toHaveBeenCalledTimes(1);
       });
 
-      fs.writeFileSync(pathToFile, originalCode);
+      fs.writeFileSync(pathToOverlayFixture, overlayFixtureCode);
     } finally {
       await browser.close();
       await server.stop();

--- a/test/e2e/target.test.js
+++ b/test/e2e/target.test.js
@@ -12,6 +12,7 @@ import "../helpers/jsdom-setup.js";
 import workerConfig from "../fixtures/worker-config/webpack.config.js";
 import workerConfigDevServerFalse from "../fixtures/worker-config-dev-server-false/webpack.config.js";
 import runBrowser from "../helpers/run-browser.js";
+import waitFor from "../helpers/wait-for.js";
 import portsMap from "../ports-map.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -141,6 +142,16 @@ describe("target", () => {
         waitUntil: "networkidle0",
       });
 
+      // The worker posts its messages after the navigation has settled, so
+      // wait for both of them instead of snapshotting whichever ones happened
+      // to arrive first.
+      await waitFor(
+        () =>
+          consoleMessages.filter((message) =>
+            message.text().includes("Worker said:"),
+          ).length === 2,
+      );
+
       t.assert.snapshot(
         sortByTerm(
           consoleMessages.map((message) => message.text()),
@@ -189,6 +200,16 @@ describe("target", () => {
       await page.goto(`http://localhost:${port}/`, {
         waitUntil: "networkidle0",
       });
+
+      // The worker posts its messages after the navigation has settled, so
+      // wait for both of them instead of snapshotting whichever ones happened
+      // to arrive first.
+      await waitFor(
+        () =>
+          consoleMessages.filter((message) =>
+            message.text().includes("Worker said:"),
+          ).length === 2,
+      );
 
       t.assert.snapshot(
         sortByTerm(

--- a/test/e2e/web-socket-communication.test.js
+++ b/test/e2e/web-socket-communication.test.js
@@ -6,6 +6,7 @@ import Server from "../../lib/Server.js";
 import WebsocketServer from "../../lib/servers/WebsocketServer.js";
 import config from "../fixtures/client-config/webpack.config.js";
 import runBrowser from "../helpers/run-browser.js";
+import waitFor from "../helpers/wait-for.js";
 import portsMap from "../ports-map.js";
 
 const port = portsMap["web-socket-communication"];
@@ -45,17 +46,14 @@ describe("web socket communication", () => {
         });
 
         await server.stop();
-        await new Promise((resolve) => {
-          const interval = setInterval(() => {
-            if (
-              consoleMessages.includes("[webpack-dev-server] Disconnected!")
-            ) {
-              clearInterval(interval);
-
-              resolve();
-            }
-          }, 100);
-        });
+        // Wait for the last message the client logs when the connection drops.
+        // Waiting only for "Disconnected!" would race with the reconnect line
+        // that the snapshot also records.
+        await waitFor(() =>
+          consoleMessages.includes(
+            "[webpack-dev-server] Trying to reconnect...",
+          ),
+        );
 
         t.assert.snapshot(consoleMessages);
         t.assert.snapshot(pageErrors);
@@ -93,18 +91,25 @@ describe("web socket communication", () => {
         await page.goto(`http://localhost:${port}/`, {
           waitUntil: "networkidle0",
         });
+        // Tearing down the browser below makes the client log "Disconnected!"
+        // and "Trying to reconnect...", and those can still reach the console
+        // listener before the CDP connection goes away. Record what the page
+        // logged while it was alive first, so the teardown cannot race into
+        // the snapshot.
+        const loadedConsoleMessages = consoleMessages.map((message) =>
+          message.text(),
+        );
+        const loadedPageErrors = [...pageErrors];
+
         await browser.close();
 
-        // Wait heartbeat
-        await new Promise((resolve) => {
-          setTimeout(() => {
-            resolve();
-          }, 200);
-        });
+        // Wait for the heartbeat to notice the client is gone. Polling keeps
+        // this quick on a fast machine without being too short on a slow one.
+        await waitFor(() => server.webSocketServer.clients.length === 0);
 
         expect(server.webSocketServer.clients).toHaveLength(0);
-        t.assert.snapshot(consoleMessages.map((message) => message.text()));
-        t.assert.snapshot(pageErrors);
+        t.assert.snapshot(loadedConsoleMessages);
+        t.assert.snapshot(loadedPageErrors);
       } finally {
         await server.stop();
       }

--- a/test/helpers/puppeteer-constants.js
+++ b/test/helpers/puppeteer-constants.js
@@ -3,6 +3,12 @@ export const completeReloadDelay = 10000;
 export const initConsoleDelay = 3000;
 export const awaitServerCloseDelay = 1000;
 export const beforeBrowserCloseDelay = 3000;
+// Puppeteer defaults to 30s. That is not enough headroom on a cold or
+// contended CI runner (Windows especially), where a navigation that normally
+// takes a second has been observed taking tens of seconds, and the whole run
+// then fails on an unrelated-looking `TimeoutError`. Node's own per-test
+// timeout (400s) still catches a genuine hang.
+export const navigationTimeout = 120000;
 export const puppeteerArgs = [
   "--disable-background-timer-throttling",
   "--disable-breakpad",

--- a/test/helpers/run-browser.js
+++ b/test/helpers/run-browser.js
@@ -1,5 +1,5 @@
 import { launch } from "puppeteer";
-import { puppeteerArgs } from "./puppeteer-constants.js";
+import { navigationTimeout, puppeteerArgs } from "./puppeteer-constants.js";
 
 /** @typedef {import("puppeteer").Browser} Browser */
 /** @typedef {import("puppeteer").Page} Page */
@@ -35,10 +35,13 @@ export function runPage(browser, device) {
     .then(() => browser.newPage())
     .then((newPage) => {
       page = newPage;
-      page.emulate(options);
 
-      return page.setRequestInterception(true);
+      page.setDefaultNavigationTimeout(navigationTimeout);
+      page.setDefaultTimeout(navigationTimeout);
+
+      return page.emulate(options);
     })
+    .then(() => page.setRequestInterception(true))
     .then(() => {
       page.on("request", (interceptedRequest) => {
         if (interceptedRequest.isInterceptResolutionHandled()) return;

--- a/test/helpers/wait-for.js
+++ b/test/helpers/wait-for.js
@@ -1,0 +1,30 @@
+/**
+ * Polls `predicate` until it returns a truthy value.
+ *
+ * E2E assertions frequently depend on work the page keeps doing after the
+ * navigation settles - a web worker posting a message, the client logging a
+ * reconnect, the server dropping a dead socket. Snapshotting straight after
+ * `page.goto()` races with that work, and a fixed delay is either flaky on a
+ * slow CI runner or wasted time on a fast one. Waiting for the observable
+ * result is both stable and quick. Node's per-test timeout bounds the wait, so
+ * a condition that never becomes true still fails the test.
+ * @param {() => boolean} predicate condition to wait for
+ * @param {number=} interval poll interval in milliseconds
+ * @returns {Promise<void>} resolves once `predicate` returns a truthy value
+ */
+export default function waitFor(predicate, interval = 50) {
+  return new Promise((resolve) => {
+    if (predicate()) {
+      resolve();
+
+      return;
+    }
+
+    const timer = setInterval(() => {
+      if (!predicate()) return;
+
+      clearInterval(timer);
+      resolve();
+    }, interval);
+  });
+}


### PR DESCRIPTION
**Summary**

Adds a way to poll for events instead of timeouts crashing the app, restores overlay fixtures so that they work individually. Closes #2843

**What kind of change does this PR introduce?**

test

**Did you add tests for your changes?**

Yes

**Does this PR introduce a breaking change?**

No

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

N/A

**Use of AI**

Claude has implemented the suggestions I had.

## Summary by CodeRabbit

- **Tests**
  - Improved browser-based test reliability with longer, consistent navigation and operation timeouts.
  - Ensured page emulation completes before request interception and subsequent test steps proceed.
  - Reduced flaky timing-related failures by waiting for expected browser and server events instead of relying on fixed delays.
  - Automatically restores modified test fixtures after each test, preventing failures from affecting later runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->